### PR TITLE
Don't run ErrorProne by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build the project
-        run: mvn --batch-mode clean test install verify checkstyle:checkstyle pmd:check
+        run: mvn --batch-mode -P=errorprone clean test install verify checkstyle:checkstyle pmd:check
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,34 @@
                                 <fork>true</fork>
                                 <release>${maven.compiler.release}</release>
                                 <showWarnings>true</showWarnings>
+                                <annotationProcessorPaths>
+                                    <path>
+                                        <groupId>org.projectlombok</groupId>
+                                        <artifactId>lombok</artifactId>
+                                        <version>${version.lombok}</version>
+                                    </path>
+                                </annotationProcessorPaths>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <profile>
+            <id>errorprone</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>${version.maven-compiler-plugin}</version>
+                            <configuration>
+                                <encoding>UTF-8</encoding>
+                                <fork>true</fork>
+                                <release>${maven.compiler.release}</release>
+                                <showWarnings>true</showWarnings>
                                 <compilerArgs>
                                     <arg>-XDcompilePolicy=simple</arg>
                                     <arg>--should-stop=ifError=FLOW</arg>
@@ -320,32 +348,6 @@
                                         <groupId>com.uber.nullaway</groupId>
                                         <artifactId>nullaway</artifactId>
                                         <version>${version.nullaway}</version>
-                                    </path>
-                                </annotationProcessorPaths>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-
-        <profile>
-            <id>skip-errorprone</id>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <version>${version.maven-compiler-plugin}</version>
-                            <configuration>
-                                <release>${maven.compiler.release}</release>
-                                <encoding>UTF-8</encoding>
-                                <annotationProcessorPaths>
-                                    <path>
-                                        <groupId>org.projectlombok</groupId>
-                                        <artifactId>lombok</artifactId>
-                                        <version>${version.lombok}</version>
                                     </path>
                                 </annotationProcessorPaths>
                             </configuration>


### PR DESCRIPTION
- To make it easier to do stuff like run a single test in IntelliJ, we no longer run ErrorProne by default. Instead, it runs on a separate profile