### PR TITLE
[codex] Add JitPack publishing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LightKeeper
 
+[![](https://jitpack.io/v/PimvanderLoos/LightKeeper.svg)](https://jitpack.io/#PimvanderLoos/LightKeeper)
+
 LightKeeper is an end-to-end testing stack for Minecraft plugins.
 
 It provisions a real server runtime (Paper or Spigot), installs your test assets, boots the server with a LightKeeper
@@ -41,6 +43,66 @@ planned and reviewed by a human.
 - Java 21
 - Maven 3.9+
 - Linux/macOS recommended (UDS-based transport)
+
+## Developers
+
+This project can be included as a dependency using [JitPack](https://jitpack.io/#PimvanderLoos/LightKeeper).
+
+The usual test setup needs both the Maven plugin and the JUnit framework module. The Maven plugin provisions the server
+runtime, and the framework module provides the API used by your tests.
+
+### Maven
+
+```xml
+
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+
+<pluginRepositories>
+    <pluginRepository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </pluginRepository>
+</pluginRepositories>
+```
+
+```xml
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.github.PimvanderLoos.LightKeeper</groupId>
+            <artifactId>lightkeeper-maven-plugin</artifactId>
+            <version>1.2.0</version>
+        </plugin>
+    </plugins>
+</build>
+
+<dependencies>
+    <dependency>
+        <groupId>com.github.PimvanderLoos.LightKeeper</groupId>
+        <artifactId>lightkeeper-framework-junit</artifactId>
+        <version>1.2.0</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+### Gradle
+
+```gradle
+repositories {
+    maven { url "https://jitpack.io/" }
+}
+
+dependencies {
+    testImplementation("com.github.PimvanderLoos.LightKeeper:lightkeeper-framework-junit:1.2.0")
+}
+```
 
 ## Quick Start
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,9 @@
+jdk:
+  - openjdk21
+
+before_install:
+  - sdk install maven 3.9.14
+  - sdk use maven 3.9.14
+
+install:
+  - mvn -pl lightkeeper-runtime-core,lightkeeper-nms-parent,lightkeeper-agent-spigot,lightkeeper-framework-junit,lightkeeper-maven-plugin -am -DskipTests -Dmaven.javadoc.skip=true install


### PR DESCRIPTION
## Why
- Make LightKeeper consumable through JitPack.
- Surface the JitPack status badge and dependency coordinates in the README.

## How
- Add `jitpack.yml` that pins Java 21 and installs the publishable runtime/framework/plugin modules without running server integration provisioning on JitPack.
- Add README JitPack badge plus Maven and Gradle usage examples for the framework and Maven plugin coordinates.

## Tests
- `mvn -pl lightkeeper-runtime-core,lightkeeper-nms-parent,lightkeeper-agent-spigot,lightkeeper-framework-junit,lightkeeper-maven-plugin -am -DskipTests -Dmaven.javadoc.skip=true install` - passed.
- `mvn clean verify install -Perrorprone -Dmaven.javadoc.skip=true checkstyle:checkstyle pmd:check jacoco:report` - passed.