### PR TITLE
fix: constrain latest-supported server resolution

### DIFF
--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import nl.pim16aap2.lightkeeper.nms.v121r7.BotPlayerNmsAdapterV1_21_R7;
+import nl.pim16aap2.lightkeeper.runtime.RuntimeProtocol;
 import nl.pim16aap2.lightkeeper.runtime.agent.AgentResponse;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -43,7 +44,7 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
     /**
      * Bukkit version prefix this plugin is compiled and validated against.
      */
-    static final String SUPPORTED_MINECRAFT_VERSION = "1.21.11";
+    static final String SUPPORTED_MINECRAFT_VERSION = RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION;
     /**
      * Prefix used to extract CraftBukkit package revision identifiers.
      */

--- a/lightkeeper-integration-tests/pom.xml
+++ b/lightkeeper-integration-tests/pom.xml
@@ -24,7 +24,7 @@
         <lightkeeper.spigot.server-work-directory>${project.build.directory}/lightkeeper-server/spigot</lightkeeper.spigot.server-work-directory>
         <lightkeeper.paper.socket-directory>${project.build.directory}/lightkeeper/sockets/paper</lightkeeper.paper.socket-directory>
         <lightkeeper.spigot.socket-directory>${project.build.directory}/lightkeeper/sockets/spigot</lightkeeper.spigot.socket-directory>
-        <lightkeeper.spigot.server-version>latest-supported</lightkeeper.spigot.server-version>
+        <lightkeeper.integration.server-version>${lightkeeper.minecraft-version}</lightkeeper.integration.server-version>
     </properties>
 
     <repositories>
@@ -124,6 +124,7 @@
                         </goals>
                         <configuration>
                             <serverType>paper</serverType>
+                            <serverVersion>${lightkeeper.integration.server-version}</serverVersion>
                             <runtimeManifestPath>${lightkeeper.paper.runtime-manifest.path}</runtimeManifestPath>
                             <serverWorkDirectoryRoot>${lightkeeper.paper.server-work-directory}</serverWorkDirectoryRoot>
                             <agentSocketDirectory>${lightkeeper.paper.socket-directory}</agentSocketDirectory>
@@ -136,7 +137,7 @@
                         </goals>
                         <configuration>
                             <serverType>spigot</serverType>
-                            <serverVersion>${lightkeeper.spigot.server-version}</serverVersion>
+                            <serverVersion>${lightkeeper.integration.server-version}</serverVersion>
                             <runtimeManifestPath>${lightkeeper.spigot.runtime-manifest.path}</runtimeManifestPath>
                             <serverWorkDirectoryRoot>${lightkeeper.spigot.server-work-directory}</serverWorkDirectoryRoot>
                             <agentSocketDirectory>${lightkeeper.spigot.socket-directory}</agentSocketDirectory>

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/PaperDownloadsClient.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/PaperDownloadsClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.pim16aap2.lightkeeper.runtime.RuntimeProtocol;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
@@ -14,13 +15,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -32,7 +31,6 @@ public final class PaperDownloadsClient
     private static final String STABLE_CHANNEL = "STABLE";
     private static final String SERVER_DOWNLOAD_KEY = "server:default";
     private static final String LATEST_SUPPORTED = "latest-supported";
-    private static final Pattern NUMERIC_VERSION_PATTERN = Pattern.compile("\\d+(?:\\.\\d+)*");
     private static final Pattern URL_HASH_PATTERN =
         Pattern.compile(".*/v1/objects/(?<hash>[a-fA-F0-9]{64})/.*");
 
@@ -83,30 +81,32 @@ public final class PaperDownloadsClient
     public PaperBuildMetadata resolveBuild(String requestedVersion)
         throws MojoExecutionException
     {
-        if (requestedVersion.equalsIgnoreCase(LATEST_SUPPORTED))
-            return resolveLatestSupportedBuild();
+        final String resolvedVersion = resolveSupportedMinecraftVersion(requestedVersion);
 
-        return resolveStableBuildForVersion(requestedVersion)
+        return resolveStableBuildForVersion(resolvedVersion)
             .orElseThrow(() -> new MojoExecutionException(
-                "Could not find a stable Paper build for version '%s'.".formatted(requestedVersion))
+                "Could not find a stable Paper build for version '%s'.".formatted(resolvedVersion))
             );
     }
 
-    private PaperBuildMetadata resolveLatestSupportedBuild()
+    private static String resolveSupportedMinecraftVersion(String requestedVersion)
         throws MojoExecutionException
     {
-        final ProjectResponse projectResponse = fetchProject();
-        final List<String> versionsDescending =
-            sortStableVersionsDescending(flattenVersions(projectResponse.versions()));
+        final String normalizedRequestedVersion = Objects.requireNonNull(requestedVersion, "requestedVersion")
+            .trim();
+        if (normalizedRequestedVersion.isEmpty())
+            throw new IllegalArgumentException("requestedVersion may not be blank.");
 
-        for (final String version : versionsDescending)
-        {
-            final Optional<PaperBuildMetadata> buildMetadata = resolveStableBuildForVersion(version);
-            if (buildMetadata.isPresent())
-                return buildMetadata.get();
-        }
+        if (normalizedRequestedVersion.equalsIgnoreCase(LATEST_SUPPORTED))
+            return RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION;
 
-        throw new MojoExecutionException("Unable to resolve latest-supported Paper build.");
+        if (normalizedRequestedVersion.equals(RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION))
+            return normalizedRequestedVersion;
+
+        throw new MojoExecutionException(
+            "Unsupported Paper version '%s'. This LightKeeper build supports Minecraft version '%s'."
+                .formatted(normalizedRequestedVersion, RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION)
+        );
     }
 
     private Optional<PaperBuildMetadata> resolveStableBuildForVersion(String minecraftVersion)
@@ -165,21 +165,6 @@ public final class PaperDownloadsClient
             return Optional.of(matcher.group("hash"));
 
         return Optional.empty();
-    }
-
-    private ProjectResponse fetchProject()
-        throws MojoExecutionException
-    {
-        final JsonNode root = fetchJson(PROJECT_URI);
-
-        try
-        {
-            return objectMapper.treeToValue(root, ProjectResponse.class);
-        }
-        catch (JsonProcessingException exception)
-        {
-            throw new MojoExecutionException("Failed to parse project metadata from Fill response.", exception);
-        }
     }
 
     private List<BuildResponse> parseBuildResponses(JsonNode root)
@@ -243,68 +228,11 @@ public final class PaperDownloadsClient
         }
     }
 
-    private Set<String> flattenVersions(Map<String, List<String>> versionsByGroup)
-    {
-        final Set<String> versions = new LinkedHashSet<>();
-        for (final List<String> versionsInGroup : versionsByGroup.values())
-            versions.addAll(versionsInGroup);
-        return versions;
-    }
-
-    static List<String> sortStableVersionsDescending(Set<String> versions)
-    {
-        return versions.stream()
-            .map(String::trim)
-            .filter(version -> NUMERIC_VERSION_PATTERN.matcher(version).matches())
-            .sorted((leftVersion, rightVersion) -> compareVersions(rightVersion, leftVersion))
-            .toList();
-    }
-
-    private static int compareVersions(String leftVersion, String rightVersion)
-    {
-        int leftTokenStart = 0;
-        int rightTokenStart = 0;
-
-        while (leftTokenStart < leftVersion.length() || rightTokenStart < rightVersion.length())
-        {
-            final int leftTokenEnd = findTokenEnd(leftVersion, leftTokenStart);
-            final int rightTokenEnd = findTokenEnd(rightVersion, rightTokenStart);
-
-            final int leftPart = leftTokenStart < leftVersion.length()
-                ? Integer.parseInt(leftVersion.substring(leftTokenStart, leftTokenEnd))
-                : 0;
-            final int rightPart = rightTokenStart < rightVersion.length()
-                ? Integer.parseInt(rightVersion.substring(rightTokenStart, rightTokenEnd))
-                : 0;
-
-            final int partComparison = Integer.compare(leftPart, rightPart);
-            if (partComparison != 0)
-                return partComparison;
-
-            leftTokenStart = leftTokenEnd + 1;
-            rightTokenStart = rightTokenEnd + 1;
-        }
-
-        return 0;
-    }
-
-    private static int findTokenEnd(String version, int startIndex)
-    {
-        final int nextDotIndex = version.indexOf('.', startIndex);
-        return nextDotIndex < 0 ? version.length() : nextDotIndex;
-    }
-
     private static String validateUserAgent(String userAgent)
     {
         if (userAgent == null || userAgent.isBlank())
             throw new IllegalArgumentException("A non-empty Fill API User-Agent is required.");
         return userAgent;
-    }
-
-    private record ProjectResponse(
-        Map<String, List<String>> versions
-    )
-    {
     }
 
     private record BuildResponse(

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/SpigotDownloadsClient.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/SpigotDownloadsClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import nl.pim16aap2.lightkeeper.runtime.RuntimeProtocol;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
@@ -13,7 +14,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -35,7 +35,6 @@ public final class SpigotDownloadsClient
         Pattern.compile(".*/job/BuildTools/(?<buildNumber>\\d+)/.*");
 
     private final Log log;
-    private final PaperDownloadsClient paperDownloadsClient;
     private final String userAgent;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
@@ -47,16 +46,13 @@ public final class SpigotDownloadsClient
      *
      * @param log
      *     Maven log for diagnostics.
-     * @param paperDownloadsClient
-     *     Paper metadata resolver used only for {@code latest-supported} version resolution.
      * @param userAgent
      *     HTTP user-agent used for BuildTools metadata requests.
      */
-    public SpigotDownloadsClient(Log log, PaperDownloadsClient paperDownloadsClient, String userAgent)
+    public SpigotDownloadsClient(Log log, String userAgent)
     {
         this(
             log,
-            paperDownloadsClient,
             userAgent,
             DEFAULT_BUILDTOOLS_URI,
             DEFAULT_BUILDTOOLS_METADATA_URI
@@ -68,8 +64,6 @@ public final class SpigotDownloadsClient
      *
      * @param log
      *     Maven log for diagnostics.
-     * @param paperDownloadsClient
-     *     Paper metadata resolver used only for {@code latest-supported} version resolution.
      * @param userAgent
      *     HTTP user-agent used for BuildTools metadata requests.
      * @param buildToolsUri
@@ -79,14 +73,11 @@ public final class SpigotDownloadsClient
      */
     SpigotDownloadsClient(
         Log log,
-        PaperDownloadsClient paperDownloadsClient,
         String userAgent,
         URI buildToolsUri,
         URI buildToolsMetadataUri)
     {
         this.log = Objects.requireNonNull(log, "log may not be null.");
-        this.paperDownloadsClient =
-            Objects.requireNonNull(paperDownloadsClient, "paperDownloadsClient may not be null.");
         this.userAgent = validateUserAgent(userAgent);
         this.buildToolsUri = Objects.requireNonNull(buildToolsUri, "buildToolsUri may not be null.");
         this.buildToolsMetadataUri =
@@ -111,21 +102,7 @@ public final class SpigotDownloadsClient
     public SpigotBuildMetadata resolveBuild(String requestedVersion)
         throws MojoExecutionException
     {
-        final String normalizedRequestedVersion = normalizeRequestedVersion(requestedVersion);
-        final String resolvedVersion;
-        if (LATEST_SUPPORTED.equalsIgnoreCase(normalizedRequestedVersion))
-        {
-            final PaperBuildMetadata paperBuildMetadata = paperDownloadsClient.resolveBuild(LATEST_SUPPORTED);
-            resolvedVersion = paperBuildMetadata.minecraftVersion();
-            log.info(
-                "Resolved Spigot latest-supported version to Minecraft %s via Paper metadata."
-                    .formatted(resolvedVersion)
-            );
-        }
-        else
-        {
-            resolvedVersion = normalizedRequestedVersion;
-        }
+        final String resolvedVersion = resolveSupportedMinecraftVersion(requestedVersion);
 
         final String buildToolsIdentity = resolveBuildToolsIdentity();
         return new SpigotBuildMetadata(
@@ -214,7 +191,8 @@ public final class SpigotDownloadsClient
         return Optional.of(Long.parseLong(matcher.group("buildNumber")));
     }
 
-    private static String normalizeRequestedVersion(String requestedVersion)
+    private String resolveSupportedMinecraftVersion(String requestedVersion)
+        throws MojoExecutionException
     {
         final String normalizedRequestedVersion = Objects.requireNonNull(
             requestedVersion,
@@ -223,7 +201,23 @@ public final class SpigotDownloadsClient
             .trim();
         if (normalizedRequestedVersion.isEmpty())
             throw new IllegalArgumentException("requestedVersion may not be blank.");
-        return normalizedRequestedVersion.toLowerCase(Locale.ROOT);
+
+        if (LATEST_SUPPORTED.equalsIgnoreCase(normalizedRequestedVersion))
+        {
+            log.info(
+                "Resolved Spigot latest-supported version to Minecraft %s."
+                    .formatted(RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION)
+            );
+            return RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION;
+        }
+
+        if (normalizedRequestedVersion.equals(RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION))
+            return normalizedRequestedVersion;
+
+        throw new MojoExecutionException(
+            "Unsupported Spigot version '%s'. This LightKeeper build supports Minecraft version '%s'."
+                .formatted(normalizedRequestedVersion, RuntimeProtocol.SUPPORTED_MINECRAFT_VERSION)
+        );
     }
 
     private static String validateUserAgent(String userAgent)

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
@@ -288,8 +288,7 @@ public class PrepareServerMojo extends AbstractMojo
                 executionContext,
                 agentMetadata,
                 agentAuthToken,
-                runtimeProtocolVersion,
-                paperDownloadsClient
+                runtimeProtocolVersion
             );
             default -> throw new MojoExecutionException(
                 "Unsupported server type '%s'. Supported types: %s"
@@ -338,12 +337,11 @@ public class PrepareServerMojo extends AbstractMojo
         PrepareServerExecutionContext executionContext,
         PrepareServerAgentMetadata agentMetadata,
         String agentAuthToken,
-        int runtimeProtocolVersion,
-        PaperDownloadsClient paperDownloadsClient)
+        int runtimeProtocolVersion)
         throws MojoExecutionException
     {
         final SpigotBuildMetadata spigotBuildMetadata =
-            createSpigotDownloadsClient(paperDownloadsClient, executionContext.userAgent())
+            createSpigotDownloadsClient(executionContext.userAgent())
                 .resolveBuild(executionContext.serverVersion());
         final String cacheKey = CacheKeyUtil.createSpigotCacheKey(
             spigotBuildMetadata.minecraftVersion(),
@@ -439,11 +437,9 @@ public class PrepareServerMojo extends AbstractMojo
         return new PaperDownloadsClient(getLog(), effectiveUserAgent);
     }
 
-    protected SpigotDownloadsClient createSpigotDownloadsClient(
-        PaperDownloadsClient paperDownloadsClient,
-        String effectiveUserAgent)
+    protected SpigotDownloadsClient createSpigotDownloadsClient(String effectiveUserAgent)
     {
-        return new SpigotDownloadsClient(getLog(), paperDownloadsClient, effectiveUserAgent);
+        return new SpigotDownloadsClient(getLog(), effectiveUserAgent);
     }
 
     static void writeRuntimeManifest(RuntimeManifest runtimeManifest, Path runtimeManifestPathValue)

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/PaperDownloadsClientTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/PaperDownloadsClientTest.java
@@ -11,10 +11,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -25,47 +22,6 @@ import static org.mockito.Mockito.when;
 
 class PaperDownloadsClientTest
 {
-    @Test
-    void sortStableVersionsDescending_shouldSortStableSemanticVersions()
-    {
-        // setup
-        final Set<String> versions = new LinkedHashSet<>(List.of(
-            "1.21.9",
-            "1.21.11",
-            "1.20.6",
-            "1.21.10",
-            "1.21.11-rc1",
-            "latest"
-        ));
-
-        // execute
-        final List<String> sortedVersions = PaperDownloadsClient.sortStableVersionsDescending(versions);
-
-        // verify
-        assertThat(sortedVersions)
-            .containsExactly("1.21.11", "1.21.10", "1.21.9", "1.20.6");
-    }
-
-    @Test
-    void sortStableVersionsDescending_shouldIgnoreNonNumericEntriesAndTrimWhitespace()
-    {
-        // setup
-        final Set<String> versions = new LinkedHashSet<>(List.of(
-            " 1.21.2 ",
-            "1.21.1",
-            "dev-build",
-            "1.19",
-            " 1.21.0-pre1"
-        ));
-
-        // execute
-        final List<String> sortedVersions = PaperDownloadsClient.sortStableVersionsDescending(versions);
-
-        // verify
-        assertThat(sortedVersions)
-            .containsExactly("1.21.2", "1.21.1", "1.19");
-    }
-
     @Test
     void resolveBuild_shouldResolveExplicitStableVersion()
         throws Exception
@@ -107,17 +63,8 @@ class PaperDownloadsClientTest
         throws Exception
     {
         // setup
-        final URI projectUri = URI.create("https://fill.papermc.io/v3/projects/paper");
         final URI buildsLatestUri = URI.create("https://fill.papermc.io/v3/projects/paper/versions/1.21.11/builds");
         final PaperDownloadsClient client = createClient(Map.of(
-            projectUri,
-            """
-                {
-                  "versions": {
-                    "stable": ["1.21.11", "1.21.10", "1.21.11-rc1"]
-                  }
-                }
-                """,
             buildsLatestUri,
             """
                 [
@@ -147,11 +94,25 @@ class PaperDownloadsClientTest
     }
 
     @Test
+    void resolveBuild_shouldThrowExceptionWhenVersionIsUnsupported()
+        throws Exception
+    {
+        // setup
+        final PaperDownloadsClient client = createClient(Map.of());
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolveBuild("26.1.2"))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Unsupported Paper version")
+            .hasMessageContaining("1.21.11");
+    }
+
+    @Test
     void resolveBuild_shouldDeriveChecksumFromDownloadUrlWhenChecksumsAreMissing()
         throws Exception
     {
         // setup
-        final URI buildsUri = URI.create("https://fill.papermc.io/v3/projects/paper/versions/1.21.10/builds");
+        final URI buildsUri = URI.create("https://fill.papermc.io/v3/projects/paper/versions/1.21.11/builds");
         final PaperDownloadsClient client = createClient(Map.of(
             buildsUri,
             """
@@ -171,7 +132,7 @@ class PaperDownloadsClientTest
         ));
 
         // execute
-        final PaperBuildMetadata result = client.resolveBuild("1.21.10");
+        final PaperBuildMetadata result = client.resolveBuild("1.21.11");
 
         // verify
         assertThat(result.sha256()).isEqualTo("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
@@ -207,17 +168,8 @@ class PaperDownloadsClientTest
         throws Exception
     {
         // setup
-        final URI projectUri = URI.create("https://fill.papermc.io/v3/projects/paper");
         final URI buildsUri = URI.create("https://fill.papermc.io/v3/projects/paper/versions/1.21.11/builds");
         final PaperDownloadsClient client = createClient(Map.of(
-            projectUri,
-            """
-                {
-                  "versions": {
-                    "stable": ["1.21.11"]
-                  }
-                }
-                """,
             buildsUri,
             """
                 [
@@ -291,23 +243,6 @@ class PaperDownloadsClientTest
         assertThatThrownBy(() -> client.resolveBuild("1.21.11"))
             .isInstanceOf(MojoExecutionException.class)
             .hasMessageContaining("Failed to parse Fill API response");
-    }
-
-    @Test
-    void resolveBuild_shouldThrowExceptionWhenProjectPayloadIsMalformed()
-        throws Exception
-    {
-        // setup
-        final URI projectUri = URI.create("https://fill.papermc.io/v3/projects/paper");
-        final PaperDownloadsClient client = createClient(Map.of(
-            projectUri,
-            "{\"versions\":123}"
-        ));
-
-        // execute + verify
-        assertThatThrownBy(() -> client.resolveBuild("latest-supported"))
-            .isInstanceOf(MojoExecutionException.class)
-            .hasMessageContaining("Failed to parse project metadata");
     }
 
     @Test

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/SpigotDownloadsClientTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/SpigotDownloadsClientTest.java
@@ -14,8 +14,6 @@ import java.nio.charset.StandardCharsets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class SpigotDownloadsClientTest
 {
@@ -28,11 +26,9 @@ class SpigotDownloadsClientTest
             {"number":197,"url":"https://hub.spigotmc.org/jenkins/job/BuildTools/197/"}
             """);
         final Log log = mock();
-        final PaperDownloadsClient paperDownloadsClient = mock();
         final URI buildToolsUri = URI.create("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar");
         final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
             log,
-            paperDownloadsClient,
             "LightKeeper/Test",
             buildToolsUri,
             fixtureServer.metadataUri()
@@ -55,7 +51,7 @@ class SpigotDownloadsClientTest
     }
 
     @Test
-    void resolveBuild_shouldUsePaperVersionForLatestSupported()
+    void resolveBuild_shouldUseSupportedVersionForLatestSupported()
         throws Exception
     {
         // setup
@@ -63,17 +59,8 @@ class SpigotDownloadsClientTest
             {"number":201}
             """);
         final Log log = mock();
-        final PaperDownloadsClient paperDownloadsClient = mock();
-        when(paperDownloadsClient.resolveBuild("latest-supported"))
-            .thenReturn(new PaperBuildMetadata(
-                "1.21.11",
-                116L,
-                URI.create("https://example.invalid/paper.jar"),
-                "abc"
-            ));
         final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
             log,
-            paperDownloadsClient,
             "LightKeeper/Test",
             URI.create("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"),
             fixtureServer.metadataUri()
@@ -87,7 +74,6 @@ class SpigotDownloadsClientTest
             // verify
             assertThat(spigotBuildMetadata.minecraftVersion()).isEqualTo("1.21.11");
             assertThat(spigotBuildMetadata.buildToolsIdentity()).isEqualTo("spigot-buildtools-build-201");
-            verify(paperDownloadsClient).resolveBuild("latest-supported");
         }
         finally
         {
@@ -104,10 +90,8 @@ class SpigotDownloadsClientTest
             {"status":"ok"}
             """);
         final Log log = mock();
-        final PaperDownloadsClient paperDownloadsClient = mock();
         final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
             log,
-            paperDownloadsClient,
             "LightKeeper/Test",
             URI.create("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"),
             fixtureServer.metadataUri()
@@ -140,7 +124,6 @@ class SpigotDownloadsClientTest
         );
         final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
             mock(),
-            mock(),
             "LightKeeper/Test",
             URI.create("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"),
             fixtureServer.metadataUri()
@@ -168,7 +151,6 @@ class SpigotDownloadsClientTest
         final HttpFixtureServer fixtureServer = new HttpFixtureServer(503, "{\"status\":\"down\"}");
         final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
             mock(),
-            mock(),
             "LightKeeper/Test",
             URI.create("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"),
             fixtureServer.metadataUri()
@@ -195,7 +177,6 @@ class SpigotDownloadsClientTest
         final HttpFixtureServer fixtureServer = new HttpFixtureServer(200, "{ not-json ");
         final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
             mock(),
-            mock(),
             "LightKeeper/Test",
             URI.create("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"),
             fixtureServer.metadataUri()
@@ -220,7 +201,6 @@ class SpigotDownloadsClientTest
         // execute + verify
         assertThatThrownBy(() -> new SpigotDownloadsClient(
             mock(),
-            mock(),
             "   ",
             URI.create("https://example.invalid/buildtools.jar"),
             URI.create("https://example.invalid/buildtools.json")
@@ -235,7 +215,6 @@ class SpigotDownloadsClientTest
         // setup
         final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
             mock(),
-            mock(),
             "LightKeeper/Test",
             URI.create("https://example.invalid/buildtools.jar"),
             URI.create("https://example.invalid/buildtools.json")
@@ -245,6 +224,24 @@ class SpigotDownloadsClientTest
         assertThatThrownBy(() -> spigotDownloadsClient.resolveBuild("   "))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("requestedVersion may not be blank");
+    }
+
+    @Test
+    void resolveBuild_shouldThrowExceptionWhenVersionIsUnsupported()
+    {
+        // setup
+        final SpigotDownloadsClient spigotDownloadsClient = new SpigotDownloadsClient(
+            mock(),
+            "LightKeeper/Test",
+            URI.create("https://example.invalid/buildtools.jar"),
+            URI.create("https://example.invalid/buildtools.json")
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> spigotDownloadsClient.resolveBuild("26.1.2"))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Unsupported Spigot version")
+            .hasMessageContaining("1.21.11");
     }
 
     private static final class HttpFixtureServer implements AutoCloseable

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
@@ -876,13 +876,9 @@ class PrepareServerMojoInternalTest
     {
         // setup
         final PrepareServerMojo mojo = new PrepareServerMojo();
-        final PaperDownloadsClient paperDownloadsClient = mock();
 
         // execute
-        final SpigotDownloadsClient client = mojo.createSpigotDownloadsClient(
-            paperDownloadsClient,
-            "LightKeeper/Test"
-        );
+        final SpigotDownloadsClient client = mojo.createSpigotDownloadsClient("LightKeeper/Test");
 
         // verify
         assertThat(client).isNotNull();
@@ -1011,9 +1007,7 @@ class PrepareServerMojoInternalTest
         }
 
         @Override
-        protected SpigotDownloadsClient createSpigotDownloadsClient(
-            PaperDownloadsClient injectedPaperDownloadsClient,
-            String effectiveUserAgent)
+        protected SpigotDownloadsClient createSpigotDownloadsClient(String effectiveUserAgent)
         {
             return spigotDownloadsClient;
         }

--- a/lightkeeper-runtime-core/pom.xml
+++ b/lightkeeper-runtime-core/pom.xml
@@ -21,6 +21,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -1,20 +1,78 @@
 package nl.pim16aap2.lightkeeper.runtime;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+
 /**
  * Shared runtime protocol constants for LightKeeper v1.
  */
 public final class RuntimeProtocol
 {
+    private static final String METADATA_RESOURCE = "/nl/pim16aap2/lightkeeper/runtime/lightkeeper-runtime.properties";
+    private static final String SUPPORTED_MINECRAFT_VERSION_KEY = "supportedMinecraftVersion";
+
+    /**
+     * Runtime protocol version understood by the framework and in-server agent.
+     */
     public static final int VERSION = 1;
 
+    /**
+     * Minecraft server version supported by this LightKeeper build.
+     */
+    public static final String SUPPORTED_MINECRAFT_VERSION = loadSupportedMinecraftVersion();
+
+    /**
+     * System property containing the Unix domain socket path used by the agent.
+     */
     public static final String PROPERTY_SOCKET_PATH = "lightkeeper.agent.socketPath";
+    /**
+     * System property containing the runtime authentication token expected by the agent.
+     */
     public static final String PROPERTY_AUTH_TOKEN = "lightkeeper.agent.authToken";
+    /**
+     * System property containing the runtime protocol version expected by the agent.
+     */
     public static final String PROPERTY_PROTOCOL_VERSION = "lightkeeper.agent.protocolVersion";
+    /**
+     * System property containing the expected SHA-256 hash of the embedded agent JAR.
+     */
     public static final String PROPERTY_EXPECTED_AGENT_SHA256 = "lightkeeper.agent.expectedSha256";
+    /**
+     * System property containing the synchronous operation timeout in seconds.
+     */
     public static final String PROPERTY_SYNC_OPERATION_TIMEOUT_SECONDS =
         "lightkeeper.agent.syncOperationTimeoutSeconds";
 
     private RuntimeProtocol()
     {
+    }
+
+    private static String loadSupportedMinecraftVersion()
+    {
+        final Properties properties = new Properties();
+        try (InputStream inputStream = RuntimeProtocol.class.getResourceAsStream(METADATA_RESOURCE))
+        {
+            if (inputStream == null)
+                throw new IllegalStateException("Missing runtime metadata resource '" + METADATA_RESOURCE + "'.");
+
+            properties.load(inputStream);
+        }
+        catch (IOException exception)
+        {
+            throw new UncheckedIOException("Failed to read runtime metadata resource '" + METADATA_RESOURCE + "'.",
+                exception);
+        }
+
+        final String supportedMinecraftVersion = properties.getProperty(SUPPORTED_MINECRAFT_VERSION_KEY, "").trim();
+        if (supportedMinecraftVersion.isEmpty())
+        {
+            throw new IllegalStateException(
+                "Runtime metadata resource '%s' does not define '%s'."
+                    .formatted(METADATA_RESOURCE, SUPPORTED_MINECRAFT_VERSION_KEY)
+            );
+        }
+        return supportedMinecraftVersion;
     }
 }

--- a/lightkeeper-runtime-core/src/main/resources/nl/pim16aap2/lightkeeper/runtime/lightkeeper-runtime.properties
+++ b/lightkeeper-runtime-core/src/main/resources/nl/pim16aap2/lightkeeper/runtime/lightkeeper-runtime.properties
@@ -1,0 +1,1 @@
+supportedMinecraftVersion=${lightkeeper.minecraft-version}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
+        <lightkeeper.minecraft-version>1.21.11</lightkeeper.minecraft-version>
         <project.root-dir>${project.basedir}</project.root-dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -41,7 +42,7 @@
         <version.mockito>5.23.0</version.mockito>
         <version.nullaway>0.13.1</version.nullaway>
         <version.inventorygui>1.6.5-SNAPSHOT</version.inventorygui>
-        <version.spigot-api>1.21.11-R0.2-SNAPSHOT</version.spigot-api>
+        <version.spigot-api>${lightkeeper.minecraft-version}-R0.2-SNAPSHOT</version.spigot-api>
         <version.pmd>7.23.0</version.pmd>
         <version.semver4j>6.0.0</version.semver4j>
 


### PR DESCRIPTION
Make latest-supported resolve to the Minecraft version supported by this LightKeeper build instead of the newest upstream Paper/Spigot release. This keeps Java 21 CI aligned with the agent/NMS compatibility surface and avoids accidental upgrades to server versions requiring newer JVMs.

Centralize the supported Minecraft version in the parent POM and expose it through runtime metadata so the agent, provisioning logic, and integration tests share one source of truth.