### PR TITLE
[codex] Add verified plugin dependency provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ class MyPluginIT
     </worlds>
     <plugins>
         <plugin>
-            <sourceType>path</sourceType> <!-- path | maven -->
+            <sourceType>path</sourceType> <!-- path | maven | modrinth | url -->
             <path>${project.basedir}/src/test/resources/plugins/MyDependency.jar</path>
             <renameTo>MyDependency.jar</renameTo>
         </plugin>
@@ -240,6 +240,18 @@ class MyPluginIT
             <version>1.2.3</version>
             <includeTransitive>false</includeTransitive>
         </plugin>
+        <plugin>
+            <sourceType>modrinth</sourceType>
+            <modrinthProject>luckperms</modrinthProject>
+            <modrinthVersion>v5.5.0-bukkit</modrinthVersion>
+            <modrinthLoader>bukkit</modrinthLoader>
+            <renameTo>LuckPerms.jar</renameTo>
+        </plugin>
+        <plugin>
+            <sourceType>url</sourceType>
+            <url>https://example.com/plugins/MyVerifiedDependency.jar</url>
+            <sha256>0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef</sha256>
+        </plugin>
     </plugins>
     <configOverlayPath>${project.basedir}/src/test/resources/overlay</configOverlayPath>
 </configuration>
@@ -248,6 +260,11 @@ class MyPluginIT
 ## Caching and Retry Behavior
 
 - JAR cache and base-server cache are separate.
+- Maven plugin dependencies use Maven's local repository. URL and Modrinth plugin dependencies are cached under
+  `lightkeeper.pluginArtifactCacheDirectoryRoot`, which defaults to
+  `${settings.localRepository}/nl/pim16aap2/lightkeeper/cache/plugins`.
+- URL plugin dependencies require SHA-256. Modrinth plugin files are verified against Modrinth's file checksum before
+  entering the LightKeeper plugin cache.
 - Cache keys include stable server artifact identity (Paper jar SHA-256 or Spigot BuildTools identity), with
   Java/OS included for build-sensitive Spigot outputs.
 - `prepare-server` prunes expired unused cache-key directories by default (`cleanupUnusedCacheDirectories=true`).
@@ -256,6 +273,15 @@ class MyPluginIT
   `<cleanupUnusedCacheDirectories>false</cleanupUnusedCacheDirectories>`
 - Start retries reuse the prepared artifacts; failed starts do not force a full re-download/rebuild unless explicitly
   configured via force flags.
+
+GitHub Actions can cache URL and Modrinth plugin downloads separately from the normal Maven cache:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.m2/repository/nl/pim16aap2/lightkeeper/cache/plugins
+    key: lightkeeper-plugin-cache-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+```
 
 ## Running Locally
 

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
@@ -60,6 +60,18 @@ public final class ModrinthDownloadsClient
         );
     }
 
+    public ModrinthDownloadsClient(Log log, String userAgent, HttpClient httpClient)
+    {
+        this(
+            log,
+            userAgent,
+            httpClient,
+            new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+        );
+    }
+
     ModrinthDownloadsClient(Log log, String userAgent, HttpClient httpClient, ObjectMapper objectMapper)
     {
         this.log = Objects.requireNonNull(log, "log");

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
@@ -109,7 +109,7 @@ public final class ModrinthDownloadsClient
             version.id(),
             version.versionNumber(),
             file.filename(),
-            URI.create(file.url()),
+            requireDownloadUri(file, version),
             requireSha512(file)
         );
     }
@@ -254,6 +254,42 @@ public final class ModrinthDownloadsClient
         if (sha512 == null || sha512.isBlank())
             throw new MojoExecutionException("Modrinth file '%s' has no SHA-512 checksum.".formatted(file.filename()));
         return sha512.toLowerCase(Locale.ROOT);
+    }
+
+    private static URI requireDownloadUri(FileResponse file, VersionResponse version)
+        throws MojoExecutionException
+    {
+        final String url = file.url();
+        if (url == null || url.isBlank())
+        {
+            throw new MojoExecutionException(
+                "Modrinth file '%s' in version '%s' has no download URL.".formatted(file.filename(), version.id())
+            );
+        }
+
+        final URI uri;
+        try
+        {
+            uri = URI.create(url);
+        }
+        catch (IllegalArgumentException exception)
+        {
+            throw new MojoExecutionException(
+                "Modrinth file '%s' in version '%s' has invalid download URL '%s'."
+                    .formatted(file.filename(), version.id(), url),
+                exception
+            );
+        }
+
+        final String scheme = uri.getScheme();
+        if (!"https".equalsIgnoreCase(scheme) && !"http".equalsIgnoreCase(scheme))
+        {
+            throw new MojoExecutionException(
+                "Modrinth file '%s' in version '%s' download URL '%s' must use http or https."
+                    .formatted(file.filename(), version.id(), url)
+            );
+        }
+        return uri;
     }
 
     private JsonNode fetchJson(URI uri)

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
@@ -81,7 +81,7 @@ public final class ModrinthDownloadsClient
     }
 
     /**
-     * Resolves an exact Modrinth version and selects one Bukkit-compatible jar file.
+     * Resolves an exact Modrinth version and selects one jar file compatible with the configured loader.
      *
      * @param spec
      *     Validated Modrinth plugin spec.
@@ -100,7 +100,7 @@ public final class ModrinthDownloadsClient
             Objects.requireNonNull(spec.modrinthLoader()),
             spec.modrinthGameVersion()
         );
-        final FileResponse file = selectFile(version);
+        final FileResponse file = selectFile(version, Objects.requireNonNull(spec.modrinthLoader()));
 
         log.info("LK_PLUGIN: Resolved Modrinth plugin '%s' version '%s' file '%s'."
             .formatted(version.projectId(), version.versionNumber(), file.filename()));
@@ -208,7 +208,7 @@ public final class ModrinthDownloadsClient
         }
     }
 
-    private FileResponse selectFile(VersionResponse version)
+    private FileResponse selectFile(VersionResponse version, String loader)
         throws MojoExecutionException
     {
         final List<FileResponse> jarFiles = nonNullList(version.files()).stream()
@@ -242,8 +242,8 @@ public final class ModrinthDownloadsClient
             return requiredFiles.getFirst();
 
         throw new MojoExecutionException(
-            "Modrinth version '%s' has ambiguous jar files; choose a version with one primary Bukkit jar."
-                .formatted(version.id())
+            "Modrinth version '%s' has ambiguous jar files for loader '%s'; choose a version with one primary jar."
+                .formatted(version.id(), loader)
         );
     }
 

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClient.java
@@ -1,0 +1,352 @@
+package nl.pim16aap2.lightkeeper.maven;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import nl.pim16aap2.lightkeeper.maven.provisioning.PluginArtifactSpec;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Small client for Modrinth v2 plugin metadata.
+ */
+public final class ModrinthDownloadsClient
+{
+    private static final URI API_BASE_URI = URI.create("https://api.modrinth.com/v2");
+
+    private final Log log;
+    private final String userAgent;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Creates a Modrinth downloads client.
+     *
+     * @param log
+     *     Maven log sink.
+     * @param userAgent
+     *     HTTP user-agent header value.
+     */
+    public ModrinthDownloadsClient(Log log, String userAgent)
+    {
+        this(
+            log,
+            userAgent,
+            HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(Duration.ofSeconds(15))
+                .build(),
+            new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+        );
+    }
+
+    ModrinthDownloadsClient(Log log, String userAgent, HttpClient httpClient, ObjectMapper objectMapper)
+    {
+        this.log = Objects.requireNonNull(log, "log");
+        this.userAgent = validateUserAgent(userAgent);
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    /**
+     * Resolves an exact Modrinth version and selects one Bukkit-compatible jar file.
+     *
+     * @param spec
+     *     Validated Modrinth plugin spec.
+     * @return Selected Modrinth file metadata.
+     * @throws MojoExecutionException
+     *     When metadata cannot be resolved unambiguously.
+     */
+    public ModrinthPluginMetadata resolvePluginFile(PluginArtifactSpec spec)
+        throws MojoExecutionException
+    {
+        final VersionResponse version = spec.modrinthVersionId() == null
+            ? resolveByProjectAndVersionNumber(spec)
+            : fetchVersion(Objects.requireNonNull(spec.modrinthVersionId()));
+        validateVersionCompatibility(
+            version,
+            Objects.requireNonNull(spec.modrinthLoader()),
+            spec.modrinthGameVersion()
+        );
+        final FileResponse file = selectFile(version);
+
+        log.info("LK_PLUGIN: Resolved Modrinth plugin '%s' version '%s' file '%s'."
+            .formatted(version.projectId(), version.versionNumber(), file.filename()));
+
+        return new ModrinthPluginMetadata(
+            version.id(),
+            version.versionNumber(),
+            file.filename(),
+            URI.create(file.url()),
+            requireSha512(file)
+        );
+    }
+
+    private VersionResponse resolveByProjectAndVersionNumber(PluginArtifactSpec spec)
+        throws MojoExecutionException
+    {
+        final String project = Objects.requireNonNull(spec.modrinthProject());
+        final String loader = Objects.requireNonNull(spec.modrinthLoader());
+        final String query = query(
+            "loaders",
+            "[\"%s\"]".formatted(loader),
+            "include_changelog",
+            "false"
+        ) + (spec.modrinthGameVersion() == null
+            ? ""
+            : "&" + query("game_versions", "[\"%s\"]".formatted(spec.modrinthGameVersion())));
+        final URI uri = API_BASE_URI.resolve("/v2/project/%s/version?%s".formatted(encodePath(project), query));
+        final List<VersionResponse> versions = fetchVersions(uri);
+        final List<VersionResponse> matches = versions.stream()
+            .filter(version -> Objects.requireNonNull(spec.modrinthVersion()).equals(version.versionNumber()))
+            .toList();
+        if (matches.isEmpty())
+        {
+            throw new MojoExecutionException(
+                "Could not find Modrinth version '%s' for project '%s' with loader '%s'."
+                    .formatted(spec.modrinthVersion(), project, loader)
+            );
+        }
+        if (matches.size() > 1)
+        {
+            throw new MojoExecutionException(
+                "Modrinth version '%s' for project '%s' resolved to %d entries; use modrinthVersionId."
+                    .formatted(spec.modrinthVersion(), project, matches.size())
+            );
+        }
+        return matches.getFirst();
+    }
+
+    private VersionResponse fetchVersion(String versionId)
+        throws MojoExecutionException
+    {
+        final URI uri = API_BASE_URI.resolve("/v2/version/%s".formatted(encodePath(versionId)));
+        return parseVersion(fetchJson(uri), uri);
+    }
+
+    private List<VersionResponse> fetchVersions(URI uri)
+        throws MojoExecutionException
+    {
+        try
+        {
+            return objectMapper.readValue(fetchJson(uri).traverse(), new TypeReference<>()
+            {
+            });
+        }
+        catch (IOException exception)
+        {
+            throw new MojoExecutionException("Failed to parse Modrinth versions response from '%s'.".formatted(uri),
+                exception);
+        }
+    }
+
+    private VersionResponse parseVersion(JsonNode root, URI uri)
+        throws MojoExecutionException
+    {
+        try
+        {
+            return objectMapper.treeToValue(root, VersionResponse.class);
+        }
+        catch (JsonProcessingException exception)
+        {
+            throw new MojoExecutionException("Failed to parse Modrinth version response from '%s'.".formatted(uri),
+                exception);
+        }
+    }
+
+    private void validateVersionCompatibility(
+        VersionResponse version,
+        String loader,
+        @Nullable String gameVersion)
+        throws MojoExecutionException
+    {
+        if (!containsIgnoreCase(nonNullList(version.loaders()), loader))
+        {
+            throw new MojoExecutionException(
+                "Modrinth version '%s' is not compatible with loader '%s'."
+                    .formatted(version.id(), loader)
+            );
+        }
+        if (gameVersion != null && !nonNullList(version.gameVersions()).contains(gameVersion))
+        {
+            throw new MojoExecutionException(
+                "Modrinth version '%s' is not compatible with Minecraft version '%s'."
+                    .formatted(version.id(), gameVersion)
+            );
+        }
+    }
+
+    private FileResponse selectFile(VersionResponse version)
+        throws MojoExecutionException
+    {
+        final List<FileResponse> jarFiles = nonNullList(version.files()).stream()
+            .filter(file -> file.filename() != null && file.filename().toLowerCase(Locale.ROOT).endsWith(".jar"))
+            .filter(file -> file.fileType() == null || "unknown".equals(file.fileType()))
+            .toList();
+        if (jarFiles.isEmpty())
+        {
+            throw new MojoExecutionException(
+                "Modrinth version '%s' has no installable jar file.".formatted(version.id())
+            );
+        }
+
+        final List<FileResponse> primaryFiles = jarFiles.stream().filter(FileResponse::primary).toList();
+        if (primaryFiles.size() == 1)
+            return primaryFiles.getFirst();
+        if (primaryFiles.size() > 1)
+        {
+            throw new MojoExecutionException(
+                "Modrinth version '%s' has multiple primary jar files.".formatted(version.id())
+            );
+        }
+        if (jarFiles.size() == 1)
+            return jarFiles.getFirst();
+
+        final List<FileResponse> requiredFiles = jarFiles.stream()
+            .filter(file -> file.fileType() == null)
+            .sorted(Comparator.comparing(FileResponse::filename))
+            .toList();
+        if (requiredFiles.size() == 1)
+            return requiredFiles.getFirst();
+
+        throw new MojoExecutionException(
+            "Modrinth version '%s' has ambiguous jar files; choose a version with one primary Bukkit jar."
+                .formatted(version.id())
+        );
+    }
+
+    private static String requireSha512(FileResponse file)
+        throws MojoExecutionException
+    {
+        final String sha512 = nonNullMap(file.hashes()).get("sha512");
+        if (sha512 == null || sha512.isBlank())
+            throw new MojoExecutionException("Modrinth file '%s' has no SHA-512 checksum.".formatted(file.filename()));
+        return sha512.toLowerCase(Locale.ROOT);
+    }
+
+    private JsonNode fetchJson(URI uri)
+        throws MojoExecutionException
+    {
+        final HttpRequest request = HttpRequest.newBuilder(uri)
+            .header("User-Agent", userAgent)
+            .header("Accept", "application/json")
+            .timeout(Duration.ofSeconds(30))
+            .GET()
+            .build();
+
+        final HttpResponse<String> response;
+        try
+        {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        catch (InterruptedException exception)
+        {
+            Thread.currentThread().interrupt();
+            throw new MojoExecutionException("Failed to query Modrinth API at '%s'.".formatted(uri), exception);
+        }
+        catch (IOException exception)
+        {
+            throw new MojoExecutionException("Failed to query Modrinth API at '%s'.".formatted(uri), exception);
+        }
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300)
+            throw new MojoExecutionException(
+                "Modrinth API request to '%s' failed with status %d.".formatted(uri, response.statusCode())
+            );
+
+        try
+        {
+            return objectMapper.readTree(response.body());
+        }
+        catch (JsonProcessingException exception)
+        {
+            throw new MojoExecutionException("Failed to parse Modrinth API response from '%s'.".formatted(uri),
+                exception);
+        }
+    }
+
+    private static boolean containsIgnoreCase(List<String> values, String expected)
+    {
+        return values.stream().anyMatch(value -> value.equalsIgnoreCase(expected));
+    }
+
+    private static <T> List<T> nonNullList(@Nullable List<T> value)
+    {
+        return value == null ? List.of() : value;
+    }
+
+    private static <K, V> Map<K, V> nonNullMap(@Nullable Map<K, V> value)
+    {
+        return value == null ? Map.of() : value;
+    }
+
+    private static String query(String... keyValues)
+    {
+        final StringBuilder ret = new StringBuilder();
+        for (int idx = 0; idx < keyValues.length; idx += 2)
+        {
+            if (!ret.isEmpty())
+                ret.append('&');
+            ret.append(encodeQuery(keyValues[idx])).append('=').append(encodeQuery(keyValues[idx + 1]));
+        }
+        return ret.toString();
+    }
+
+    private static String encodePath(String value)
+    {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private static String encodeQuery(String value)
+    {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String validateUserAgent(String userAgent)
+    {
+        if (userAgent == null || userAgent.isBlank())
+            throw new IllegalArgumentException("A non-empty Modrinth API User-Agent is required.");
+        return userAgent;
+    }
+
+    private record VersionResponse(
+        String id,
+        String projectId,
+        String versionNumber,
+        List<String> gameVersions,
+        List<String> loaders,
+        List<FileResponse> files
+    )
+    {
+    }
+
+    private record FileResponse(
+        Map<String, String> hashes,
+        String url,
+        String filename,
+        boolean primary,
+        @Nullable String fileType
+    )
+    {
+    }
+}

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthPluginMetadata.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/ModrinthPluginMetadata.java
@@ -1,0 +1,27 @@
+package nl.pim16aap2.lightkeeper.maven;
+
+import java.net.URI;
+
+/**
+ * Resolved Modrinth plugin file metadata.
+ *
+ * @param versionId
+ *     Modrinth version ID.
+ * @param versionNumber
+ *     Modrinth version number.
+ * @param fileName
+ *     Downloaded plugin file name.
+ * @param downloadUri
+ *     Direct file download URI.
+ * @param sha512
+ *     Modrinth-provided SHA-512 file checksum.
+ */
+public record ModrinthPluginMetadata(
+    String versionId,
+    String versionNumber,
+    String fileName,
+    URI downloadUri,
+    String sha512
+)
+{
+}

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerExecutionContext.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerExecutionContext.java
@@ -14,6 +14,7 @@ record PrepareServerExecutionContext(
     String serverVersion,
     Path jarCacheDirectoryRoot,
     Path baseServerCacheDirectoryRoot,
+    Path pluginArtifactCacheDirectoryRoot,
     Path serverWorkDirectoryRoot,
     Path runtimeManifestPath,
     Path agentSocketDirectory,

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolver.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolver.java
@@ -5,17 +5,21 @@ import nl.pim16aap2.lightkeeper.maven.provisioning.WorldInputSpec;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jspecify.annotations.Nullable;
 
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Resolves and validates world/plugin input sections for {@code prepare-server}.
  */
 final class PrepareServerInputResolver
 {
+    private static final Pattern SHA_256_PATTERN = Pattern.compile("[a-fA-F0-9]{64}");
+
     List<WorldInputSpec> resolveWorldInputSpecs(@Nullable List<PrepareServerWorldInputConfig> configuredWorlds)
         throws MojoExecutionException
     {
@@ -106,7 +110,85 @@ final class PrepareServerInputResolver
                     null,
                     "jar",
                     false,
-                    renameTo
+                    renameTo,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ));
+                continue;
+            }
+
+            if (sourceType == PluginArtifactSpec.SourceType.URL)
+            {
+                final URI url = requireHttpUri(pluginArtifactConfig.url(), "lightkeeper.plugins.url");
+                final String sha256 = requireSha256(pluginArtifactConfig.sha256(), "lightkeeper.plugins.sha256");
+                final String outputFileName = renameTo == null
+                    ? validatePluginFileName(extractFileName(url), "URL filename")
+                    : renameTo;
+                specs.add(new PluginArtifactSpec(
+                    sourceType,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    "jar",
+                    false,
+                    outputFileName,
+                    url,
+                    sha256,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ));
+                continue;
+            }
+
+            if (sourceType == PluginArtifactSpec.SourceType.MODRINTH)
+            {
+                final @Nullable String versionId = normalizeOptionalString(pluginArtifactConfig.modrinthVersionId());
+                final @Nullable String project = normalizeOptionalString(pluginArtifactConfig.modrinthProject());
+                final @Nullable String version = normalizeOptionalString(pluginArtifactConfig.modrinthVersion());
+                if (versionId == null && (project == null || version == null))
+                {
+                    throw new MojoExecutionException(
+                        "Configured Modrinth plugin requires either 'lightkeeper.plugins.modrinthVersionId' or both " +
+                            "'lightkeeper.plugins.modrinthProject' and 'lightkeeper.plugins.modrinthVersion'."
+                    );
+                }
+                if (versionId != null && (project != null || version != null))
+                {
+                    throw new MojoExecutionException(
+                        "Configured Modrinth plugin may not combine modrinthVersionId with modrinthProject or " +
+                            "modrinthVersion."
+                    );
+                }
+
+                specs.add(new PluginArtifactSpec(
+                    sourceType,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    "jar",
+                    false,
+                    renameTo,
+                    null,
+                    null,
+                    project,
+                    version,
+                    versionId,
+                    normalizeOptionalString(pluginArtifactConfig.modrinthLoader()) == null
+                        ? "bukkit"
+                        : normalizeOptionalString(pluginArtifactConfig.modrinthLoader()),
+                    normalizeOptionalString(pluginArtifactConfig.modrinthGameVersion())
                 ));
                 continue;
             }
@@ -140,7 +222,14 @@ final class PrepareServerInputResolver
                 classifier,
                 type,
                 includeTransitive,
-                renameTo
+                renameTo,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
             ));
         }
 
@@ -248,6 +337,57 @@ final class PrepareServerInputResolver
             );
         }
         return normalized;
+    }
+
+    private static String validatePluginFileName(String fileName, String description)
+        throws MojoExecutionException
+    {
+        final String normalized = requireNonBlank(fileName, description);
+        if (!normalized.toLowerCase(Locale.ROOT).endsWith(".jar"))
+        {
+            throw new MojoExecutionException(
+                "Configured plugin filename '%s' must end with .jar.".formatted(normalized)
+            );
+        }
+        if (normalized.contains("/") || normalized.contains("\\") ||
+            normalized.equals(".") || normalized.contains(".."))
+        {
+            throw new MojoExecutionException(
+                "Configured plugin filename '%s' may not contain path separators, '.', or '..'."
+                    .formatted(normalized)
+            );
+        }
+        return normalized;
+    }
+
+    private static URI requireHttpUri(@Nullable URI value, String fieldName)
+        throws MojoExecutionException
+    {
+        if (value == null)
+            throw new MojoExecutionException("Missing required configuration value '%s'.".formatted(fieldName));
+        final String scheme = value.getScheme();
+        if (!"https".equalsIgnoreCase(scheme) && !"http".equalsIgnoreCase(scheme))
+            throw new MojoExecutionException("Configured URL '%s' must use http or https.".formatted(value));
+        return value;
+    }
+
+    private static String requireSha256(@Nullable String value, String fieldName)
+        throws MojoExecutionException
+    {
+        final String normalized = requireNonBlank(value, fieldName).toLowerCase(Locale.ROOT);
+        if (!SHA_256_PATTERN.matcher(normalized).matches())
+            throw new MojoExecutionException("Configured SHA-256 value '%s' must be 64 hexadecimal characters."
+                .formatted(value));
+        return normalized;
+    }
+
+    private static String extractFileName(URI uri)
+        throws MojoExecutionException
+    {
+        final String path = uri.getPath();
+        if (path == null || path.isBlank() || path.endsWith("/"))
+            throw new MojoExecutionException("Configured URL '%s' does not include an output filename.".formatted(uri));
+        return path.substring(path.lastIndexOf('/') + 1);
     }
 
     static String requireNonBlank(@Nullable String value, String fieldName)

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolver.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolver.java
@@ -339,7 +339,7 @@ final class PrepareServerInputResolver
         return normalized;
     }
 
-    private static String validatePluginFileName(String fileName, String description)
+    static String validatePluginFileName(String fileName, String description)
         throws MojoExecutionException
     {
         final String normalized = requireNonBlank(fileName, description);

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolver.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolver.java
@@ -169,6 +169,8 @@ final class PrepareServerInputResolver
                             "modrinthVersion."
                     );
                 }
+                final @Nullable String configuredModrinthLoader =
+                    normalizeOptionalString(pluginArtifactConfig.modrinthLoader());
 
                 specs.add(new PluginArtifactSpec(
                     sourceType,
@@ -185,9 +187,7 @@ final class PrepareServerInputResolver
                     project,
                     version,
                     versionId,
-                    normalizeOptionalString(pluginArtifactConfig.modrinthLoader()) == null
-                        ? "bukkit"
-                        : normalizeOptionalString(pluginArtifactConfig.modrinthLoader()),
+                    configuredModrinthLoader == null ? "bukkit" : configuredModrinthLoader,
                     normalizeOptionalString(pluginArtifactConfig.modrinthGameVersion())
                 ));
                 continue;

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
@@ -70,6 +70,13 @@ public class PrepareServerMojo extends AbstractMojo
     private Path baseServerCacheDirectoryRoot;
 
     @Parameter(
+        property = "lightkeeper.pluginArtifactCacheDirectoryRoot",
+        defaultValue = "${settings.localRepository}/nl/pim16aap2/lightkeeper/cache/plugins"
+    )
+    @Nullable
+    private Path pluginArtifactCacheDirectoryRoot;
+
+    @Parameter(
         property = "lightkeeper.serverWorkDirectoryRoot",
         defaultValue = "${project.build.directory}/lightkeeper-server", required = true
     )
@@ -240,6 +247,9 @@ public class PrepareServerMojo extends AbstractMojo
             Objects.requireNonNull(serverVersion),
             Objects.requireNonNull(jarCacheDirectoryRoot),
             Objects.requireNonNull(baseServerCacheDirectoryRoot),
+            pluginArtifactCacheDirectoryRoot == null
+                ? Path.of(System.getProperty("java.io.tmpdir"), "lightkeeper-plugin-cache")
+                : pluginArtifactCacheDirectoryRoot,
             Objects.requireNonNull(serverWorkDirectoryRoot),
             Objects.requireNonNull(runtimeManifestPath),
             Objects.requireNonNull(agentSocketDirectory),
@@ -262,6 +272,10 @@ public class PrepareServerMojo extends AbstractMojo
     {
         FileUtil.createDirectories(executionContext.jarCacheDirectoryRoot(), "jar cache directory root");
         FileUtil.createDirectories(executionContext.baseServerCacheDirectoryRoot(), "base server cache directory root");
+        FileUtil.createDirectories(
+            executionContext.pluginArtifactCacheDirectoryRoot(),
+            "plugin artifact cache directory root"
+        );
         FileUtil.createDirectories(executionContext.serverWorkDirectoryRoot(), "server work directory root");
         FileUtil.createDirectories(executionContext.agentSocketDirectory(), "agent socket directory");
     }
@@ -528,7 +542,17 @@ public class PrepareServerMojo extends AbstractMojo
         final RepositorySystemSession session = Objects.requireNonNull(repositorySystemSession,
             "Maven RepositorySystemSession was not injected by the plugin runtime.");
         final List<RemoteRepository> repositories = Objects.requireNonNullElse(remoteProjectRepositories, List.of());
-        return pluginArtifactResolver().resolvePluginArtifacts(specs, resolver, session, repositories);
+        return pluginArtifactResolver().resolvePluginArtifacts(
+            specs,
+            resolver,
+            session,
+            repositories,
+            pluginArtifactCacheDirectoryRoot == null
+                ? Path.of(System.getProperty("java.io.tmpdir"), "lightkeeper-plugin-cache")
+                : pluginArtifactCacheDirectoryRoot,
+            Objects.requireNonNullElse(userAgent, "LightKeeper/Test"),
+            getLog()
+        );
     }
 
     PrepareServerAgentMetadata resolveAgentMetadata()

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactConfig.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactConfig.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.lightkeeper.maven.mojo.prepareserver;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.jspecify.annotations.Nullable;
 
+import java.net.URI;
 import java.nio.file.Path;
 
 /**
@@ -45,6 +46,34 @@ public final class PrepareServerPluginArtifactConfig
     @Parameter
     @Nullable
     private String renameTo;
+
+    @Parameter
+    @Nullable
+    private URI url;
+
+    @Parameter
+    @Nullable
+    private String sha256;
+
+    @Parameter
+    @Nullable
+    private String modrinthProject;
+
+    @Parameter
+    @Nullable
+    private String modrinthVersion;
+
+    @Parameter
+    @Nullable
+    private String modrinthVersionId;
+
+    @Parameter
+    @Nullable
+    private String modrinthLoader;
+
+    @Parameter
+    @Nullable
+    private String modrinthGameVersion;
 
     @Nullable String sourceType()
     {
@@ -89,5 +118,40 @@ public final class PrepareServerPluginArtifactConfig
     @Nullable String renameTo()
     {
         return renameTo;
+    }
+
+    @Nullable URI url()
+    {
+        return url;
+    }
+
+    @Nullable String sha256()
+    {
+        return sha256;
+    }
+
+    @Nullable String modrinthProject()
+    {
+        return modrinthProject;
+    }
+
+    @Nullable String modrinthVersion()
+    {
+        return modrinthVersion;
+    }
+
+    @Nullable String modrinthVersionId()
+    {
+        return modrinthVersionId;
+    }
+
+    @Nullable String modrinthLoader()
+    {
+        return modrinthLoader;
+    }
+
+    @Nullable String modrinthGameVersion()
+    {
+        return modrinthGameVersion;
     }
 }

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolver.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolver.java
@@ -58,6 +58,7 @@ final class PrepareServerPluginArtifactResolver
             .followRedirects(HttpClient.Redirect.NORMAL)
             .connectTimeout(Duration.ofSeconds(15))
             .build();
+        final ModrinthDownloadsClient modrinthDownloadsClient = new ModrinthDownloadsClient(log, userAgent, httpClient);
         for (final PluginArtifactSpec spec : specs)
         {
             switch (spec.sourceType())
@@ -92,7 +93,7 @@ final class PrepareServerPluginArtifactResolver
                     pluginArtifactCacheDirectoryRoot,
                     userAgent,
                     httpClient,
-                    new ModrinthDownloadsClient(log, userAgent),
+                    modrinthDownloadsClient,
                     log
                 ));
             }
@@ -338,8 +339,18 @@ final class PrepareServerPluginArtifactResolver
         {
             throw new MojoExecutionException(
                 "%s '%s' failed %s verification. Expected %s but got %s."
-                    .formatted(description, path, hashAlgorithm.toUpperCase(Locale.ROOT), expectedHash, actualHash)
+                    .formatted(description, path, displayHashAlgorithm(hashAlgorithm), expectedHash, actualHash)
             );
         }
+    }
+
+    private static String displayHashAlgorithm(String hashAlgorithm)
+    {
+        return switch (hashAlgorithm)
+        {
+            case "sha256" -> "SHA-256";
+            case "sha512" -> "SHA-512";
+            default -> hashAlgorithm.toUpperCase(Locale.ROOT);
+        };
     }
 }

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolver.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolver.java
@@ -1,8 +1,14 @@
 package nl.pim16aap2.lightkeeper.maven.mojo.prepareserver;
 
+import nl.pim16aap2.lightkeeper.maven.ModrinthDownloadsClient;
+import nl.pim16aap2.lightkeeper.maven.ModrinthPluginMetadata;
 import nl.pim16aap2.lightkeeper.maven.provisioning.PluginArtifactSpec;
 import nl.pim16aap2.lightkeeper.maven.provisioning.ResolvedPluginArtifact;
+import nl.pim16aap2.lightkeeper.maven.util.CacheKeyUtil;
+import nl.pim16aap2.lightkeeper.maven.util.FileUtil;
+import nl.pim16aap2.lightkeeper.maven.util.HashUtil;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -18,9 +24,18 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.artifact.JavaScopes;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -32,32 +47,55 @@ final class PrepareServerPluginArtifactResolver
         List<PluginArtifactSpec> specs,
         RepositorySystem repositorySystem,
         RepositorySystemSession repositorySystemSession,
-        List<RemoteRepository> remoteProjectRepositories)
+        List<RemoteRepository> remoteProjectRepositories,
+        Path pluginArtifactCacheDirectoryRoot,
+        String userAgent,
+        Log log)
         throws MojoExecutionException
     {
         final List<ResolvedPluginArtifact> resolvedPluginArtifacts = new ArrayList<>();
+        final HttpClient httpClient = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(15))
+            .build();
         for (final PluginArtifactSpec spec : specs)
         {
-            if (spec.sourceType() == PluginArtifactSpec.SourceType.PATH)
+            switch (spec.sourceType())
             {
-                final Path sourceJar = Objects.requireNonNull(spec.path());
-                final String outputFileName = spec.renameTo() == null
-                    ? sourceJar.getFileName().toString()
-                    : spec.renameTo();
-                resolvedPluginArtifacts.add(new ResolvedPluginArtifact(
-                    sourceJar,
-                    outputFileName,
-                    "path:" + sourceJar
+                case PATH ->
+                {
+                    final Path sourceJar = Objects.requireNonNull(spec.path());
+                    final String outputFileName = spec.renameTo() == null
+                        ? sourceJar.getFileName().toString()
+                        : spec.renameTo();
+                    resolvedPluginArtifacts.add(new ResolvedPluginArtifact(
+                        sourceJar,
+                        outputFileName,
+                        "path:" + sourceJar
+                    ));
+                }
+                case MAVEN -> resolvedPluginArtifacts.addAll(resolveMavenPluginArtifacts(
+                    spec,
+                    repositorySystem,
+                    repositorySystemSession,
+                    remoteProjectRepositories
                 ));
-                continue;
+                case URL -> resolvedPluginArtifacts.add(resolveUrlPluginArtifact(
+                    spec,
+                    pluginArtifactCacheDirectoryRoot,
+                    userAgent,
+                    httpClient,
+                    log
+                ));
+                case MODRINTH -> resolvedPluginArtifacts.add(resolveModrinthPluginArtifact(
+                    spec,
+                    pluginArtifactCacheDirectoryRoot,
+                    userAgent,
+                    httpClient,
+                    new ModrinthDownloadsClient(log, userAgent),
+                    log
+                ));
             }
-
-            resolvedPluginArtifacts.addAll(resolveMavenPluginArtifacts(
-                spec,
-                repositorySystem,
-                repositorySystemSession,
-                remoteProjectRepositories
-            ));
         }
 
         return resolvedPluginArtifacts;
@@ -134,6 +172,173 @@ final class PrepareServerPluginArtifactResolver
             throw new MojoExecutionException(
                 "Failed to resolve transitive plugin artifacts for '%s'.".formatted(rootArtifact),
                 exception
+            );
+        }
+    }
+
+    private ResolvedPluginArtifact resolveUrlPluginArtifact(
+        PluginArtifactSpec spec,
+        Path pluginArtifactCacheDirectoryRoot,
+        String userAgent,
+        HttpClient httpClient,
+        Log log)
+        throws MojoExecutionException
+    {
+        final URI uri = Objects.requireNonNull(spec.uri());
+        return downloadToCache(
+            uri,
+            Objects.requireNonNull(spec.renameTo()),
+            "url:" + uri.normalize(),
+            "sha256",
+            Objects.requireNonNull(spec.sha256()),
+            pluginArtifactCacheDirectoryRoot,
+            userAgent,
+            httpClient,
+            log
+        );
+    }
+
+    private ResolvedPluginArtifact resolveModrinthPluginArtifact(
+        PluginArtifactSpec spec,
+        Path pluginArtifactCacheDirectoryRoot,
+        String userAgent,
+        HttpClient httpClient,
+        ModrinthDownloadsClient modrinthDownloadsClient,
+        Log log)
+        throws MojoExecutionException
+    {
+        final ModrinthPluginMetadata metadata = modrinthDownloadsClient.resolvePluginFile(spec);
+        final String outputFileName = spec.renameTo() == null ? metadata.fileName() : spec.renameTo();
+        return downloadToCache(
+            metadata.downloadUri(),
+            outputFileName,
+            "modrinth:%s:%s:%s".formatted(metadata.versionId(), metadata.versionNumber(), metadata.fileName()),
+            "sha512",
+            metadata.sha512(),
+            pluginArtifactCacheDirectoryRoot,
+            userAgent,
+            httpClient,
+            log
+        );
+    }
+
+    private ResolvedPluginArtifact downloadToCache(
+        URI uri,
+        String outputFileName,
+        String identity,
+        String hashAlgorithm,
+        String expectedHash,
+        Path pluginArtifactCacheDirectoryRoot,
+        String userAgent,
+        HttpClient httpClient,
+        Log log)
+        throws MojoExecutionException
+    {
+        final String normalizedHash = expectedHash.toLowerCase(Locale.ROOT);
+        final String cacheKey = CacheKeyUtil.createCacheKey(List.of(
+            hashAlgorithm,
+            identity,
+            outputFileName,
+            normalizedHash
+        ));
+        final Path cacheDirectory = pluginArtifactCacheDirectoryRoot.resolve(cacheKey);
+        final Path cachedJar = cacheDirectory.resolve(outputFileName);
+        if (Files.isRegularFile(cachedJar))
+        {
+            verifyHash(cachedJar, hashAlgorithm, normalizedHash, "cached plugin artifact");
+            log.info("LK_PLUGIN: Reusing cached plugin artifact '%s'.".formatted(cachedJar));
+            return new ResolvedPluginArtifact(cachedJar, outputFileName, identity);
+        }
+
+        FileUtil.createDirectories(cacheDirectory, "plugin artifact cache directory");
+        final Path temporaryDownload;
+        try
+        {
+            temporaryDownload = Files.createTempFile(cacheDirectory, outputFileName, ".tmp");
+        }
+        catch (IOException exception)
+        {
+            throw new MojoExecutionException(
+                "Failed to create temporary plugin artifact download in '%s'.".formatted(cacheDirectory),
+                exception
+            );
+        }
+
+        try
+        {
+            download(uri, temporaryDownload, userAgent, httpClient);
+            verifyHash(temporaryDownload, hashAlgorithm, normalizedHash, "downloaded plugin artifact");
+            Files.move(
+                temporaryDownload,
+                cachedJar,
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING
+            );
+            log.info("LK_PLUGIN: Cached plugin artifact '%s' from '%s'.".formatted(cachedJar, uri));
+            return new ResolvedPluginArtifact(cachedJar, outputFileName, identity);
+        }
+        catch (IOException exception)
+        {
+            throw new MojoExecutionException(
+                "Failed to cache plugin artifact from '%s' to '%s'.".formatted(uri, cachedJar),
+                exception
+            );
+        }
+        finally
+        {
+            try
+            {
+                Files.deleteIfExists(temporaryDownload);
+            }
+            catch (IOException ignored)
+            {
+                log.debug("Failed to delete temporary plugin artifact download '%s'.".formatted(temporaryDownload));
+            }
+        }
+    }
+
+    private static void download(URI uri, Path target, String userAgent, HttpClient httpClient)
+        throws MojoExecutionException
+    {
+        final HttpRequest request = HttpRequest.newBuilder(uri)
+            .header("User-Agent", userAgent)
+            .timeout(Duration.ofMinutes(2))
+            .GET()
+            .build();
+        final HttpResponse<Path> response;
+        try
+        {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofFile(target));
+        }
+        catch (InterruptedException exception)
+        {
+            Thread.currentThread().interrupt();
+            throw new MojoExecutionException("Failed to download plugin artifact from '%s'.".formatted(uri), exception);
+        }
+        catch (IOException exception)
+        {
+            throw new MojoExecutionException("Failed to download plugin artifact from '%s'.".formatted(uri), exception);
+        }
+        if (response.statusCode() < 200 || response.statusCode() >= 300)
+            throw new MojoExecutionException(
+                "Plugin artifact download from '%s' failed with status %d.".formatted(uri, response.statusCode())
+            );
+    }
+
+    private static void verifyHash(Path path, String hashAlgorithm, String expectedHash, String description)
+        throws MojoExecutionException
+    {
+        final String actualHash = switch (hashAlgorithm)
+        {
+            case "sha256" -> HashUtil.sha256(path);
+            case "sha512" -> HashUtil.sha512(path);
+            default -> throw new IllegalArgumentException("Unsupported hash algorithm: " + hashAlgorithm);
+        };
+        if (!expectedHash.equalsIgnoreCase(actualHash))
+        {
+            throw new MojoExecutionException(
+                "%s '%s' failed %s verification. Expected %s but got %s."
+                    .formatted(description, path, hashAlgorithm.toUpperCase(Locale.ROOT), expectedHash, actualHash)
             );
         }
     }

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolver.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolver.java
@@ -31,6 +31,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.nio.file.Files;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * Resolves plugin artifacts from local paths or Maven coordinates.
+ * Resolves plugin artifacts from local paths, Maven coordinates, URL downloads, and Modrinth downloads.
  */
 final class PrepareServerPluginArtifactResolver
 {
@@ -53,12 +54,37 @@ final class PrepareServerPluginArtifactResolver
         Log log)
         throws MojoExecutionException
     {
-        final List<ResolvedPluginArtifact> resolvedPluginArtifacts = new ArrayList<>();
         final HttpClient httpClient = HttpClient.newBuilder()
             .followRedirects(HttpClient.Redirect.NORMAL)
             .connectTimeout(Duration.ofSeconds(15))
             .build();
         final ModrinthDownloadsClient modrinthDownloadsClient = new ModrinthDownloadsClient(log, userAgent, httpClient);
+        return resolvePluginArtifacts(
+            specs,
+            repositorySystem,
+            repositorySystemSession,
+            remoteProjectRepositories,
+            pluginArtifactCacheDirectoryRoot,
+            userAgent,
+            httpClient,
+            modrinthDownloadsClient,
+            log
+        );
+    }
+
+    List<ResolvedPluginArtifact> resolvePluginArtifacts(
+        List<PluginArtifactSpec> specs,
+        RepositorySystem repositorySystem,
+        RepositorySystemSession repositorySystemSession,
+        List<RemoteRepository> remoteProjectRepositories,
+        Path pluginArtifactCacheDirectoryRoot,
+        String userAgent,
+        HttpClient httpClient,
+        ModrinthDownloadsClient modrinthDownloadsClient,
+        Log log)
+        throws MojoExecutionException
+    {
+        final List<ResolvedPluginArtifact> resolvedPluginArtifacts = new ArrayList<>();
         for (final PluginArtifactSpec spec : specs)
         {
             switch (spec.sourceType())
@@ -209,7 +235,9 @@ final class PrepareServerPluginArtifactResolver
         throws MojoExecutionException
     {
         final ModrinthPluginMetadata metadata = modrinthDownloadsClient.resolvePluginFile(spec);
-        final String outputFileName = spec.renameTo() == null ? metadata.fileName() : spec.renameTo();
+        final String outputFileName = spec.renameTo() == null
+            ? PrepareServerInputResolver.validatePluginFileName(metadata.fileName(), "Modrinth filename")
+            : spec.renameTo();
         return downloadToCache(
             metadata.downloadUri(),
             outputFileName,
@@ -269,12 +297,23 @@ final class PrepareServerPluginArtifactResolver
         {
             download(uri, temporaryDownload, userAgent, httpClient);
             verifyHash(temporaryDownload, hashAlgorithm, normalizedHash, "downloaded plugin artifact");
-            Files.move(
-                temporaryDownload,
-                cachedJar,
-                StandardCopyOption.ATOMIC_MOVE,
-                StandardCopyOption.REPLACE_EXISTING
-            );
+            try
+            {
+                Files.move(
+                    temporaryDownload,
+                    cachedJar,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING
+                );
+            }
+            catch (AtomicMoveNotSupportedException exception)
+            {
+                Files.move(
+                    temporaryDownload,
+                    cachedJar,
+                    StandardCopyOption.REPLACE_EXISTING
+                );
+            }
             log.info("LK_PLUGIN: Cached plugin artifact '%s' from '%s'.".formatted(cachedJar, uri));
             return new ResolvedPluginArtifact(cachedJar, outputFileName, identity);
         }

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/provisioning/PluginArtifactSpec.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/provisioning/PluginArtifactSpec.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.lightkeeper.maven.provisioning;
 
 import org.jspecify.annotations.Nullable;
 
+import java.net.URI;
 import java.nio.file.Path;
 
 /**
@@ -25,6 +26,20 @@ import java.nio.file.Path;
  *     Whether transitive dependencies should be copied.
  * @param renameTo
  *     Optional output filename override.
+ * @param uri
+ *     Direct artifact URI for {@code URL} sources.
+ * @param sha256
+ *     Required SHA-256 checksum for {@code URL} sources.
+ * @param modrinthProject
+ *     Modrinth project slug or ID for {@code MODRINTH} sources.
+ * @param modrinthVersion
+ *     Modrinth version number for {@code MODRINTH} sources.
+ * @param modrinthVersionId
+ *     Modrinth version ID for {@code MODRINTH} sources.
+ * @param modrinthLoader
+ *     Modrinth loader to select. Defaults to Bukkit during config resolution.
+ * @param modrinthGameVersion
+ *     Optional Minecraft version filter for Modrinth version selection.
  */
 public record PluginArtifactSpec(
     SourceType sourceType,
@@ -35,15 +50,55 @@ public record PluginArtifactSpec(
     @Nullable String classifier,
     String type,
     boolean includeTransitive,
-    @Nullable String renameTo
+    @Nullable String renameTo,
+    @Nullable URI uri,
+    @Nullable String sha256,
+    @Nullable String modrinthProject,
+    @Nullable String modrinthVersion,
+    @Nullable String modrinthVersionId,
+    @Nullable String modrinthLoader,
+    @Nullable String modrinthGameVersion
 )
 {
+    public PluginArtifactSpec(
+        SourceType sourceType,
+        @Nullable Path path,
+        @Nullable String groupId,
+        @Nullable String artifactId,
+        @Nullable String version,
+        @Nullable String classifier,
+        String type,
+        boolean includeTransitive,
+        @Nullable String renameTo)
+    {
+        this(
+            sourceType,
+            path,
+            groupId,
+            artifactId,
+            version,
+            classifier,
+            type,
+            includeTransitive,
+            renameTo,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
     /**
      * Plugin artifact source type.
      */
     public enum SourceType
     {
         PATH,
-        MAVEN
+        MAVEN,
+        MODRINTH,
+        URL
     }
 }

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/util/HashUtil.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/util/HashUtil.java
@@ -11,7 +11,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * Utility methods for SHA-256 hashing.
+ * Utility methods for SHA-256 and SHA-512 hashing.
  */
 public final class HashUtil
 {

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/util/HashUtil.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/util/HashUtil.java
@@ -24,22 +24,49 @@ public final class HashUtil
     public static String sha256(Path path)
         throws MojoExecutionException
     {
-        try (InputStream inputStream = Files.newInputStream(path))
-        {
-            return sha256(inputStream);
-        }
-        catch (IOException exception)
-        {
-            throw new MojoExecutionException("Failed to compute SHA-256 for file '%s'.".formatted(path), exception);
-        }
+        return hash(path, "SHA-256");
     }
 
     public static String sha256(InputStream inputStream)
         throws MojoExecutionException
     {
+        return hash(inputStream, "SHA-256");
+    }
+
+    public static String sha512(Path path)
+        throws MojoExecutionException
+    {
+        return hash(path, "SHA-512");
+    }
+
+    public static String sha512(InputStream inputStream)
+        throws MojoExecutionException
+    {
+        return hash(inputStream, "SHA-512");
+    }
+
+    private static String hash(Path path, String algorithm)
+        throws MojoExecutionException
+    {
+        try (InputStream inputStream = Files.newInputStream(path))
+        {
+            return hash(inputStream, algorithm);
+        }
+        catch (IOException exception)
+        {
+            throw new MojoExecutionException(
+                "Failed to compute %s for file '%s'.".formatted(algorithm, path),
+                exception
+            );
+        }
+    }
+
+    private static String hash(InputStream inputStream, String algorithm)
+        throws MojoExecutionException
+    {
         try
         {
-            final MessageDigest digest = getSha256Digest();
+            final MessageDigest digest = getDigest(algorithm);
             final byte[] buffer = new byte[BUFFER_SIZE];
 
             int readBytes;
@@ -50,7 +77,7 @@ public final class HashUtil
         }
         catch (IOException exception)
         {
-            throw new MojoExecutionException("Failed to compute SHA-256 from input stream.", exception);
+            throw new MojoExecutionException("Failed to compute %s from input stream.".formatted(algorithm), exception);
         }
     }
 
@@ -70,13 +97,18 @@ public final class HashUtil
 
     private static MessageDigest getSha256Digest()
     {
+        return getDigest("SHA-256");
+    }
+
+    private static MessageDigest getDigest(String algorithm)
+    {
         try
         {
-            return MessageDigest.getInstance("SHA-256");
+            return MessageDigest.getInstance(algorithm);
         }
         catch (NoSuchAlgorithmException exception)
         {
-            throw new IllegalStateException("SHA-256 is unavailable in the current JVM.", exception);
+            throw new IllegalStateException("%s is unavailable in the current JVM.".formatted(algorithm), exception);
         }
     }
 

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
@@ -1,0 +1,175 @@
+package nl.pim16aap2.lightkeeper.maven;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import nl.pim16aap2.lightkeeper.maven.provisioning.PluginArtifactSpec;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ModrinthDownloadsClientTest
+{
+    @Test
+    void resolvePluginFile_shouldResolveProjectVersionAndPrimaryJar()
+        throws Exception
+    {
+        // setup
+        final URI versionsUri = URI.create(
+            "https://api.modrinth.com/v2/project/luckperms/version?loaders=%5B%22bukkit%22%5D&include_changelog=false"
+        );
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionsUri,
+            """
+                [
+                  {
+                    "id": "version01",
+                    "project_id": "project01",
+                    "version_number": "v5.5.0-bukkit",
+                    "game_versions": ["1.21.11"],
+                    "loaders": ["bukkit"],
+                    "files": [
+                      {
+                        "hashes": {
+                          "sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        "url": "https://cdn.modrinth.com/data/project01/versions/version01/LuckPerms-Bukkit.jar",
+                        "filename": "LuckPerms-Bukkit.jar",
+                        "primary": true
+                      }
+                    ]
+                  }
+                ]
+                """
+        ));
+
+        // execute
+        final ModrinthPluginMetadata metadata = client.resolvePluginFile(modrinthProjectSpec());
+
+        // verify
+        assertThat(metadata.versionId()).isEqualTo("version01");
+        assertThat(metadata.versionNumber()).isEqualTo("v5.5.0-bukkit");
+        assertThat(metadata.fileName()).isEqualTo("LuckPerms-Bukkit.jar");
+        assertThat(metadata.sha512()).startsWith("aaaaaaaa");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectAmbiguousFiles()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            """
+                {
+                  "id": "version01",
+                  "project_id": "project01",
+                  "version_number": "v5.5.0-bukkit",
+                  "game_versions": ["1.21.11"],
+                  "loaders": ["bukkit"],
+                  "files": [
+                    {
+                      "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                      "url": "https://cdn.modrinth.com/a.jar",
+                      "filename": "a.jar",
+                      "primary": false
+                    },
+                    {
+                      "hashes": {"sha512": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                      "url": "https://cdn.modrinth.com/b.jar",
+                      "filename": "b.jar",
+                      "primary": false
+                    }
+                  ]
+                }
+                """
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("ambiguous jar files");
+    }
+
+    private static PluginArtifactSpec modrinthProjectSpec()
+    {
+        return new PluginArtifactSpec(
+            PluginArtifactSpec.SourceType.MODRINTH,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "jar",
+            false,
+            null,
+            null,
+            null,
+            "luckperms",
+            "v5.5.0-bukkit",
+            null,
+            "bukkit",
+            null
+        );
+    }
+
+    private static PluginArtifactSpec modrinthVersionIdSpec()
+    {
+        return new PluginArtifactSpec(
+            PluginArtifactSpec.SourceType.MODRINTH,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "jar",
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "version01",
+            "bukkit",
+            null
+        );
+    }
+
+    private static ModrinthDownloadsClient createClient(Map<URI, String> responses)
+        throws Exception
+    {
+        final HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.send(
+            argThat((HttpRequest request) -> responses.containsKey(request.uri())),
+            any(HttpResponse.BodyHandler.class)
+        )).thenAnswer(invocation -> {
+            final HttpRequest request = invocation.getArgument(0);
+            final HttpResponse<String> response = mock(HttpResponse.class);
+            when(response.statusCode()).thenReturn(200);
+            when(response.body()).thenReturn(responses.get(request.uri()));
+            return response;
+        });
+        return new ModrinthDownloadsClient(
+            new SystemStreamLog(),
+            "LightKeeper/Test",
+            httpClient,
+            new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+        );
+    }
+}

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import nl.pim16aap2.lightkeeper.maven.provisioning.PluginArtifactSpec;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -13,6 +14,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,7 +33,7 @@ class ModrinthDownloadsClientTest
         final URI versionsUri = URI.create(
             "https://api.modrinth.com/v2/project/luckperms/version?loaders=%5B%22bukkit%22%5D&include_changelog=false"
         );
-        final ModrinthDownloadsClient client = createClient(Map.of(
+        final ModrinthDownloadsClient client = createJsonClient(Map.of(
             versionsUri,
             """
                 [
@@ -67,12 +69,226 @@ class ModrinthDownloadsClientTest
     }
 
     @Test
-    void resolvePluginFile_shouldRejectAmbiguousFiles()
+    void resolvePluginFile_shouldResolveVersionIdAndSingleJarWithoutPrimary()
         throws Exception
     {
         // setup
         final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
         final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["bukkit"],
+                      "files": [
+                        {
+                          "hashes": {
+                            "sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                          },
+                          "url": "https://cdn.modrinth.com/data/project01/versions/version01/LuckPerms-Bukkit.jar",
+                          "filename": "LuckPerms-Bukkit.jar",
+                          "primary": false,
+                          "file_type": "unknown"
+                        }
+                      ]
+                    }
+                    """
+            )
+        ));
+
+        // execute
+        final ModrinthPluginMetadata metadata = client.resolvePluginFile(modrinthVersionIdSpec());
+
+        // verify
+        assertThat(metadata.versionId()).isEqualTo("version01");
+        assertThat(metadata.fileName()).isEqualTo("LuckPerms-Bukkit.jar");
+        assertThat(metadata.downloadUri()).isEqualTo(URI.create(
+            "https://cdn.modrinth.com/data/project01/versions/version01/LuckPerms-Bukkit.jar"
+        ));
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectMissingVersionWhenResolvingByProject()
+        throws Exception
+    {
+        // setup
+        final URI versionsUri = URI.create(
+            "https://api.modrinth.com/v2/project/luckperms/version?loaders=%5B%22bukkit%22%5D&include_changelog=false"
+        );
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionsUri,
+            jsonResponse(200, "[]")
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthProjectSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Could not find Modrinth version");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectAmbiguousProjectVersionMatches()
+        throws Exception
+    {
+        // setup
+        final URI versionsUri = URI.create(
+            "https://api.modrinth.com/v2/project/luckperms/version?loaders=%5B%22bukkit%22%5D&include_changelog=false"
+        );
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionsUri,
+            jsonResponse(
+                200,
+                """
+                    [
+                      {
+                        "id": "version01",
+                        "project_id": "project01",
+                        "version_number": "v5.5.0-bukkit",
+                        "game_versions": ["1.21.11"],
+                        "loaders": ["bukkit"],
+                        "files": []
+                      },
+                      {
+                        "id": "version02",
+                        "project_id": "project01",
+                        "version_number": "v5.5.0-bukkit",
+                        "game_versions": ["1.21.11"],
+                        "loaders": ["bukkit"],
+                        "files": []
+                      }
+                    ]
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthProjectSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("resolved to 2 entries");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectIncompatibleLoader()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["fabric"],
+                      "files": []
+                    }
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("not compatible with loader");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectIncompatibleGameVersion()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.10"],
+                      "loaders": ["bukkit"],
+                      "files": []
+                    }
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec("1.21.11")))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("not compatible with Minecraft version");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectMissingChecksum()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["bukkit"],
+                      "files": [
+                        {
+                          "url": "https://cdn.modrinth.com/data/project01/versions/version01/LuckPerms-Bukkit.jar",
+                          "filename": "LuckPerms-Bukkit.jar",
+                          "primary": true
+                        }
+                      ]
+                    }
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("no SHA-512 checksum");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectNonSuccessApiResponse()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(500, "{\"error\":\"boom\"}")
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("failed with status 500");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectAmbiguousFiles()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createJsonClient(Map.of(
             versionUri,
             """
                 {
@@ -105,6 +321,170 @@ class ModrinthDownloadsClientTest
             .hasMessageContaining("ambiguous jar files");
     }
 
+    @Test
+    void resolvePluginFile_shouldRejectMultiplePrimaryFiles()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["bukkit"],
+                      "files": [
+                        {
+                          "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                          "url": "https://cdn.modrinth.com/a.jar",
+                          "filename": "a.jar",
+                          "primary": true
+                        },
+                        {
+                          "hashes": {"sha512": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                          "url": "https://cdn.modrinth.com/b.jar",
+                          "filename": "b.jar",
+                          "primary": true
+                        }
+                      ]
+                    }
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("multiple primary jar files");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectNoJarFiles()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["bukkit"],
+                      "files": [
+                        {
+                          "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                          "url": "https://cdn.modrinth.com/a.txt",
+                          "filename": "a.txt",
+                          "primary": true
+                        }
+                      ]
+                    }
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("no installable jar file");
+    }
+
+    @Test
+    void resolvePluginFile_shouldSelectRequiredJarWhenMultipleCandidatesExist()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["bukkit"],
+                      "files": [
+                        {
+                          "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                          "url": "https://cdn.modrinth.com/b.jar",
+                          "filename": "b.jar",
+                          "primary": false
+                        },
+                        {
+                          "hashes": {"sha512": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                          "url": "https://cdn.modrinth.com/a.jar",
+                          "filename": "a.jar",
+                          "primary": false,
+                          "file_type": "unknown"
+                        }
+                      ]
+                    }
+                    """
+            )
+        ));
+
+        // execute
+        final ModrinthPluginMetadata metadata = client.resolvePluginFile(modrinthVersionIdSpec());
+
+        // verify
+        assertThat(metadata.fileName()).isEqualTo("b.jar");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectMultipleRequiredJarCandidates()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["bukkit"],
+                      "files": [
+                        {
+                          "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                          "url": "https://cdn.modrinth.com/a.jar",
+                          "filename": "a.jar",
+                          "primary": false
+                        },
+                        {
+                          "hashes": {"sha512": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                          "url": "https://cdn.modrinth.com/b.jar",
+                          "filename": "b.jar",
+                          "primary": false
+                        }
+                      ]
+                    }
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("choose a version with one primary Bukkit jar");
+    }
+
     private static PluginArtifactSpec modrinthProjectSpec()
     {
         return new PluginArtifactSpec(
@@ -129,6 +509,11 @@ class ModrinthDownloadsClientTest
 
     private static PluginArtifactSpec modrinthVersionIdSpec()
     {
+        return modrinthVersionIdSpec(null);
+    }
+
+    private static PluginArtifactSpec modrinthVersionIdSpec(@Nullable String gameVersion)
+    {
         return new PluginArtifactSpec(
             PluginArtifactSpec.SourceType.MODRINTH,
             null,
@@ -145,11 +530,24 @@ class ModrinthDownloadsClientTest
             null,
             "version01",
             "bukkit",
-            null
+            gameVersion
         );
     }
 
-    private static ModrinthDownloadsClient createClient(Map<URI, String> responses)
+    private record ResponseSpec(int statusCode, String body)
+    {
+    }
+
+    private static ModrinthDownloadsClient createJsonClient(Map<URI, String> responses)
+        throws Exception
+    {
+        return createClient(responses.entrySet().stream().collect(java.util.stream.Collectors.toMap(
+            Map.Entry::getKey,
+            entry -> new ResponseSpec(200, entry.getValue())
+        )));
+    }
+
+    private static ModrinthDownloadsClient createClient(Map<URI, ResponseSpec> responses)
         throws Exception
     {
         final HttpClient httpClient = mock(HttpClient.class);
@@ -159,8 +557,9 @@ class ModrinthDownloadsClientTest
         )).thenAnswer(invocation -> {
             final HttpRequest request = invocation.getArgument(0);
             final HttpResponse<String> response = mock(HttpResponse.class);
-            when(response.statusCode()).thenReturn(200);
-            when(response.body()).thenReturn(responses.get(request.uri()));
+            final ResponseSpec responseSpec = Objects.requireNonNull(responses.get(request.uri()));
+            when(response.statusCode()).thenReturn(responseSpec.statusCode());
+            when(response.body()).thenReturn(responseSpec.body());
             return response;
         });
         return new ModrinthDownloadsClient(
@@ -171,5 +570,10 @@ class ModrinthDownloadsClientTest
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
         );
+    }
+
+    private static ResponseSpec jsonResponse(int statusCode, String body)
+    {
+        return new ResponseSpec(statusCode, body);
     }
 }

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
@@ -400,6 +400,93 @@ class ModrinthDownloadsClientTest
     }
 
     @Test
+    void resolvePluginFile_shouldRejectMissingDownloadUrl()
+        throws Exception
+    {
+        // setup
+        final ModrinthDownloadsClient client = createVersionIdClientWithFile(
+            """
+                {
+                  "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                  "filename": "LuckPerms-Bukkit.jar",
+                  "primary": true
+                }
+                """
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("has no download URL");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectBlankDownloadUrl()
+        throws Exception
+    {
+        // setup
+        final ModrinthDownloadsClient client = createVersionIdClientWithFile(
+            """
+                {
+                  "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                  "url": "   ",
+                  "filename": "LuckPerms-Bukkit.jar",
+                  "primary": true
+                }
+                """
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("has no download URL");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectMalformedDownloadUrl()
+        throws Exception
+    {
+        // setup
+        final ModrinthDownloadsClient client = createVersionIdClientWithFile(
+            """
+                {
+                  "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                  "url": "https://cdn.modrinth.com/invalid url.jar",
+                  "filename": "LuckPerms-Bukkit.jar",
+                  "primary": true
+                }
+                """
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("has invalid download URL");
+    }
+
+    @Test
+    void resolvePluginFile_shouldRejectUnsupportedDownloadUrlScheme()
+        throws Exception
+    {
+        // setup
+        final ModrinthDownloadsClient client = createVersionIdClientWithFile(
+            """
+                {
+                  "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                  "url": "file:///tmp/LuckPerms-Bukkit.jar",
+                  "filename": "LuckPerms-Bukkit.jar",
+                  "primary": true
+                }
+                """
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("must use http or https");
+    }
+
+    @Test
     void resolvePluginFile_shouldSelectRequiredJarWhenMultipleCandidatesExist()
         throws Exception
     {
@@ -618,6 +705,30 @@ class ModrinthDownloadsClientTest
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
         );
+    }
+
+    private static ModrinthDownloadsClient createVersionIdClientWithFile(String fileJson)
+        throws Exception
+    {
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        return createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-bukkit",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["bukkit"],
+                      "files": [
+                    %s
+                      ]
+                    }
+                    """.formatted(fileJson.indent(4))
+            )
+        ));
     }
 
     private static ResponseSpec jsonResponse(int statusCode, String body)

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/ModrinthDownloadsClientTest.java
@@ -482,7 +482,50 @@ class ModrinthDownloadsClientTest
         // execute + verify
         assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec()))
             .isInstanceOf(MojoExecutionException.class)
-            .hasMessageContaining("choose a version with one primary Bukkit jar");
+            .hasMessageContaining("ambiguous jar files for loader 'bukkit'")
+            .hasMessageContaining("choose a version with one primary jar");
+    }
+
+    @Test
+    void resolvePluginFile_shouldReportConfiguredLoaderWhenJarSelectionIsAmbiguous()
+        throws Exception
+    {
+        // setup
+        final URI versionUri = URI.create("https://api.modrinth.com/v2/version/version01");
+        final ModrinthDownloadsClient client = createClient(Map.of(
+            versionUri,
+            jsonResponse(
+                200,
+                """
+                    {
+                      "id": "version01",
+                      "project_id": "project01",
+                      "version_number": "v5.5.0-paper",
+                      "game_versions": ["1.21.11"],
+                      "loaders": ["paper"],
+                      "files": [
+                        {
+                          "hashes": {"sha512": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                          "url": "https://cdn.modrinth.com/a.jar",
+                          "filename": "a.jar",
+                          "primary": false
+                        },
+                        {
+                          "hashes": {"sha512": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                          "url": "https://cdn.modrinth.com/b.jar",
+                          "filename": "b.jar",
+                          "primary": false
+                        }
+                      ]
+                    }
+                    """
+            )
+        ));
+
+        // execute + verify
+        assertThatThrownBy(() -> client.resolvePluginFile(modrinthVersionIdSpec("paper", null)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("ambiguous jar files for loader 'paper'");
     }
 
     private static PluginArtifactSpec modrinthProjectSpec()
@@ -514,6 +557,11 @@ class ModrinthDownloadsClientTest
 
     private static PluginArtifactSpec modrinthVersionIdSpec(@Nullable String gameVersion)
     {
+        return modrinthVersionIdSpec("bukkit", gameVersion);
+    }
+
+    private static PluginArtifactSpec modrinthVersionIdSpec(String loader, @Nullable String gameVersion)
+    {
         return new PluginArtifactSpec(
             PluginArtifactSpec.SourceType.MODRINTH,
             null,
@@ -529,7 +577,7 @@ class ModrinthDownloadsClientTest
             null,
             null,
             "version01",
-            "bukkit",
+            loader,
             gameVersion
         );
     }

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolverTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolverTest.java
@@ -270,6 +270,25 @@ class PrepareServerInputResolverTest
     }
 
     @Test
+    void resolvePluginArtifactSpecs_shouldUseConfiguredModrinthLoader()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "modrinth");
+        setField(config, "modrinthVersionId", "ABCDEFGH");
+        setField(config, "modrinthLoader", "paper");
+
+        // execute
+        final List<PluginArtifactSpec> specs = RESOLVER.resolvePluginArtifactSpecs(List.of(config));
+
+        // verify
+        assertThat(specs).singleElement().satisfies(spec ->
+            assertThat(spec.modrinthLoader()).isEqualTo("paper")
+        );
+    }
+
+    @Test
     void resolvePluginArtifactSpecs_shouldRejectModrinthSourceWithoutVersionIdOrVersion()
         throws Exception
     {

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolverTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolverTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -117,6 +118,81 @@ class PrepareServerInputResolverTest
         assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
             .isInstanceOf(MojoExecutionException.class)
             .hasMessageContaining("must end with .jar");
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldRequireSha256ForUrlSource()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "url");
+        setField(config, "url", URI.create("https://example.com/plugin.jar"));
+
+        // execute + verify
+        assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("lightkeeper.plugins.sha256");
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldResolveUrlSource()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "url");
+        setField(config, "url", URI.create("https://example.com/downloads/plugin.jar"));
+        setField(config, "sha256", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+        // execute
+        final List<PluginArtifactSpec> specs = RESOLVER.resolvePluginArtifactSpecs(List.of(config));
+
+        // verify
+        assertThat(specs).singleElement().satisfies(spec -> {
+            assertThat(spec.sourceType()).isEqualTo(PluginArtifactSpec.SourceType.URL);
+            assertThat(spec.renameTo()).isEqualTo("plugin.jar");
+            assertThat(spec.uri()).isEqualTo(URI.create("https://example.com/downloads/plugin.jar"));
+            assertThat(spec.sha256()).isEqualTo("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+        });
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldResolveModrinthSource()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "modrinth");
+        setField(config, "modrinthProject", "luckperms");
+        setField(config, "modrinthVersion", "v5.5.0-bukkit");
+
+        // execute
+        final List<PluginArtifactSpec> specs = RESOLVER.resolvePluginArtifactSpecs(List.of(config));
+
+        // verify
+        assertThat(specs).singleElement().satisfies(spec -> {
+            assertThat(spec.sourceType()).isEqualTo(PluginArtifactSpec.SourceType.MODRINTH);
+            assertThat(spec.modrinthProject()).isEqualTo("luckperms");
+            assertThat(spec.modrinthVersion()).isEqualTo("v5.5.0-bukkit");
+            assertThat(spec.modrinthLoader()).isEqualTo("bukkit");
+        });
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldRejectAmbiguousModrinthConfig()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "modrinth");
+        setField(config, "modrinthVersionId", "ABCDEFGH");
+        setField(config, "modrinthProject", "luckperms");
+
+        // execute + verify
+        assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("may not combine");
     }
 
     private static void setField(Object target, String fieldName, Object value)

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolverTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerInputResolverTest.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +19,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class PrepareServerInputResolverTest
 {
     private static final PrepareServerInputResolver RESOLVER = new PrepareServerInputResolver();
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldReturnEmptyListForNullConfiguration()
+        throws Exception
+    {
+        // execute + verify
+        assertThat(RESOLVER.resolvePluginArtifactSpecs(null)).isEmpty();
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldRejectNullPluginEntry()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(Collections.singletonList(null)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("may not be null");
+    }
 
     @Test
     void resolveWorldInputSpecs_shouldThrowExceptionWhenFolderSourceIsNotDirectory(@TempDir Path tempDirectory)
@@ -121,6 +139,27 @@ class PrepareServerInputResolverTest
     }
 
     @Test
+    void resolvePluginArtifactSpecs_shouldResolvePathSource(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path pluginJar = Files.writeString(tempDirectory.resolve("fixture.jar"), "x");
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "path");
+        setField(config, "path", pluginJar);
+
+        // execute
+        final List<PluginArtifactSpec> specs = RESOLVER.resolvePluginArtifactSpecs(List.of(config));
+
+        // verify
+        assertThat(specs).singleElement().satisfies(spec -> {
+            assertThat(spec.sourceType()).isEqualTo(PluginArtifactSpec.SourceType.PATH);
+            assertThat(spec.path()).isEqualTo(pluginJar.toAbsolutePath().normalize());
+            assertThat(spec.renameTo()).isNull();
+        });
+    }
+
+    @Test
     void resolvePluginArtifactSpecs_shouldRequireSha256ForUrlSource()
         throws Exception
     {
@@ -133,6 +172,22 @@ class PrepareServerInputResolverTest
         assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
             .isInstanceOf(MojoExecutionException.class)
             .hasMessageContaining("lightkeeper.plugins.sha256");
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldRejectUrlSourceWithoutFilename()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "url");
+        setField(config, "url", URI.create("https://example.com/downloads/"));
+        setField(config, "sha256", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+        // execute + verify
+        assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("does not include an output filename");
     }
 
     @Test
@@ -158,6 +213,41 @@ class PrepareServerInputResolverTest
     }
 
     @Test
+    void resolvePluginArtifactSpecs_shouldNormalizeUrlChecksum()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "url");
+        setField(config, "url", URI.create("https://example.com/downloads/plugin.jar"));
+        setField(config, "sha256", "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789");
+
+        // execute
+        final List<PluginArtifactSpec> specs = RESOLVER.resolvePluginArtifactSpecs(List.of(config));
+
+        // verify
+        assertThat(specs.getFirst().sha256())
+            .isEqualTo("abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldRejectInvalidRenameToForUrlSource()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "url");
+        setField(config, "url", URI.create("https://example.com/downloads/plugin.jar"));
+        setField(config, "sha256", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+        setField(config, "renameTo", "folder/invalid.jar");
+
+        // execute + verify
+        assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("may not contain path separators");
+    }
+
+    @Test
     void resolvePluginArtifactSpecs_shouldResolveModrinthSource()
         throws Exception
     {
@@ -180,6 +270,21 @@ class PrepareServerInputResolverTest
     }
 
     @Test
+    void resolvePluginArtifactSpecs_shouldRejectModrinthSourceWithoutVersionIdOrVersion()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "modrinth");
+        setField(config, "modrinthProject", "luckperms");
+
+        // execute + verify
+        assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("requires either");
+    }
+
+    @Test
     void resolvePluginArtifactSpecs_shouldRejectAmbiguousModrinthConfig()
         throws Exception
     {
@@ -193,6 +298,25 @@ class PrepareServerInputResolverTest
         assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
             .isInstanceOf(MojoExecutionException.class)
             .hasMessageContaining("may not combine");
+    }
+
+    @Test
+    void resolvePluginArtifactSpecs_shouldRejectMavenRenameWhenIncludingTransitiveArtifacts()
+        throws Exception
+    {
+        // setup
+        final PrepareServerPluginArtifactConfig config = new PrepareServerPluginArtifactConfig();
+        setField(config, "sourceType", "maven");
+        setField(config, "groupId", "com.example");
+        setField(config, "artifactId", "fixture");
+        setField(config, "version", "1.0.0");
+        setField(config, "includeTransitive", Boolean.TRUE);
+        setField(config, "renameTo", "fixture.jar");
+
+        // execute + verify
+        assertThatThrownBy(() -> RESOLVER.resolvePluginArtifactSpecs(List.of(config)))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("cannot set renameTo");
     }
 
     private static void setField(Object target, String fieldName, Object value)

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
@@ -10,6 +10,7 @@ import nl.pim16aap2.lightkeeper.maven.provisioning.WorldInputSpec;
 import nl.pim16aap2.lightkeeper.maven.serverprovider.PaperServerProvider;
 import nl.pim16aap2.lightkeeper.maven.serverprovider.ServerProvider;
 import nl.pim16aap2.lightkeeper.maven.serverprovider.SpigotServerProvider;
+import nl.pim16aap2.lightkeeper.maven.util.FileUtil;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -620,25 +621,31 @@ class PrepareServerMojoInternalTest
     }
 
     @Test
-    void resolveUdsSocketPath_shouldUsePreferredPathWhenItFits(@TempDir Path tempDirectory)
+    void resolveUdsSocketPath_shouldUsePreferredPathWhenItFits()
         throws Exception
     {
         // setup
         final PrepareServerMojo mojo = new PrepareServerMojo();
-        final Path preferredDirectory = Files.createDirectories(tempDirectory.resolve("socket-dir"));
+        final Path preferredDirectory = Files.createTempDirectory(Path.of("/tmp"), "lk-uds-fit-");
+        try
+        {
+            // execute
+            final Path socketPath = invokePrivate(
+                mojo,
+                "resolveUdsSocketPath",
+                new Class<?>[]{Path.class, String.class},
+                preferredDirectory,
+                "abcdef0123456789abcdef0123456789"
+            );
 
-        // execute
-        final Path socketPath = invokePrivate(
-            mojo,
-            "resolveUdsSocketPath",
-            new Class<?>[]{Path.class, String.class},
-            preferredDirectory,
-            "abcdef0123456789abcdef0123456789"
-        );
-
-        // verify
-        assertThat(socketPath.toString()).startsWith(preferredDirectory.toAbsolutePath().toString());
-        assertThat(socketPath.getFileName().toString()).startsWith("lk-abcdef01");
+            // verify
+            assertThat(socketPath.toString()).startsWith(preferredDirectory.toAbsolutePath().toString());
+            assertThat(socketPath.getFileName().toString()).startsWith("lk-abcdef01");
+        }
+        finally
+        {
+            FileUtil.deleteRecursively(preferredDirectory, "temporary socket directory");
+        }
     }
 
     @Test

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
@@ -626,7 +626,10 @@ class PrepareServerMojoInternalTest
     {
         // setup
         final PrepareServerMojo mojo = new PrepareServerMojo();
-        final Path preferredDirectory = Files.createTempDirectory(Path.of("/tmp"), "lk-uds-fit-");
+        final Path preferredDirectory = Files.createTempDirectory(
+            Path.of(System.getProperty("java.io.tmpdir")),
+            "lk-uds-fit-"
+        );
         try
         {
             // execute

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
@@ -10,7 +10,6 @@ import nl.pim16aap2.lightkeeper.maven.provisioning.WorldInputSpec;
 import nl.pim16aap2.lightkeeper.maven.serverprovider.PaperServerProvider;
 import nl.pim16aap2.lightkeeper.maven.serverprovider.ServerProvider;
 import nl.pim16aap2.lightkeeper.maven.serverprovider.SpigotServerProvider;
-import nl.pim16aap2.lightkeeper.maven.util.FileUtil;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -30,11 +29,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -621,34 +622,30 @@ class PrepareServerMojoInternalTest
     }
 
     @Test
-    void resolveUdsSocketPath_shouldUsePreferredPathWhenItFits()
+    void resolveUdsSocketPath_shouldUsePreferredPathWhenItFits(@TempDir Path tempDirectory)
         throws Exception
     {
         // setup
         final PrepareServerMojo mojo = new PrepareServerMojo();
-        final Path preferredDirectory = Files.createTempDirectory(
-            Path.of(System.getProperty("java.io.tmpdir")),
-            "lk-uds-fit-"
+        final Path preferredDirectory = tempDirectory;
+        assumeTrue(
+            preferredDirectory.resolve("lk-abcdef01.sock").toAbsolutePath().toString()
+                .getBytes(StandardCharsets.UTF_8).length <= 108,
+            "Temporary directory path is too long for this AF_UNIX preferred-path test."
         );
-        try
-        {
-            // execute
-            final Path socketPath = invokePrivate(
-                mojo,
-                "resolveUdsSocketPath",
-                new Class<?>[]{Path.class, String.class},
-                preferredDirectory,
-                "abcdef0123456789abcdef0123456789"
-            );
 
-            // verify
-            assertThat(socketPath.toString()).startsWith(preferredDirectory.toAbsolutePath().toString());
-            assertThat(socketPath.getFileName().toString()).startsWith("lk-abcdef01");
-        }
-        finally
-        {
-            FileUtil.deleteRecursively(preferredDirectory, "temporary socket directory");
-        }
+        // execute
+        final Path socketPath = invokePrivate(
+            mojo,
+            "resolveUdsSocketPath",
+            new Class<?>[]{Path.class, String.class},
+            preferredDirectory,
+            "abcdef0123456789abcdef0123456789"
+        );
+
+        // verify
+        assertThat(socketPath.toString()).startsWith(preferredDirectory.toAbsolutePath().toString());
+        assertThat(socketPath.getFileName().toString()).startsWith("lk-abcdef01");
     }
 
     @Test

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
@@ -1,6 +1,8 @@
 package nl.pim16aap2.lightkeeper.maven.mojo.prepareserver;
 
 import com.sun.net.httpserver.HttpServer;
+import nl.pim16aap2.lightkeeper.maven.ModrinthDownloadsClient;
+import nl.pim16aap2.lightkeeper.maven.ModrinthPluginMetadata;
 import nl.pim16aap2.lightkeeper.maven.provisioning.PluginArtifactSpec;
 import nl.pim16aap2.lightkeeper.maven.provisioning.ResolvedPluginArtifact;
 import nl.pim16aap2.lightkeeper.maven.util.HashUtil;
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.net.InetSocketAddress;
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,6 +27,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class PrepareServerPluginArtifactResolverTest
 {
@@ -127,6 +131,79 @@ class PrepareServerPluginArtifactResolverTest
         }
     }
 
+    @Test
+    void resolvePluginArtifacts_shouldDownloadModrinthSourceToCacheAndReuseCache(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final byte[] pluginBytes = "modrinth-plugin".getBytes(StandardCharsets.UTF_8);
+        final AtomicInteger requestCount = new AtomicInteger();
+        final HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/plugin.jar", exchange -> {
+            requestCount.incrementAndGet();
+            exchange.sendResponseHeaders(200, pluginBytes.length);
+            exchange.getResponseBody().write(pluginBytes);
+            exchange.close();
+        });
+        server.start();
+        final URI downloadUri = URI.create("http://127.0.0.1:%d/plugin.jar".formatted(server.getAddress().getPort()));
+        final Path hashSource = Files.write(tempDirectory.resolve("modrinth.jar"), pluginBytes);
+        final ModrinthPluginMetadata metadata = new ModrinthPluginMetadata(
+            "version01",
+            "v5.5.0-bukkit",
+            "LuckPerms-Bukkit.jar",
+            downloadUri,
+            HashUtil.sha512(hashSource)
+        );
+        final ModrinthDownloadsClient modrinthDownloadsClient = mock(ModrinthDownloadsClient.class);
+        final PluginArtifactSpec spec = modrinthSpec();
+        when(modrinthDownloadsClient.resolvePluginFile(spec)).thenReturn(metadata);
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+        final HttpClient httpClient = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+        try
+        {
+            // execute
+            final List<ResolvedPluginArtifact> firstResolved = resolver.resolvePluginArtifacts(
+                List.of(spec),
+                mock(RepositorySystem.class),
+                mock(RepositorySystemSession.class),
+                List.of(),
+                tempDirectory.resolve("cache"),
+                "LightKeeper/Test",
+                httpClient,
+                modrinthDownloadsClient,
+                new SystemStreamLog()
+            );
+            final List<ResolvedPluginArtifact> secondResolved = resolver.resolvePluginArtifacts(
+                List.of(spec),
+                mock(RepositorySystem.class),
+                mock(RepositorySystemSession.class),
+                List.of(),
+                tempDirectory.resolve("cache"),
+                "LightKeeper/Test",
+                httpClient,
+                modrinthDownloadsClient,
+                new SystemStreamLog()
+            );
+
+            // verify
+            assertThat(firstResolved).singleElement().satisfies(artifact -> {
+                assertThat(artifact.outputFileName()).isEqualTo("LuckPerms-Bukkit.jar");
+                assertThat(artifact.sourceJar()).isRegularFile();
+                assertThat(artifact.sourceJar()).hasContent("modrinth-plugin");
+            });
+            assertThat(secondResolved.getFirst().sourceJar()).isEqualTo(firstResolved.getFirst().sourceJar());
+            assertThat(requestCount).hasValue(1);
+        }
+        finally
+        {
+            server.stop(0);
+        }
+    }
+
     private static PluginArtifactSpec urlSpec(URI uri, String sha256)
     {
         return new PluginArtifactSpec(
@@ -145,6 +222,28 @@ class PrepareServerPluginArtifactResolverTest
             null,
             null,
             null,
+            null
+        );
+    }
+
+    private static PluginArtifactSpec modrinthSpec()
+    {
+        return new PluginArtifactSpec(
+            PluginArtifactSpec.SourceType.MODRINTH,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "jar",
+            false,
+            null,
+            null,
+            null,
+            "luckperms",
+            "v5.5.0-bukkit",
+            "version01",
+            "bukkit",
             null
         );
     }

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
@@ -113,7 +113,7 @@ class PrepareServerPluginArtifactResolverTest
                 new SystemStreamLog()
             ))
                 .isInstanceOf(MojoExecutionException.class)
-                .hasMessageContaining("failed SHA256 verification");
+                .hasMessageContaining("failed SHA-256 verification");
             try (Stream<Path> cachedFiles = Files.walk(tempDirectory.resolve("cache")))
             {
                 assertThat(cachedFiles

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
@@ -10,13 +10,21 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
 import java.net.InetSocketAddress;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,11 +34,121 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class PrepareServerPluginArtifactResolverTest
 {
+    @Test
+    void resolvePluginArtifacts_shouldResolvePathSourceWithRename(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path sourceJar = Files.writeString(tempDirectory.resolve("source.jar"), "plugin");
+        final PluginArtifactSpec spec = new PluginArtifactSpec(
+            PluginArtifactSpec.SourceType.PATH,
+            sourceJar,
+            null,
+            null,
+            null,
+            null,
+            "jar",
+            false,
+            "renamed.jar"
+        );
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        // execute
+        final List<ResolvedPluginArtifact> resolved = resolver.resolvePluginArtifacts(
+            List.of(spec),
+            mock(RepositorySystem.class),
+            mock(RepositorySystemSession.class),
+            List.of(),
+            tempDirectory.resolve("cache"),
+            "LightKeeper/Test",
+            new SystemStreamLog()
+        );
+
+        // verify
+        assertThat(resolved).singleElement().satisfies(artifact -> {
+            assertThat(artifact.sourceJar()).isEqualTo(sourceJar);
+            assertThat(artifact.outputFileName()).isEqualTo("renamed.jar");
+            assertThat(artifact.sourceDescription()).isEqualTo("path:" + sourceJar);
+        });
+    }
+
+    @Test
+    void resolvePluginArtifacts_shouldResolveSingleMavenArtifact(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path sourceJar = Files.writeString(tempDirectory.resolve("fixture.jar"), "plugin");
+        final RepositorySystem repositorySystem = mock(RepositorySystem.class);
+        final RepositorySystemSession repositorySystemSession = mock(RepositorySystemSession.class);
+        final ArtifactRequest request = new ArtifactRequest()
+            .setArtifact(new DefaultArtifact("com.example:fixture:jar:1.0.0"))
+            .setRepositories(List.of());
+        when(repositorySystem.resolveArtifact(any(), any())).thenReturn(new ArtifactResult(request)
+            .setArtifact(new DefaultArtifact("com.example:fixture:jar:1.0.0").setFile(sourceJar.toFile())));
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        // execute
+        final List<ResolvedPluginArtifact> resolved = resolver.resolvePluginArtifacts(
+            List.of(mavenSpec(false, "renamed.jar")),
+            repositorySystem,
+            repositorySystemSession,
+            List.of(),
+            tempDirectory.resolve("cache"),
+            "LightKeeper/Test",
+            new SystemStreamLog()
+        );
+
+        // verify
+        assertThat(resolved).singleElement().satisfies(artifact -> {
+            assertThat(artifact.sourceJar()).isEqualTo(sourceJar);
+            assertThat(artifact.outputFileName()).isEqualTo("renamed.jar");
+            assertThat(artifact.sourceDescription()).startsWith("maven:com.example:fixture:jar:1.0.0");
+        });
+    }
+
+    @Test
+    void resolvePluginArtifacts_shouldResolveTransitiveMavenArtifacts(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path rootJar = Files.writeString(tempDirectory.resolve("fixture.jar"), "root");
+        final Path dependencyJar = Files.writeString(tempDirectory.resolve("dependency.jar"), "dependency");
+        final RepositorySystem repositorySystem = mock(RepositorySystem.class);
+        final RepositorySystemSession repositorySystemSession = mock(RepositorySystemSession.class);
+        final DependencyRequest request = new DependencyRequest();
+        final DependencyResult dependencyResult = new DependencyResult(request).setArtifactResults(List.of(
+            new ArtifactResult(new ArtifactRequest())
+                .setArtifact(new DefaultArtifact("com.example:fixture:jar:1.0.0").setFile(rootJar.toFile())),
+            new ArtifactResult(new ArtifactRequest())
+                .setArtifact(new DefaultArtifact("com.example:dependency:jar:1.0.0").setFile(dependencyJar.toFile()))
+        ));
+        when(repositorySystem.resolveDependencies(any(), any())).thenReturn(dependencyResult);
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        // execute
+        final List<ResolvedPluginArtifact> resolved = resolver.resolvePluginArtifacts(
+            List.of(mavenSpec(true, null)),
+            repositorySystem,
+            repositorySystemSession,
+            List.of(),
+            tempDirectory.resolve("cache"),
+            "LightKeeper/Test",
+            new SystemStreamLog()
+        );
+
+        // verify
+        assertThat(resolved).extracting(ResolvedPluginArtifact::outputFileName)
+            .containsExactly("fixture.jar", "dependency.jar");
+        assertThat(resolved).extracting(ResolvedPluginArtifact::sourceJar)
+            .containsExactly(rootJar, dependencyJar);
+    }
+
     @Test
     void resolvePluginArtifacts_shouldDownloadUrlSourceToCacheAndReuseCache(@TempDir Path tempDirectory)
         throws Exception
@@ -86,6 +204,87 @@ class PrepareServerPluginArtifactResolverTest
         {
             server.stop(0);
         }
+    }
+
+    @Test
+    void resolvePluginArtifacts_shouldRejectCorruptCachedUrlArtifact(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final byte[] pluginBytes = "plugin".getBytes(StandardCharsets.UTF_8);
+        final HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/plugin.jar", exchange -> {
+            exchange.sendResponseHeaders(200, pluginBytes.length);
+            exchange.getResponseBody().write(pluginBytes);
+            exchange.close();
+        });
+        server.start();
+        final URI uri = URI.create("http://127.0.0.1:%d/plugin.jar".formatted(server.getAddress().getPort()));
+        final PluginArtifactSpec spec = urlSpec(uri, HashUtil.sha256(pluginBytes));
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        try
+        {
+            final List<ResolvedPluginArtifact> resolved = resolver.resolvePluginArtifacts(
+                List.of(spec),
+                mock(RepositorySystem.class),
+                mock(RepositorySystemSession.class),
+                List.of(),
+                tempDirectory.resolve("cache"),
+                "LightKeeper/Test",
+                new SystemStreamLog()
+            );
+            Files.writeString(resolved.getFirst().sourceJar(), "tampered");
+
+            // execute + verify
+            assertThatThrownBy(() -> resolver.resolvePluginArtifacts(
+                List.of(spec),
+                mock(RepositorySystem.class),
+                mock(RepositorySystemSession.class),
+                List.of(),
+                tempDirectory.resolve("cache"),
+                "LightKeeper/Test",
+                new SystemStreamLog()
+            ))
+                .isInstanceOf(MojoExecutionException.class)
+                .hasMessageContaining("cached plugin artifact")
+                .hasMessageContaining("failed SHA-256 verification");
+        }
+        finally
+        {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolvePluginArtifacts_shouldRejectFailedUrlDownload(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final HttpClient httpClient = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        final HttpResponse<Path> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(404);
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        // execute + verify
+        assertThatThrownBy(() -> resolver.resolvePluginArtifacts(
+            List.of(urlSpec(
+                URI.create("https://example.com/plugin.jar"),
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            )),
+            mock(RepositorySystem.class),
+            mock(RepositorySystemSession.class),
+            List.of(),
+            tempDirectory.resolve("cache"),
+            "LightKeeper/Test",
+            httpClient,
+            mock(ModrinthDownloadsClient.class),
+            new SystemStreamLog()
+        ))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("failed with status 404");
     }
 
     @Test
@@ -204,6 +403,40 @@ class PrepareServerPluginArtifactResolverTest
         }
     }
 
+    @Test
+    void resolvePluginArtifacts_shouldRejectModrinthFilenameWithoutJarSuffix(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final URI downloadUri = URI.create("https://example.com/modrinth/plugin.txt");
+        final ModrinthPluginMetadata metadata = new ModrinthPluginMetadata(
+            "version01",
+            "v5.5.0-bukkit",
+            "plugin.txt",
+            downloadUri,
+            HashUtil.sha512(new ByteArrayInputStream("modrinth-plugin".getBytes(StandardCharsets.UTF_8)))
+        );
+        final ModrinthDownloadsClient modrinthDownloadsClient = mock(ModrinthDownloadsClient.class);
+        final PluginArtifactSpec spec = modrinthSpec();
+        when(modrinthDownloadsClient.resolvePluginFile(spec)).thenReturn(metadata);
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        // execute + verify
+        assertThatThrownBy(() -> resolver.resolvePluginArtifacts(
+            List.of(spec),
+            mock(RepositorySystem.class),
+            mock(RepositorySystemSession.class),
+            List.of(),
+            tempDirectory.resolve("cache"),
+            "LightKeeper/Test",
+            mock(HttpClient.class),
+            modrinthDownloadsClient,
+            new SystemStreamLog()
+        ))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("must end with .jar");
+    }
+
     private static PluginArtifactSpec urlSpec(URI uri, String sha256)
     {
         return new PluginArtifactSpec(
@@ -244,6 +477,28 @@ class PrepareServerPluginArtifactResolverTest
             "v5.5.0-bukkit",
             "version01",
             "bukkit",
+            null
+        );
+    }
+
+    private static PluginArtifactSpec mavenSpec(boolean includeTransitive, @Nullable String renameTo)
+    {
+        return new PluginArtifactSpec(
+            PluginArtifactSpec.SourceType.MAVEN,
+            null,
+            "com.example",
+            "fixture",
+            "1.0.0",
+            null,
+            "jar",
+            includeTransitive,
+            renameTo,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
             null
         );
     }

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerPluginArtifactResolverTest.java
@@ -1,0 +1,151 @@
+package nl.pim16aap2.lightkeeper.maven.mojo.prepareserver;
+
+import com.sun.net.httpserver.HttpServer;
+import nl.pim16aap2.lightkeeper.maven.provisioning.PluginArtifactSpec;
+import nl.pim16aap2.lightkeeper.maven.provisioning.ResolvedPluginArtifact;
+import nl.pim16aap2.lightkeeper.maven.util.HashUtil;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.InetSocketAddress;
+import java.net.InetAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class PrepareServerPluginArtifactResolverTest
+{
+    @Test
+    void resolvePluginArtifacts_shouldDownloadUrlSourceToCacheAndReuseCache(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final byte[] pluginBytes = "plugin".getBytes(StandardCharsets.UTF_8);
+        final AtomicInteger requestCount = new AtomicInteger();
+        final HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/plugin.jar", exchange -> {
+            requestCount.incrementAndGet();
+            exchange.sendResponseHeaders(200, pluginBytes.length);
+            exchange.getResponseBody().write(pluginBytes);
+            exchange.close();
+        });
+        server.start();
+        final URI uri = URI.create("http://127.0.0.1:%d/plugin.jar".formatted(server.getAddress().getPort()));
+        final PluginArtifactSpec spec = urlSpec(uri, HashUtil.sha256(pluginBytes));
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        try
+        {
+            // execute
+            final List<ResolvedPluginArtifact> firstResolved = resolver.resolvePluginArtifacts(
+                List.of(spec),
+                mock(RepositorySystem.class),
+                mock(RepositorySystemSession.class),
+                List.of(),
+                tempDirectory.resolve("cache"),
+                "LightKeeper/Test",
+                new SystemStreamLog()
+            );
+            server.stop(0);
+            final List<ResolvedPluginArtifact> secondResolved = resolver.resolvePluginArtifacts(
+                List.of(spec),
+                mock(RepositorySystem.class),
+                mock(RepositorySystemSession.class),
+                List.of(),
+                tempDirectory.resolve("cache"),
+                "LightKeeper/Test",
+                new SystemStreamLog()
+            );
+
+            // verify
+            assertThat(firstResolved).singleElement().satisfies(artifact -> {
+                assertThat(artifact.outputFileName()).isEqualTo("plugin.jar");
+                assertThat(artifact.sourceJar()).isRegularFile();
+                assertThat(artifact.sourceJar()).hasContent("plugin");
+            });
+            assertThat(secondResolved.getFirst().sourceJar()).isEqualTo(firstResolved.getFirst().sourceJar());
+            assertThat(requestCount).hasValue(1);
+        }
+        finally
+        {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolvePluginArtifacts_shouldRejectUrlHashMismatch(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final byte[] pluginBytes = "plugin".getBytes(StandardCharsets.UTF_8);
+        final HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/plugin.jar", exchange -> {
+            exchange.sendResponseHeaders(200, pluginBytes.length);
+            exchange.getResponseBody().write(pluginBytes);
+            exchange.close();
+        });
+        server.start();
+        final URI uri = URI.create("http://127.0.0.1:%d/plugin.jar".formatted(server.getAddress().getPort()));
+        final PrepareServerPluginArtifactResolver resolver = new PrepareServerPluginArtifactResolver();
+
+        try
+        {
+            // execute + verify
+            assertThatThrownBy(() -> resolver.resolvePluginArtifacts(
+                List.of(urlSpec(uri, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),
+                mock(RepositorySystem.class),
+                mock(RepositorySystemSession.class),
+                List.of(),
+                tempDirectory.resolve("cache"),
+                "LightKeeper/Test",
+                new SystemStreamLog()
+            ))
+                .isInstanceOf(MojoExecutionException.class)
+                .hasMessageContaining("failed SHA256 verification");
+            try (Stream<Path> cachedFiles = Files.walk(tempDirectory.resolve("cache")))
+            {
+                assertThat(cachedFiles
+                    .filter(path -> path.getFileName().toString().equals("plugin.jar"))
+                    .toList()).isEmpty();
+            }
+        }
+        finally
+        {
+            server.stop(0);
+        }
+    }
+
+    private static PluginArtifactSpec urlSpec(URI uri, String sha256)
+    {
+        return new PluginArtifactSpec(
+            PluginArtifactSpec.SourceType.URL,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "jar",
+            false,
+            "plugin.jar",
+            uri,
+            sha256,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/util/HashUtilTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/util/HashUtilTest.java
@@ -5,7 +5,10 @@ import com.google.common.jimfs.Jimfs;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -56,5 +59,78 @@ class HashUtilTest
         assertThatThrownBy(() -> HashUtil.sha256(missingFile))
             .isInstanceOf(MojoExecutionException.class)
             .hasMessageContaining("Failed to compute SHA-256");
+    }
+
+    @Test
+    void sha512_shouldGenerateDeterministicHashForString()
+        throws MojoExecutionException
+    {
+        // setup
+        final String input = "LightKeeper";
+
+        // execute
+        final String hash = HashUtil.sha512(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+
+        // verify
+        assertThat(hash).isEqualTo(
+            "90d2cf252faed910836b776745d54aae4e384345d57b1a26e83b77f94328ea66e11fb235090df83a9503f855842fbf7372c39c1793345051e5894723b1a62831"
+        );
+    }
+
+    @Test
+    void sha512_shouldGenerateDeterministicHashForFile()
+        throws IOException, MojoExecutionException
+    {
+        // setup
+        try (FileSystem fileSystem = Jimfs.newFileSystem(Configuration.unix()))
+        {
+            final Path file = fileSystem.getPath("test.txt");
+            Files.writeString(file, "LightKeeper");
+
+            // execute
+            final String hash = HashUtil.sha512(file);
+
+            // verify
+            assertThat(hash).isEqualTo(
+                "90d2cf252faed910836b776745d54aae4e384345d57b1a26e83b77f94328ea66e11fb235090df83a9503f855842fbf7372c39c1793345051e5894723b1a62831"
+            );
+        }
+    }
+
+    @Test
+    void sha512_shouldGenerateDeterministicHashForInputStream()
+        throws IOException, MojoExecutionException
+    {
+        // setup
+        try (InputStream inputStream = new ByteArrayInputStream("LightKeeper".getBytes(StandardCharsets.UTF_8)))
+        {
+            // execute
+            final String hash = HashUtil.sha512(inputStream);
+
+            // verify
+            assertThat(hash).isEqualTo(
+                "90d2cf252faed910836b776745d54aae4e384345d57b1a26e83b77f94328ea66e11fb235090df83a9503f855842fbf7372c39c1793345051e5894723b1a62831"
+            );
+        }
+    }
+
+    @Test
+    void sha256_shouldWrapIOExceptionFromInputStream()
+    {
+        // setup
+        final InputStream inputStream = new InputStream()
+        {
+            @Override
+            public int read()
+                throws IOException
+            {
+                throw new IOException("boom");
+            }
+        };
+
+        // execute + verify
+        assertThatThrownBy(() -> HashUtil.sha256(inputStream))
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Failed to compute SHA-256 from input stream");
     }
 }


### PR DESCRIPTION
## Summary

Adds first-class plugin dependency provisioning to `lightkeeper-maven-plugin` for Maven, Modrinth, and direct URL sources.

## Changes

- Extends plugin artifact config/specs with `modrinth` and `url` source types while preserving existing `path` and `maven` behavior.
- Adds `lightkeeper.pluginArtifactCacheDirectoryRoot` for downloaded/provider-backed plugin jars.
- Downloads URL and Modrinth artifacts through a canonical cache path with temp-file writes, checksum verification, and atomic cache moves before install.
- Adds a Modrinth v2 metadata client that resolves exact versions and rejects ambiguous Bukkit jar selection.
- Updates README examples and GitHub Actions cache guidance.

## Validation

- `mvn -pl lightkeeper-maven-plugin '-Dtest=PrepareServer*Test,ServerAssetInstallerTest,ModrinthDownloadsClientTest,HashUtilTest' test`
- `mvn -pl lightkeeper-maven-plugin checkstyle:check`

## Notes

URL sources require SHA-256. Modrinth file downloads are verified with the checksum Modrinth provides for files, SHA-512.