### PR TITLE
🤖feat: player teleportation and chunk control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+## Build & Validation
+
+- Before committing, run all checks: `mvn clean verify install -Perrorprone -Dmaven.javadoc.skip=true checkstyle:checkstyle pmd:check jacoco:report`
+  All checks must pass. Fix any errors before proposing changes.
+
+
+## Git handling
+
+- When adding new files, also add them to git.
+- Never add `AGENTS.md` or any file in the `.codex` directory.
+- Rationale: `.codex` is local Codex-cli working state (plans/scratch output) and must stay out of version control.
+
+## Project LightKeeper
+
+LightKeeper is an end-to-end integration testing stack for Minecraft plugins.
+It runs real Paper/Spigot server instances, injects a LightKeeper runtime agent plugin, and lets JUnit tests
+control/assert server state through a typed framework API.
+
+### What LightKeeper does
+
+- Provisions test server runtimes via Maven (`prepare-server` goal):
+  - Resolves/builds Paper or Spigot server artifacts
+  - Caches server artifacts and prepared base server directories
+  - Installs test assets (plugins, worlds, config overlays)
+  - Auto-provisions the embedded `lightkeeper-agent-spigot` plugin
+  - Writes a runtime manifest JSON for test execution
+- Executes tests via JUnit framework:
+  - `LightkeeperExtension` injects `ILightkeeperFramework`
+  - Framework starts/stops the server process from the runtime manifest
+  - Framework connects to in-server agent over Unix Domain Socket (UDS)
+- Performs rich E2E interactions/assertions:
+  - World operations (create worlds, set/query blocks, load/unload chunks)
+  - Synthetic players (spawn/remove, permissions, health, commands, teleportation, inventory, item drops)
+  - GUI/menu actions (snapshot, click, drag, close)
+  - Dynamic event capture (listen to any Bukkit event)
+  - Message/chat assertions (plain text and clickable components)
+  - Fluent AssertJ helpers and platform awareness (Paper/Spigot)
+  - Server lifecycle control (crash and restart mid-test)
+
+### Primary modules
+
+- `lightkeeper-maven-plugin`: Maven goals `prepare-server` and `cleanup-server` for provisioning and lifecycle cleanup.
+- `lightkeeper-framework-junit`: Public test API (`ILightkeeperFramework`, handles/builders, JUnit extension, assertions).
+- `lightkeeper-agent-spigot`: In-server RPC agent handling handshake/auth and action dispatch.
+- `lightkeeper-runtime-core`: Shared protocol constants, manifest model, request/response DTOs.
+- `lightkeeper-nms-parent`:
+  - `lightkeeper-nms-api`: NMS contracts
+  - `lightkeeper-nms-v1_21_R7`: Concrete adapter implementation
+- `lightkeeper-spigot-test-plugin`: Functional fixture plugin used by integration tests (`/lktestgui` flow).
+- `lightkeeper-integration-tests`: Full-stack tests validating provisioning + runtime behavior on both Paper and Spigot.
+- `lightkeeper-report-aggregate`: Aggregated reporting module.
+
+### Runtime flow (canonical)
+
+1. Maven `prepare-server` runs in `pre-integration-test`.
+2. Runtime manifest is generated with socket path/auth token/protocol/server paths.
+3. JUnit tests start framework (`Lightkeeper.start(...)` or `LightkeeperExtension`).
+4. Framework starts Minecraft server process and handshakes with the agent via UDS.
+5. Tests execute actions/assertions through framework handles.
+6. Maven `cleanup-server` may delete server work directories after successful test runs.
+
+### Current platform/runtime constraints
+
+- Java 21, Maven 3.9+
+- Transport is UDS (Linux/macOS preferred)
+- Agent validates supported Bukkit/NMS version at startup (currently 1.21.11 / `v1_21_R7` in this codebase)
+
+### Typical test API examples
+
+- `framework.mainWorld()`, `framework.newWorld(...)`
+- `framework.buildPlayer().withPermissions(...).build()`
+- `player.executeCommand("lktestgui").andWaitForMenuOpen(...).clickAtIndex(...)`
+- `assertThat(world).hasBlockAt(x, y, z).ofType("minecraft:stone")`
+- `assertThat(player).receivedMessage("...")`
+
+## Package and naming conventions
+
+- Keep public framework API in `lightkeeper-framework-junit/.../framework`; keep implementation details in
+  `lightkeeper-framework-junit/.../framework/internal`.
+- Keep runtime protocol enums/DTOs in `lightkeeper-runtime-core/.../runtime` and
+  `lightkeeper-runtime-core/.../runtime/agent`.
+- Keep in-server action handling in `lightkeeper-agent-spigot/.../agent/spigot`.
+- Keep Maven provisioning/lifecycle logic in `lightkeeper-maven-plugin/.../maven/...`.
+- Naming conventions:
+  - `*Handle`: user-facing runtime objects (`WorldHandle`, `PlayerHandle`, `MenuHandle`).
+  - `I*Builder` + `Default*Builder`: fluent builders and default implementations.
+  - `*Spec`: immutable input configuration value objects.
+  - `*Snapshot`: immutable read models returned from agent/framework state reads.
+  - `*Actions`: grouped agent-side action executors per domain.
+  - `*Mojo`: Maven goals.
+  - `*Provider`: server resolution/provisioning backends.
+
+## Error handling and logging conventions
+
+- Validate inputs at API boundaries and fail fast with `IllegalArgumentException` for invalid caller input.
+- Use `IllegalStateException` for runtime/protocol/lifecycle failures that represent invalid state or failed operations.
+- Keep RPC/protocol failures structured in agent responses (`success/errorCode/errorMessage/data`) and translate once at
+  the framework boundary.
+- Log at lifecycle boundaries (start/stop/major transitions/failures) and avoid duplicate logging at multiple layers.
+- Include actionable context in thrown exceptions and logs (action, identifiers, file/path, protocol versions).
+
+## Test conventions
+
+- Place module unit tests in each module under `src/test/java`.
+- Place cross-module end-to-end tests in `lightkeeper-integration-tests`.
+- Keep integration tests focused on real runtime behavior (server startup, RPC actions, world/player/menu assertions).
+- Test method names must follow `methodToTest_whatWeTest`.
+- Test bodies must include explicit `// setup`, `// execute`, and `// verify` sections.
+- For new functionality, cover both:
+  - Happy-path behavior.
+  - Failure/validation behavior with clear assertions.
+
+## How to extend LightKeeper
+
+### Add a new runtime RPC action
+
+1. Add the action enum entry in `lightkeeper-runtime-core/.../runtime/agent/AgentAction`.
+2. Add or extend request/response payload shape in `lightkeeper-runtime-core` DTOs if needed.
+3. Implement agent-side parsing/validation/dispatch in `lightkeeper-agent-spigot`
+   (`AgentRequestDispatcher`, `AgentRequestParsers`, `AgentResponses`, and relevant `*Actions` class).
+4. Add framework client call in `lightkeeper-framework-junit/.../framework/internal/UdsAgentClient`.
+5. Expose API through `ILightkeeperFramework`, handle/builder types, and assertions if user-facing.
+6. Add unit tests for agent dispatch/parsing + framework client behavior.
+7. Add integration coverage in `lightkeeper-integration-tests` proving end-to-end behavior on Paper and Spigot.
+
+### Add support for a new NMS/server revision
+
+1. Add a new module under `lightkeeper-nms-parent` (for example `lightkeeper-nms-vX_Y_RZ`).
+2. Implement `IBotPlayerNmsAdapter` in that module.
+3. Register the adapter in `SpigotLightkeeperAgentPlugin` NMS adapter map and compatibility checks.
+4. Update module dependencies/shading so agent packaging includes the new adapter.
+5. Add focused adapter unit tests and end-to-end integration coverage for synthetic player behavior.
+6. Keep existing adapters untouched unless behavior must be shared; avoid version-specific branching outside adapter
+   boundaries.
+
+### Add a new framework API surface (handle/builder/assertion)
+
+1. Define/extend the public interface in `lightkeeper-framework-junit/.../framework`.
+2. Implement behavior in `.../framework/internal` using `IFrameworkGateway` and `UdsAgentClient`.
+3. Preserve lifecycle invariants: framework must be open, player scope must be tracked/cleaned up correctly.
+4. Add/extend AssertJ assertions in `.../framework/assertions` for the new behavior.
+5. Add unit tests plus integration tests that demonstrate fluent API usage and runtime effect.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ planned and reviewed by a human.
 4. Your tests connect through `lightkeeper-framework-junit` (using the runtime manifest path).
 5. During `post-integration-test`, `lightkeeper:cleanup-server` can delete server work directories when tests pass.
 
+## Key Features
+
+- **Server Lifecycle Control**: Crash and restart the server mid-test to verify recovery logic.
+- **World & Chunk Control**: Load/unload chunks, check chunk status, and teleport players between worlds.
+- **Inventory & Item Drops**: Inspect player inventories and simulate item drops.
+- **Dynamic Event Capture**: Capture and assert on any Bukkit event dynamically without writing custom listeners.
+- **Clickable Chat Interaction**: Verify and interact with clickable chat messages.
+- **Platform Awareness**: Write tests that adapt to Paper or Spigot specifics.
+
 ## Requirements
 
 - Java 21

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
@@ -1,0 +1,141 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
+import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
+import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.RegisterEventListenerCommand;
+import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Protocol action handler for dynamic Bukkit event capture.
+ *
+ * <p>Handles {@code REGISTER_EVENT_LISTENER}, {@code GET_CAPTURED_EVENTS},
+ * {@code CLEAR_CAPTURED_EVENTS}, and {@code UNREGISTER_EVENT_LISTENER} actions by delegating to
+ * {@link AgentEventCapture}.
+ */
+final class AgentEventActions
+{
+    /**
+     * Dynamic event listener and payload store.
+     */
+    private final AgentEventCapture eventCapture;
+    /**
+     * JSON serializer for the captured event payload list.
+     */
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param eventCapture
+     *     Dynamic event capture facade.
+     * @param objectMapper
+     *     JSON serializer for event data.
+     */
+    AgentEventActions(AgentEventCapture eventCapture, ObjectMapper objectMapper)
+    {
+        this.eventCapture = Objects.requireNonNull(eventCapture, "eventCapture");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    /**
+     * Handles {@code REGISTER_EVENT_LISTENER} by resolving and registering a monitor-priority Bukkit listener.
+     *
+     * @param command
+     *     Typed register-event-listener command.
+     * @return
+     *     Success response, or {@code INVALID_ARGUMENT} when the class is blank, unknown, or not a Bukkit Event.
+     */
+    AgentResponse handleRegisterEventListener(RegisterEventListenerCommand command)
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName == null || eventClassName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(), AgentErrorCode.INVALID_ARGUMENT, "eventClassName may not be blank."
+            );
+        }
+        try
+        {
+            eventCapture.registerListener(eventClassName);
+        }
+        catch (ClassNotFoundException | IllegalArgumentException exception)
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                Objects.requireNonNullElse(exception.getMessage(), exception.getClass().getName())
+            );
+        }
+        catch (Exception exception)
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.REQUEST_FAILED,
+                Objects.requireNonNullElse(exception.getMessage(), exception.getClass().getName())
+            );
+        }
+        return AgentResponses.successResponse(command.requestId(), Map.of());
+    }
+
+    /**
+     * Handles {@code GET_CAPTURED_EVENTS} by returning all events captured since the listener was registered or
+     * last cleared.
+     *
+     * @param command
+     *     Typed get-captured-events command.
+     * @return
+     *     Success response with {@code eventsJson}, or {@code INVALID_ARGUMENT} when the class name is blank.
+     * @throws Exception
+     *     Propagates JSON serialization failures.
+     */
+    AgentResponse handleGetCapturedEvents(GetCapturedEventsCommand command) throws Exception
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName == null || eventClassName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(), AgentErrorCode.INVALID_ARGUMENT, "eventClassName may not be blank."
+            );
+        }
+        final List<Map<String, String>> events = eventCapture.getCapturedEvents(eventClassName);
+        final String eventsJson = objectMapper.writeValueAsString(events);
+        return AgentResponses.successResponse(command.requestId(), Map.of("eventsJson", eventsJson));
+    }
+
+    /**
+     * Handles {@code CLEAR_CAPTURED_EVENTS} by discarding accumulated payloads for the event class.
+     *
+     * @param command
+     *     Typed clear-captured-events command.
+     * @return
+     *     Success response.
+     */
+    AgentResponse handleClearCapturedEvents(ClearCapturedEventsCommand command)
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName != null && !eventClassName.isBlank())
+            eventCapture.clearCapturedEvents(eventClassName);
+        return AgentResponses.successResponse(command.requestId(), Map.of());
+    }
+
+    /**
+     * Handles {@code UNREGISTER_EVENT_LISTENER} by removing the listener and discarding its accumulated events.
+     *
+     * @param command
+     *     Typed unregister-event-listener command.
+     * @return
+     *     Success response.
+     */
+    AgentResponse handleUnregisterEventListener(UnregisterEventListenerCommand command)
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName != null && !eventClassName.isBlank())
+            eventCapture.unregisterListener(eventClassName);
+        return AgentResponses.successResponse(command.requestId(), Map.of());
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
@@ -5,67 +5,225 @@ import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Dynamically captures Bukkit events by registering temporary listeners.
+ *
+ * <p>All Bukkit listener (un)registration calls are routed through {@link AgentMainThreadExecutor} because
+ * {@link org.bukkit.plugin.PluginManager#registerEvent} and {@link HandlerList#unregisterAll(Listener)} must
+ * run on the Bukkit primary thread.
  */
 final class AgentEventCapture
 {
+    /**
+     * Maximum number of events retained per registered event class name.
+     * Prevents unbounded memory growth when a test forgets to close the capture handle.
+     */
+    private static final int MAX_CAPTURED_EVENTS_PER_CLASS = 10_000;
+    /**
+     * Maximum number of getter/isser methods inspected per event instance during capture.
+     * Bounds reflection overhead for events with very wide APIs.
+     */
+    private static final int MAX_CAPTURE_METHODS_PER_EVENT = 32;
+
+    /**
+     * Owning plugin used as registration context for Bukkit listeners.
+     */
     private final JavaPlugin plugin;
+    /**
+     * Main-thread execution bridge used for Bukkit-safe (un)registration calls.
+     */
+    private final AgentMainThreadExecutor mainThreadExecutor;
+    /**
+     * Captured event payloads keyed by fully qualified event class name.
+     */
     private final Map<String, List<Map<String, String>>> capturedEvents = new ConcurrentHashMap<>();
+    /**
+     * Active marker listeners keyed by fully qualified event class name.
+     */
     private final Map<String, Listener> activeListeners = new ConcurrentHashMap<>();
 
-    AgentEventCapture(JavaPlugin plugin)
+    /**
+     * @param plugin
+     *     Owning plugin used as Bukkit registration context.
+     * @param mainThreadExecutor
+     *     Main-thread executor used to route Bukkit listener (un)registration onto the server thread.
+     */
+    AgentEventCapture(JavaPlugin plugin, AgentMainThreadExecutor mainThreadExecutor)
     {
-        this.plugin = plugin;
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.mainThreadExecutor = Objects.requireNonNull(mainThreadExecutor, "mainThreadExecutor");
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Registers a monitor-priority listener that captures every fired event of the requested type.
+     *
+     * <p>Resolution and Bukkit registration are atomic per event class name: concurrent invocations for the
+     * same class register the listener exactly once.
+     *
+     * @param eventClassName
+     *     Fully qualified Bukkit event class to register.
+     * @throws ClassNotFoundException
+     *     When the class cannot be resolved by any reachable class loader.
+     */
     void registerListener(String eventClassName)
         throws ClassNotFoundException
     {
-        if (activeListeners.containsKey(eventClassName))
+        final Listener marker = new Listener() {};
+        final Listener previous = activeListeners.putIfAbsent(eventClassName, marker);
+        if (previous != null)
             return;
 
-        final Class<? extends Event> eventClass = (Class<? extends Event>) Class.forName(eventClassName);
-        final Listener listener = new Listener() {};
+        boolean registered = false;
+        try
+        {
+            final Class<?> resolvedClass = resolveEventClass(eventClassName);
+            if (!Event.class.isAssignableFrom(resolvedClass))
+                throw new IllegalArgumentException("Class '%s' is not a Bukkit Event.".formatted(eventClassName));
 
-        Bukkit.getPluginManager().registerEvent(
-            eventClass,
-            listener,
-            EventPriority.MONITOR,
-            (l, event) -> captureEvent(event),
-            plugin,
-            true
-        );
+            final Class<? extends Event> eventClass = resolvedClass.asSubclass(Event.class);
+            final List<Map<String, String>> events =
+                capturedEvents.computeIfAbsent(eventClassName, ignored -> new CopyOnWriteArrayList<>());
 
-        activeListeners.put(eventClassName, listener);
-        capturedEvents.putIfAbsent(eventClassName, new CopyOnWriteArrayList<>());
+            mainThreadExecutor.callOnMainThread(() ->
+            {
+                Bukkit.getPluginManager().registerEvent(
+                    eventClass,
+                    marker,
+                    EventPriority.MONITOR,
+                    (listenerInstance, event) -> captureEventForList(event, events),
+                    plugin,
+                    false
+                );
+                return Boolean.TRUE;
+            });
+            registered = true;
+        }
+        catch (ClassNotFoundException | RuntimeException exception)
+        {
+            throw exception;
+        }
+        catch (Exception exception)
+        {
+            throw new IllegalStateException(
+                "Failed to register listener for '%s' on the main thread.".formatted(eventClassName), exception);
+        }
+        finally
+        {
+            if (!registered)
+                activeListeners.remove(eventClassName, marker);
+        }
     }
 
+    private Class<?> resolveEventClass(String eventClassName)
+        throws ClassNotFoundException
+    {
+        final Set<ClassLoader> classLoaders = new LinkedHashSet<>();
+        classLoaders.add(AgentEventCapture.class.getClassLoader());
+        classLoaders.add(plugin.getClass().getClassLoader());
+        final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        if (contextClassLoader != null)
+            classLoaders.add(contextClassLoader);
+
+        ClassNotFoundException failure = null;
+        for (final ClassLoader classLoader : classLoaders)
+        {
+            try
+            {
+                return Class.forName(eventClassName, false, classLoader);
+            }
+            catch (ClassNotFoundException exception)
+            {
+                if (failure == null)
+                    failure = exception;
+                else
+                    failure.addSuppressed(exception);
+            }
+        }
+
+        for (final Plugin registeredPlugin : Bukkit.getPluginManager().getPlugins())
+        {
+            try
+            {
+                return Class.forName(eventClassName, false, registeredPlugin.getClass().getClassLoader());
+            }
+            catch (ClassNotFoundException exception)
+            {
+                if (failure == null)
+                    failure = exception;
+                else
+                    failure.addSuppressed(exception);
+            }
+        }
+
+        if (failure != null)
+            throw failure;
+        throw new ClassNotFoundException(eventClassName);
+    }
+
+    /**
+     * Unregisters a previously registered capture listener and discards its accumulated events.
+     *
+     * @param eventClassName
+     *     Fully qualified event class previously passed to {@link #registerListener(String)}.
+     */
     void unregisterListener(String eventClassName)
     {
         final Listener listener = activeListeners.remove(eventClassName);
-        if (listener != null)
-            HandlerList.unregisterAll(listener);
         capturedEvents.remove(eventClassName);
+        if (listener == null)
+            return;
+
+        try
+        {
+            mainThreadExecutor.callOnMainThread(() ->
+            {
+                HandlerList.unregisterAll(listener);
+                return Boolean.TRUE;
+            });
+        }
+        catch (RuntimeException exception)
+        {
+            throw exception;
+        }
+        catch (Exception exception)
+        {
+            throw new IllegalStateException(
+                "Failed to unregister listener for '%s' on the main thread.".formatted(eventClassName), exception);
+        }
     }
 
+    /**
+     * @param eventClassName
+     *     Fully qualified event class whose captured events should be returned.
+     * @return
+     *     Snapshot list of captured event payloads, or an empty list when nothing has been captured.
+     */
     List<Map<String, String>> getCapturedEvents(String eventClassName)
     {
         final List<Map<String, String>> events = capturedEvents.get(eventClassName);
         return events != null ? new ArrayList<>(events) : Collections.emptyList();
     }
 
+    /**
+     * Discards all previously captured events for the requested event class without unregistering its listener.
+     *
+     * @param eventClassName
+     *     Fully qualified event class whose captured events should be cleared.
+     */
     void clearCapturedEvents(String eventClassName)
     {
         final List<Map<String, String>> events = capturedEvents.get(eventClassName);
@@ -73,45 +231,35 @@ final class AgentEventCapture
             events.clear();
     }
 
-    private void captureEvent(Event event)
-    {
-        final String className = event.getClass().getName();
-        // Check for the class name and its superclasses (e.g. if we listen for PlayerEvent but get PlayerMoveEvent)
-        // Actually, Bukkit's registerEvent handles the class hierarchy for us.
-        // But capturedEvents is keyed by the registered class name.
-        
-        for (final Map.Entry<String, List<Map<String, String>>> entry : capturedEvents.entrySet())
-        {
-            try
-            {
-                final Class<?> registeredClass = Class.forName(entry.getKey());
-                if (registeredClass.isInstance(event))
-                {
-                    captureEventForList(event, entry.getValue());
-                }
-            }
-            catch (ClassNotFoundException ignored) {}
-        }
-    }
-
     private void captureEventForList(Event event, List<Map<String, String>> targetList)
     {
+        if (targetList.size() >= MAX_CAPTURED_EVENTS_PER_CLASS)
+            return;
+
         final Map<String, String> data = new ConcurrentHashMap<>();
+        int inspectedMethodCount = 0;
         for (final Method method : event.getClass().getMethods())
         {
+            if (inspectedMethodCount >= MAX_CAPTURE_METHODS_PER_EVENT)
+                break;
+
             if (method.getParameterCount() == 0 &&
                 (method.getName().startsWith("get") || method.getName().startsWith("is")) &&
                 !method.getName().equals("getClass") &&
                 !method.getName().equals("getHandlers") &&
                 !method.getName().equals("getEventName"))
             {
+                ++inspectedMethodCount;
                 try
                 {
                     final Object value = method.invoke(event);
                     if (isPrintable(value))
                         data.put(method.getName(), String.valueOf(value));
                 }
-                catch (Exception ignored) {}
+                catch (Exception ignored)
+                {
+                    // Ignored
+                }
             }
         }
         targetList.add(data);
@@ -120,12 +268,10 @@ final class AgentEventCapture
     private boolean isPrintable(Object value)
     {
         if (value == null) return false;
-        final Class<?> clazz = value.getClass();
-        return clazz.isPrimitive() ||
-               value instanceof String ||
+        return value instanceof String ||
                value instanceof Number ||
                value instanceof Boolean ||
                value instanceof java.util.UUID ||
-               clazz.isEnum();
+               value.getClass().isEnum();
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
@@ -1,0 +1,131 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Dynamically captures Bukkit events by registering temporary listeners.
+ */
+final class AgentEventCapture
+{
+    private final JavaPlugin plugin;
+    private final Map<String, List<Map<String, String>>> capturedEvents = new ConcurrentHashMap<>();
+    private final Map<String, Listener> activeListeners = new ConcurrentHashMap<>();
+
+    AgentEventCapture(JavaPlugin plugin)
+    {
+        this.plugin = plugin;
+    }
+
+    @SuppressWarnings("unchecked")
+    void registerListener(String eventClassName)
+        throws ClassNotFoundException
+    {
+        if (activeListeners.containsKey(eventClassName))
+            return;
+
+        final Class<? extends Event> eventClass = (Class<? extends Event>) Class.forName(eventClassName);
+        final Listener listener = new Listener() {};
+
+        Bukkit.getPluginManager().registerEvent(
+            eventClass,
+            listener,
+            EventPriority.MONITOR,
+            (l, event) -> captureEvent(event),
+            plugin,
+            true
+        );
+
+        activeListeners.put(eventClassName, listener);
+        capturedEvents.putIfAbsent(eventClassName, new CopyOnWriteArrayList<>());
+    }
+
+    void unregisterListener(String eventClassName)
+    {
+        final Listener listener = activeListeners.remove(eventClassName);
+        if (listener != null)
+            HandlerList.unregisterAll(listener);
+        capturedEvents.remove(eventClassName);
+    }
+
+    List<Map<String, String>> getCapturedEvents(String eventClassName)
+    {
+        final List<Map<String, String>> events = capturedEvents.get(eventClassName);
+        return events != null ? new ArrayList<>(events) : Collections.emptyList();
+    }
+
+    void clearCapturedEvents(String eventClassName)
+    {
+        final List<Map<String, String>> events = capturedEvents.get(eventClassName);
+        if (events != null)
+            events.clear();
+    }
+
+    private void captureEvent(Event event)
+    {
+        final String className = event.getClass().getName();
+        // Check for the class name and its superclasses (e.g. if we listen for PlayerEvent but get PlayerMoveEvent)
+        // Actually, Bukkit's registerEvent handles the class hierarchy for us.
+        // But capturedEvents is keyed by the registered class name.
+        
+        for (final Map.Entry<String, List<Map<String, String>>> entry : capturedEvents.entrySet())
+        {
+            try
+            {
+                final Class<?> registeredClass = Class.forName(entry.getKey());
+                if (registeredClass.isInstance(event))
+                {
+                    captureEventForList(event, entry.getValue());
+                }
+            }
+            catch (ClassNotFoundException ignored) {}
+        }
+    }
+
+    private void captureEventForList(Event event, List<Map<String, String>> targetList)
+    {
+        final Map<String, String> data = new ConcurrentHashMap<>();
+        for (final Method method : event.getClass().getMethods())
+        {
+            if (method.getParameterCount() == 0 &&
+                (method.getName().startsWith("get") || method.getName().startsWith("is")) &&
+                !method.getName().equals("getClass") &&
+                !method.getName().equals("getHandlers") &&
+                !method.getName().equals("getEventName"))
+            {
+                try
+                {
+                    final Object value = method.invoke(event);
+                    if (isPrintable(value))
+                        data.put(method.getName(), String.valueOf(value));
+                }
+                catch (Exception ignored) {}
+            }
+        }
+        targetList.add(data);
+    }
+
+    private boolean isPrintable(Object value)
+    {
+        if (value == null) return false;
+        final Class<?> clazz = value.getClass();
+        return clazz.isPrimitive() ||
+               value instanceof String ||
+               value instanceof Number ||
+               value instanceof Boolean ||
+               value instanceof java.util.UUID ||
+               clazz.isEnum();
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentMaterials.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentMaterials.java
@@ -1,0 +1,32 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import org.bukkit.Material;
+
+/**
+ * Material classification helpers shared by agent action handlers.
+ *
+ * <p>Centralises predicates that need to behave identically across handlers (e.g. {@link AgentMenuActions}
+ * and {@link AgentPlayerActions}). Avoids invoking {@link Material#isAir()} directly because that delegates
+ * through {@code Material.asBlockType()}, which forces initialisation of {@code org.bukkit.Registry} and
+ * makes the call hostile to unit tests that do not boot a Bukkit server.
+ */
+final class AgentMaterials
+{
+    private AgentMaterials()
+    {
+    }
+
+    /**
+     * Determines whether the given material represents any in-game air block.
+     *
+     * @param material
+     *     Material to classify; must not be {@code null}.
+     * @return
+     *     {@code true} when the material is {@link Material#AIR}, {@link Material#CAVE_AIR}, or
+     *     {@link Material#VOID_AIR}; {@code false} otherwise.
+     */
+    static boolean isAir(Material material)
+    {
+        return material == Material.AIR || material == Material.CAVE_AIR || material == Material.VOID_AIR;
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentMenuActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentMenuActions.java
@@ -91,7 +91,7 @@ final class AgentMenuActions
             for (int rawSlot = 0; rawSlot < view.countSlots(); ++rawSlot)
             {
                 final ItemStack item = view.getItem(rawSlot);
-                if (item == null || item.getType().isAir())
+                if (item == null || AgentMaterials.isAir(item.getType()))
                     continue;
 
                 final Map<String, @Nullable Object> itemData = new HashMap<>();

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlatformDetector.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlatformDetector.java
@@ -1,0 +1,95 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import org.bukkit.Bukkit;
+
+import java.util.Locale;
+
+/**
+ * Server platform detection utility.
+ *
+ * <p>Identifies whether the running server is Paper, Spigot/CraftBukkit, or an unknown platform
+ * using a combination of heuristic signals: Paper-specific class presence, Bukkit name, Bukkit
+ * version string, and the server implementation class name.
+ *
+ * <p>Example usage in an end-to-end test:
+ * <pre>{@code
+ *     String platform = framework.serverPlatform().name(); // "PAPER" | "SPIGOT" | "UNKNOWN"
+ * }</pre>
+ */
+final class AgentPlatformDetector
+{
+    private AgentPlatformDetector()
+    {
+    }
+
+    /**
+     * Detects the server platform from live Bukkit globals.
+     *
+     * @return
+     *     {@code "PAPER"}, {@code "SPIGOT"}, or {@code "UNKNOWN"}.
+     */
+    static String detect()
+    {
+        final ClassLoader serverClassLoader = Bukkit.getServer().getClass().getClassLoader();
+        return detect(
+            Bukkit.getName(),
+            Bukkit.getVersion(),
+            Bukkit.getServer().getClass().getName(),
+            isClassPresent("io.papermc.paper.ServerBuildInfo", serverClassLoader)
+        );
+    }
+
+    /**
+     * Classifies the server platform from its identifying attributes.
+     *
+     * <p>Paper is preferred over Spigot when the Paper build-info class is present on the server
+     * class loader, or when either the name or version string contains "paper". This is exposed as
+     * a package-private overload for unit testing without a live Bukkit server.
+     *
+     * @param bukkitName
+     *     Value of {@link org.bukkit.Bukkit#getName()}.
+     * @param bukkitVersion
+     *     Value of {@link org.bukkit.Bukkit#getVersion()}.
+     * @param serverClassName
+     *     Fully qualified class name of {@link org.bukkit.Bukkit#getServer()}.
+     * @param paperClassPresent
+     *     Whether {@code io.papermc.paper.ServerBuildInfo} is loadable from the server class loader.
+     * @return
+     *     {@code "PAPER"}, {@code "SPIGOT"}, or {@code "UNKNOWN"}.
+     */
+    static String detect(
+        String bukkitName,
+        String bukkitVersion,
+        String serverClassName,
+        boolean paperClassPresent)
+    {
+        if (paperClassPresent || containsIgnoreCase(bukkitName, "paper") || containsIgnoreCase(bukkitVersion, "paper"))
+            return "PAPER";
+        if (containsIgnoreCase(bukkitName, "spigot") ||
+            containsIgnoreCase(bukkitName, "craftbukkit") ||
+            containsIgnoreCase(bukkitVersion, "spigot") ||
+            containsIgnoreCase(serverClassName, "craftbukkit"))
+        {
+            return "SPIGOT";
+        }
+        return "UNKNOWN";
+    }
+
+    private static boolean isClassPresent(String className, ClassLoader classLoader)
+    {
+        try
+        {
+            Class.forName(className, false, classLoader);
+            return true;
+        }
+        catch (ClassNotFoundException exception)
+        {
+            return false;
+        }
+    }
+
+    private static boolean containsIgnoreCase(String value, String fragment)
+    {
+        return value.toLowerCase(Locale.ROOT).contains(fragment.toLowerCase(Locale.ROOT));
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -516,29 +516,4 @@ final class AgentPlayerActions
 
         return AgentResponses.successResponse(requestId, Map.of("cancelled", cancelled.toString()));
     }
-
-    private static List<Map<String, Object>> buildInventoryItems(ItemStack... contents)
-    {
-        final List<Map<String, Object>> items = new ArrayList<>();
-        for (int i = 0; i < contents.length; i++)
-        {
-            final ItemStack item = contents[i];
-            if (item == null || AgentMaterials.isAir(item.getType()))
-                continue;
-
-            final Map<String, Object> itemData = new HashMap<>();
-            itemData.put("slot", i);
-            itemData.put("materialKey", item.getType().getKey().toString());
-            final String displayName = item.getItemMeta() == null ? null : item.getItemMeta().getDisplayName();
-            itemData.put("displayName", displayName);
-            itemData.put(
-                "lore",
-                item.getItemMeta() == null
-                    ? List.of()
-                    : Objects.requireNonNullElse(item.getItemMeta().getLore(), List.of())
-            );
-            items.add(itemData);
-        }
-        return items;
-    }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -322,6 +322,32 @@ final class AgentPlayerActions
     }
 
     /**
+     * Handles {@code GET_PLAYER_CHAT_COMPONENTS} by draining adapter components and returning history.
+     *
+     * @param requestId
+     *     Runtime request identifier.
+     * @param arguments
+     *     Request arguments; requires {@code uuid}.
+     * @return
+     *     Success response with {@code componentsJson}.
+     * @throws Exception
+     *     Propagates parsing and main-thread execution failures.
+     */
+    AgentResponse handleGetPlayerChatComponents(String requestId, Map<String, String> arguments)
+        throws Exception
+    {
+        final UUID uuid = UUID.fromString(arguments.getOrDefault("uuid", ""));
+        final String componentsJson = mainThreadExecutor.callOnMainThread(() ->
+        {
+            playerStore.getRequiredPlayer(uuid);
+            playerStore.capturePlayerChatComponents(botPlayerNmsAdapter, uuid);
+            return objectMapper.writeValueAsString(playerStore.getPlayerChatComponents(uuid));
+        });
+
+        return AgentResponses.successResponse(requestId, Map.of("componentsJson", componentsJson));
+    }
+
+    /**
      * Handles {@code GET_PLAYER_INVENTORY} by returning a snapshot of the player's inventory.
      *
      * @param command

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -4,21 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
 import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
-import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEventsCommand;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.DropItemCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommandCommand;
-import nl.pim16aap2.lightkeeper.protocol.GetCapturedEventsCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventoryCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessagesCommand;
 import nl.pim16aap2.lightkeeper.protocol.LeftClickBlockCommand;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlockCommand;
-import nl.pim16aap2.lightkeeper.protocol.RegisterEventListenerCommand;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlockCommand;
 import nl.pim16aap2.lightkeeper.protocol.TeleportPlayerCommand;
-import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -366,7 +362,7 @@ final class AgentPlayerActions
         {
             final Player player = playerStore.getRequiredPlayer(uuid);
             final ItemStack item = player.getInventory().getItemInMainHand();
-            if (item == null || item.getType().isAir())
+            if (item == null || AgentMaterials.isAir(item.getType()))
                 return Boolean.FALSE;
 
             final org.bukkit.entity.Item droppedItem =
@@ -402,6 +398,15 @@ final class AgentPlayerActions
         final double y = command.y();
         final double z = command.z();
 
+        if (worldName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                "Argument 'worldName' must not be blank."
+            );
+        }
+
         final Boolean teleported = mainThreadExecutor.callOnMainThread(() ->
         {
             final Player player = playerStore.getRequiredPlayer(uuid);
@@ -412,74 +417,6 @@ final class AgentPlayerActions
         });
 
         return AgentResponses.successResponse(command.requestId(), Map.of("teleported", teleported.toString()));
-    }
-
-    /**
-     * Handles {@code REGISTER_EVENT_LISTENER} — not yet implemented in this split branch.
-     *
-     * @param command
-     *     Typed command carrying the event class name.
-     * @return
-     *     Error response indicating the action is not yet supported.
-     */
-    AgentResponse handleRegisterEventListener(RegisterEventListenerCommand command)
-    {
-        return AgentResponses.errorResponse(
-            command.requestId(),
-            AgentErrorCode.REQUEST_FAILED,
-            "REGISTER_EVENT_LISTENER is not yet implemented in this build."
-        );
-    }
-
-    /**
-     * Handles {@code GET_CAPTURED_EVENTS} — not yet implemented in this split branch.
-     *
-     * @param command
-     *     Typed command carrying the event class name.
-     * @return
-     *     Error response indicating the action is not yet supported.
-     */
-    AgentResponse handleGetCapturedEvents(GetCapturedEventsCommand command)
-    {
-        return AgentResponses.errorResponse(
-            command.requestId(),
-            AgentErrorCode.REQUEST_FAILED,
-            "GET_CAPTURED_EVENTS is not yet implemented in this build."
-        );
-    }
-
-    /**
-     * Handles {@code CLEAR_CAPTURED_EVENTS} — not yet implemented in this split branch.
-     *
-     * @param command
-     *     Typed command carrying the event class name.
-     * @return
-     *     Error response indicating the action is not yet supported.
-     */
-    AgentResponse handleClearCapturedEvents(ClearCapturedEventsCommand command)
-    {
-        return AgentResponses.errorResponse(
-            command.requestId(),
-            AgentErrorCode.REQUEST_FAILED,
-            "CLEAR_CAPTURED_EVENTS is not yet implemented in this build."
-        );
-    }
-
-    /**
-     * Handles {@code UNREGISTER_EVENT_LISTENER} — not yet implemented in this split branch.
-     *
-     * @param command
-     *     Typed command carrying the event class name.
-     * @return
-     *     Error response indicating the action is not yet supported.
-     */
-    AgentResponse handleUnregisterEventListener(UnregisterEventListenerCommand command)
-    {
-        return AgentResponses.errorResponse(
-            command.requestId(),
-            AgentErrorCode.REQUEST_FAILED,
-            "UNREGISTER_EVENT_LISTENER is not yet implemented in this build."
-        );
     }
 
     /**
@@ -557,7 +494,7 @@ final class AgentPlayerActions
         for (int i = 0; i < contents.length; i++)
         {
             final ItemStack item = contents[i];
-            if (item == null || item.getType().isAir())
+            if (item == null || AgentMaterials.isAir(item.getType()))
                 continue;
 
             final Map<String, Object> itemData = new HashMap<>();

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -315,36 +315,11 @@ final class AgentPlayerActions
         final String componentsJson = mainThreadExecutor.callOnMainThread(() ->
         {
             playerStore.getRequiredPlayer(uuid);
-            return objectMapper.writeValueAsString(List.of());
-        });
-
-        return AgentResponses.successResponse(command.requestId(), Map.of("componentsJson", componentsJson));
-    }
-
-    /**
-     * Handles {@code GET_PLAYER_CHAT_COMPONENTS} by draining adapter components and returning history.
-     *
-     * @param requestId
-     *     Runtime request identifier.
-     * @param arguments
-     *     Request arguments; requires {@code uuid}.
-     * @return
-     *     Success response with {@code componentsJson}.
-     * @throws Exception
-     *     Propagates parsing and main-thread execution failures.
-     */
-    AgentResponse handleGetPlayerChatComponents(String requestId, Map<String, String> arguments)
-        throws Exception
-    {
-        final UUID uuid = UUID.fromString(arguments.getOrDefault("uuid", ""));
-        final String componentsJson = mainThreadExecutor.callOnMainThread(() ->
-        {
-            playerStore.getRequiredPlayer(uuid);
             playerStore.capturePlayerChatComponents(botPlayerNmsAdapter, uuid);
             return objectMapper.writeValueAsString(playerStore.getPlayerChatComponents(uuid));
         });
 
-        return AgentResponses.successResponse(requestId, Map.of("componentsJson", componentsJson));
+        return AgentResponses.successResponse(command.requestId(), Map.of("componentsJson", componentsJson));
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -345,6 +345,31 @@ final class AgentPlayerActions
         return AgentResponses.successResponse(command.requestId(), Map.of("inventoryJson", inventoryJson));
     }
 
+    private static List<Map<String, Object>> buildInventoryItems(ItemStack... contents)
+    {
+        final List<Map<String, Object>> items = new ArrayList<>();
+        for (int i = 0; i < contents.length; i++)
+        {
+            final ItemStack item = contents[i];
+            if (item == null || AgentMaterials.isAir(item.getType()))
+                continue;
+
+            final Map<String, Object> itemData = new HashMap<>();
+            itemData.put("slot", i);
+            itemData.put("materialKey", item.getType().getKey().toString());
+            final String displayName = item.getItemMeta() == null ? null : item.getItemMeta().getDisplayName();
+            itemData.put("displayName", displayName);
+            itemData.put(
+                "lore",
+                item.getItemMeta() == null
+                    ? List.of()
+                    : Objects.requireNonNullElse(item.getItemMeta().getLore(), List.of())
+            );
+            items.add(itemData);
+        }
+        return items;
+    }
+
     /**
      * Handles {@code DROP_ITEM} by simulating the player dropping their main hand item.
      *
@@ -366,6 +391,9 @@ final class AgentPlayerActions
             if (item == null || AgentMaterials.isAir(item.getType()))
                 return Boolean.FALSE;
 
+            // Bukkit's PlayerDropItemEvent requires a pre-existing Item entity, so the entity is created
+            // unconditionally and removed afterwards. The response reflects whether a plugin *would* have
+            // allowed the drop (i.e., the event was not cancelled).
             final org.bukkit.entity.Item droppedItem =
                 player.getWorld().dropItemNaturally(player.getLocation(), item.clone());
             final org.bukkit.event.player.PlayerDropItemEvent event =

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -67,7 +67,7 @@ final class AgentRequestDispatcher
     /**
      * Handler for dynamic Bukkit event capture.
      */
-    private final AgentEventCapture eventCapture;
+    private final AgentEventActions eventActions;
     /**
      * Plugin logger used for operational diagnostics.
      */
@@ -95,8 +95,8 @@ final class AgentRequestDispatcher
      *     Player action handler.
      * @param menuActions
      *     Menu action handler.
-     * @param eventCapture
-     *     Event capture handler.
+     * @param eventActions
+     *     Event capture action handler.
      * @param logger
      *     Logger for request and error diagnostics.
      * @param authToken
@@ -111,7 +111,7 @@ final class AgentRequestDispatcher
         AgentWorldActions worldActions,
         AgentPlayerActions playerActions,
         AgentMenuActions menuActions,
-        AgentEventCapture eventCapture,
+        AgentEventActions eventActions,
         java.util.logging.Logger logger,
         String authToken,
         int protocolVersion,
@@ -121,7 +121,7 @@ final class AgentRequestDispatcher
         this.worldActions = Objects.requireNonNull(worldActions, "worldActions");
         this.playerActions = Objects.requireNonNull(playerActions, "playerActions");
         this.menuActions = Objects.requireNonNull(menuActions, "menuActions");
-        this.eventCapture = Objects.requireNonNull(eventCapture, "eventCapture");
+        this.eventActions = Objects.requireNonNull(eventActions, "eventActions");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.authToken = Objects.requireNonNull(authToken, "authToken");
         this.protocolVersion = protocolVersion;
@@ -226,10 +226,10 @@ final class AgentRequestDispatcher
                 case IsChunkLoadedCommand c -> worldActions.handleIsChunkLoaded(c);
                 case GetPlayerInventoryCommand c -> playerActions.handleGetPlayerInventory(c);
                 case DropItemCommand c -> playerActions.handleDropItem(c);
-                case RegisterEventListenerCommand c -> handleRegisterEventListener(c);
-                case GetCapturedEventsCommand c -> handleGetCapturedEvents(c);
-                case ClearCapturedEventsCommand c -> handleClearCapturedEvents(c);
-                case UnregisterEventListenerCommand c -> handleUnregisterEventListener(c);
+                case RegisterEventListenerCommand c -> eventActions.handleRegisterEventListener(c);
+                case GetCapturedEventsCommand c -> eventActions.handleGetCapturedEvents(c);
+                case ClearCapturedEventsCommand c -> eventActions.handleClearCapturedEvents(c);
+                case UnregisterEventListenerCommand c -> eventActions.handleUnregisterEventListener(c);
                 case GetPlayerChatComponentsCommand c -> playerActions.handleGetPlayerChatComponents(c);
                 case GetServerPlatformCommand c -> worldActions.handleGetServerPlatform(c);
                 case HandshakeCommand ignored ->
@@ -269,71 +269,6 @@ final class AgentRequestDispatcher
                 handshakeCompleted
             );
         }
-    }
-
-    private AgentResponse handleRegisterEventListener(RegisterEventListenerCommand command)
-        throws Exception
-    {
-        final String eventClassName = command.eventClassName();
-        if (eventClassName == null || eventClassName.isBlank())
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                "eventClassName may not be blank."
-            );
-        }
-        try
-        {
-            eventCapture.registerListener(eventClassName);
-            return AgentResponses.successResponse(command.requestId(), Map.of());
-        }
-        catch (ClassNotFoundException exception)
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                "Event class not found: " + eventClassName
-            );
-        }
-        catch (IllegalArgumentException exception)
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                exception.getMessage() == null ? "Invalid event class." : exception.getMessage()
-            );
-        }
-    }
-
-    private AgentResponse handleGetCapturedEvents(GetCapturedEventsCommand command)
-        throws Exception
-    {
-        final String eventClassName = command.eventClassName();
-        if (eventClassName == null || eventClassName.isBlank())
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                "eventClassName may not be blank."
-            );
-        }
-        final java.util.List<java.util.Map<String, String>> events = eventCapture.getCapturedEvents(eventClassName);
-        final String eventsJson = objectMapper.writeValueAsString(events);
-        return AgentResponses.successResponse(command.requestId(), Map.of("eventsJson", eventsJson));
-    }
-
-    private AgentResponse handleClearCapturedEvents(ClearCapturedEventsCommand command)
-    {
-        eventCapture.clearCapturedEvents(command.eventClassName());
-        return AgentResponses.successResponse(command.requestId(), Map.of());
-    }
-
-    private AgentResponse handleUnregisterEventListener(UnregisterEventListenerCommand command)
-        throws Exception
-    {
-        eventCapture.unregisterListener(command.eventClassName());
-        return AgentResponses.successResponse(command.requestId(), Map.of());
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -65,6 +65,10 @@ final class AgentRequestDispatcher
      */
     private final AgentMenuActions menuActions;
     /**
+     * Handler for dynamic Bukkit event capture.
+     */
+    private final AgentEventCapture eventCapture;
+    /**
      * Plugin logger used for operational diagnostics.
      */
     private final java.util.logging.Logger logger;
@@ -91,6 +95,8 @@ final class AgentRequestDispatcher
      *     Player action handler.
      * @param menuActions
      *     Menu action handler.
+     * @param eventCapture
+     *     Event capture handler.
      * @param logger
      *     Logger for request and error diagnostics.
      * @param authToken
@@ -105,6 +111,7 @@ final class AgentRequestDispatcher
         AgentWorldActions worldActions,
         AgentPlayerActions playerActions,
         AgentMenuActions menuActions,
+        AgentEventCapture eventCapture,
         java.util.logging.Logger logger,
         String authToken,
         int protocolVersion,
@@ -114,6 +121,7 @@ final class AgentRequestDispatcher
         this.worldActions = Objects.requireNonNull(worldActions, "worldActions");
         this.playerActions = Objects.requireNonNull(playerActions, "playerActions");
         this.menuActions = Objects.requireNonNull(menuActions, "menuActions");
+        this.eventCapture = Objects.requireNonNull(eventCapture, "eventCapture");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.authToken = Objects.requireNonNull(authToken, "authToken");
         this.protocolVersion = protocolVersion;
@@ -218,10 +226,10 @@ final class AgentRequestDispatcher
                 case IsChunkLoadedCommand c -> worldActions.handleIsChunkLoaded(c);
                 case GetPlayerInventoryCommand c -> playerActions.handleGetPlayerInventory(c);
                 case DropItemCommand c -> playerActions.handleDropItem(c);
-                case RegisterEventListenerCommand c -> playerActions.handleRegisterEventListener(c);
-                case GetCapturedEventsCommand c -> playerActions.handleGetCapturedEvents(c);
-                case ClearCapturedEventsCommand c -> playerActions.handleClearCapturedEvents(c);
-                case UnregisterEventListenerCommand c -> playerActions.handleUnregisterEventListener(c);
+                case RegisterEventListenerCommand c -> handleRegisterEventListener(c);
+                case GetCapturedEventsCommand c -> handleGetCapturedEvents(c);
+                case ClearCapturedEventsCommand c -> handleClearCapturedEvents(c);
+                case UnregisterEventListenerCommand c -> handleUnregisterEventListener(c);
                 case GetPlayerChatComponentsCommand c -> playerActions.handleGetPlayerChatComponents(c);
                 case GetServerPlatformCommand c -> worldActions.handleGetServerPlatform(c);
                 case HandshakeCommand ignored ->
@@ -250,6 +258,55 @@ final class AgentRequestDispatcher
                 handshakeCompleted
             );
         }
+    }
+
+    private AgentResponse handleRegisterEventListener(RegisterEventListenerCommand command)
+        throws Exception
+    {
+        final String eventClassName = command.eventClassName();
+        try
+        {
+            eventCapture.registerListener(eventClassName);
+            return AgentResponses.successResponse(command.requestId(), Map.of());
+        }
+        catch (ClassNotFoundException exception)
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                "Event class not found: " + eventClassName
+            );
+        }
+        catch (IllegalArgumentException exception)
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                exception.getMessage() == null ? "Invalid event class." : exception.getMessage()
+            );
+        }
+    }
+
+    private AgentResponse handleGetCapturedEvents(GetCapturedEventsCommand command)
+        throws Exception
+    {
+        final String eventClassName = command.eventClassName();
+        final java.util.List<java.util.Map<String, String>> events = eventCapture.getCapturedEvents(eventClassName);
+        final String eventsJson = objectMapper.writeValueAsString(events);
+        return AgentResponses.successResponse(command.requestId(), Map.of("eventsJson", eventsJson));
+    }
+
+    private AgentResponse handleClearCapturedEvents(ClearCapturedEventsCommand command)
+    {
+        eventCapture.clearCapturedEvents(command.eventClassName());
+        return AgentResponses.successResponse(command.requestId(), Map.of());
+    }
+
+    private AgentResponse handleUnregisterEventListener(UnregisterEventListenerCommand command)
+        throws Exception
+    {
+        eventCapture.unregisterListener(command.eventClassName());
+        return AgentResponses.successResponse(command.requestId(), Map.of());
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -236,6 +236,17 @@ final class AgentRequestDispatcher
                     throw new IllegalStateException("Unreachable HANDSHAKE dispatch branch.");
             }, true);
         }
+        catch (IllegalArgumentException exception)
+        {
+            return new RequestDispatchResult(
+                AgentResponses.errorResponse(
+                    requestId,
+                    AgentErrorCode.INVALID_ARGUMENT,
+                    Objects.requireNonNullElse(exception.getMessage(), exception.getClass().getName())
+                ),
+                handshakeCompleted
+            );
+        }
         catch (Exception exception)
         {
             logger.log(
@@ -264,6 +275,14 @@ final class AgentRequestDispatcher
         throws Exception
     {
         final String eventClassName = command.eventClassName();
+        if (eventClassName == null || eventClassName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                "eventClassName may not be blank."
+            );
+        }
         try
         {
             eventCapture.registerListener(eventClassName);
@@ -291,6 +310,14 @@ final class AgentRequestDispatcher
         throws Exception
     {
         final String eventClassName = command.eventClassName();
+        if (eventClassName == null || eventClassName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                "eventClassName may not be blank."
+            );
+        }
         final java.util.List<java.util.Map<String, String>> events = eventCapture.getCapturedEvents(eventClassName);
         final String eventsJson = objectMapper.writeValueAsString(events);
         return AgentResponses.successResponse(command.requestId(), Map.of("eventsJson", eventsJson));

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -69,6 +69,28 @@ final class AgentRequestDispatcher
      */
     private final AgentEventActions eventActions;
     /**
+     * Immutable configuration block for the dispatcher.
+     *
+     * @param authToken
+     *     Expected handshake token.
+     * @param protocolVersion
+     *     Expected runtime protocol version.
+     * @param expectedAgentSha256
+     *     Optional expected agent artifact SHA-256 hash; blank disables the check.
+     * @param logger
+     *     Logger for request and error diagnostics.
+     */
+    record Config(String authToken, int protocolVersion, String expectedAgentSha256, java.util.logging.Logger logger)
+    {
+        Config
+        {
+            Objects.requireNonNull(authToken, "authToken");
+            Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
+            Objects.requireNonNull(logger, "logger");
+        }
+    }
+
+    /**
      * Plugin logger used for operational diagnostics.
      */
     private final java.util.logging.Logger logger;
@@ -97,14 +119,8 @@ final class AgentRequestDispatcher
      *     Menu action handler.
      * @param eventActions
      *     Event capture action handler.
-     * @param logger
-     *     Logger for request and error diagnostics.
-     * @param authToken
-     *     Expected handshake token.
-     * @param protocolVersion
-     *     Expected protocol version.
-     * @param expectedAgentSha256
-     *     Optional expected agent artifact hash.
+     * @param config
+     *     Immutable dispatcher configuration (auth, protocol, SHA, logger).
      */
     AgentRequestDispatcher(
         ObjectMapper objectMapper,
@@ -112,20 +128,18 @@ final class AgentRequestDispatcher
         AgentPlayerActions playerActions,
         AgentMenuActions menuActions,
         AgentEventActions eventActions,
-        java.util.logging.Logger logger,
-        String authToken,
-        int protocolVersion,
-        String expectedAgentSha256)
+        Config config)
     {
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
         this.worldActions = Objects.requireNonNull(worldActions, "worldActions");
         this.playerActions = Objects.requireNonNull(playerActions, "playerActions");
         this.menuActions = Objects.requireNonNull(menuActions, "menuActions");
         this.eventActions = Objects.requireNonNull(eventActions, "eventActions");
-        this.logger = Objects.requireNonNull(logger, "logger");
-        this.authToken = Objects.requireNonNull(authToken, "authToken");
-        this.protocolVersion = protocolVersion;
-        this.expectedAgentSha256 = Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
+        Objects.requireNonNull(config, "config");
+        this.logger = config.logger();
+        this.authToken = config.authToken();
+        this.protocolVersion = config.protocolVersion();
+        this.expectedAgentSha256 = config.expectedAgentSha256();
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -68,27 +68,6 @@ final class AgentRequestDispatcher
      * Handler for dynamic Bukkit event capture.
      */
     private final AgentEventActions eventActions;
-    /**
-     * Immutable configuration block for the dispatcher.
-     *
-     * @param authToken
-     *     Expected handshake token.
-     * @param protocolVersion
-     *     Expected runtime protocol version.
-     * @param expectedAgentSha256
-     *     Optional expected agent artifact SHA-256 hash; blank disables the check.
-     * @param logger
-     *     Logger for request and error diagnostics.
-     */
-    record Config(String authToken, int protocolVersion, String expectedAgentSha256, java.util.logging.Logger logger)
-    {
-        Config
-        {
-            Objects.requireNonNull(authToken, "authToken");
-            Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
-            Objects.requireNonNull(logger, "logger");
-        }
-    }
 
     /**
      * Plugin logger used for operational diagnostics.
@@ -340,5 +319,27 @@ final class AgentRequestDispatcher
      */
     record RequestDispatchResult(AgentResponse response, boolean handshakeCompleted)
     {
+    }
+
+    /**
+     * Immutable configuration block for the dispatcher.
+     *
+     * @param authToken
+     *     Expected handshake token.
+     * @param protocolVersion
+     *     Expected runtime protocol version.
+     * @param expectedAgentSha256
+     *     Optional expected agent artifact SHA-256 hash; blank disables the check.
+     * @param logger
+     *     Logger for request and error diagnostics.
+     */
+    record Config(String authToken, int protocolVersion, String expectedAgentSha256, java.util.logging.Logger logger)
+    {
+        Config
+        {
+            Objects.requireNonNull(authToken, "authToken");
+            Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
+            Objects.requireNonNull(logger, "logger");
+        }
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
@@ -218,19 +218,19 @@ final class AgentSyntheticPlayerStore
         /**
          * Live Bukkit player instance.
          */
-        final Player player;
+        private final Player player;
         /**
          * Permission attachment, or {@code null} when no permissions have been assigned.
          */
-        @Nullable PermissionAttachment permissionAttachment;
+        @Nullable private PermissionAttachment permissionAttachment;
         /**
          * Accumulated plain-text message history (direct sends + NMS adapter drains).
          */
-        final List<String> messageHistory = new CopyOnWriteArrayList<>();
+        private final List<String> messageHistory = new CopyOnWriteArrayList<>();
         /**
          * Accumulated chat-component JSON history.
          */
-        final List<String> componentHistory = new CopyOnWriteArrayList<>();
+        private final List<String> componentHistory = new CopyOnWriteArrayList<>();
 
         private SyntheticPlayerState(Player player)
         {

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
@@ -4,6 +4,7 @@ import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,31 +16,17 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * Thread-safe registry for synthetic players and related per-player state.
  *
- * <p>The store tracks:
- * <ul>
- *   <li>Registered synthetic player instances by UUID.</li>
- *   <li>Permission attachments created for those players.</li>
- *   <li>Message history merged from direct sends and NMS adapter drains.</li>
- * </ul>
+ * <p>All per-player state (player instance, permission attachment, message history, chat component
+ * history) is colocated in a single {@link SyntheticPlayerState} entry so lifecycle operations always
+ * touch a consistent, atomic view. There is no risk of one of several parallel maps being updated
+ * while another is not.
  */
 final class AgentSyntheticPlayerStore
 {
     /**
-     * Synthetic players registered by protocol UUID.
+     * All per-player state keyed by protocol UUID.
      */
-    private final ConcurrentHashMap<UUID, Player> syntheticPlayers = new ConcurrentHashMap<>();
-    /**
-     * Permission attachments associated with synthetic players.
-     */
-    private final ConcurrentHashMap<UUID, PermissionAttachment> permissionAttachments = new ConcurrentHashMap<>();
-    /**
-     * Aggregated player message history by synthetic player UUID.
-     */
-    private final ConcurrentHashMap<UUID, List<String>> playerMessageHistory = new ConcurrentHashMap<>();
-    /**
-     * Aggregated player chat component history by synthetic player UUID.
-     */
-    private final ConcurrentHashMap<UUID, List<String>> playerChatComponentHistory = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, SyntheticPlayerState> players = new ConcurrentHashMap<>();
 
     /**
      * Resolves a registered synthetic player.
@@ -53,10 +40,10 @@ final class AgentSyntheticPlayerStore
      */
     Player getRequiredPlayer(UUID uuid)
     {
-        final Player player = syntheticPlayers.get(uuid);
-        if (player == null)
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state == null)
             throw new IllegalArgumentException("Synthetic player '%s' is not registered.".formatted(uuid));
-        return player;
+        return state.player;
     }
 
     /**
@@ -69,9 +56,7 @@ final class AgentSyntheticPlayerStore
      */
     void registerSyntheticPlayer(UUID uuid, Player player)
     {
-        syntheticPlayers.put(uuid, player);
-        playerMessageHistory.put(uuid, new CopyOnWriteArrayList<>());
-        playerChatComponentHistory.put(uuid, new CopyOnWriteArrayList<>());
+        players.put(uuid, new SyntheticPlayerState(player));
     }
 
     /**
@@ -93,7 +78,10 @@ final class AgentSyntheticPlayerStore
             .map(String::trim)
             .filter(permission -> !permission.isEmpty())
             .forEach(permission -> attachment.setPermission(permission, true));
-        permissionAttachments.put(uuid, attachment);
+
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.permissionAttachment = attachment;
     }
 
     /**
@@ -106,22 +94,26 @@ final class AgentSyntheticPlayerStore
      */
     void removePermissionAttachment(UUID uuid, Player player)
     {
-        final PermissionAttachment attachment = permissionAttachments.remove(uuid);
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state == null)
+            return;
+        final PermissionAttachment attachment = state.permissionAttachment;
         if (attachment != null)
+        {
             player.removeAttachment(attachment);
+            state.permissionAttachment = null;
+        }
     }
 
     /**
-     * Removes a synthetic player and all associated message tracking state.
+     * Removes a synthetic player and all associated state.
      *
      * @param uuid
      *     Synthetic player UUID.
      */
     void removeSyntheticPlayer(UUID uuid)
     {
-        playerMessageHistory.remove(uuid);
-        playerChatComponentHistory.remove(uuid);
-        syntheticPlayers.remove(uuid);
+        players.remove(uuid);
     }
 
     /**
@@ -132,7 +124,7 @@ final class AgentSyntheticPlayerStore
      */
     Set<UUID> syntheticPlayerIds()
     {
-        return Set.copyOf(syntheticPlayers.keySet());
+        return Set.copyOf(players.keySet());
     }
 
     /**
@@ -146,9 +138,9 @@ final class AgentSyntheticPlayerStore
     void sendTrackedMessage(Player player, String message)
     {
         player.sendMessage(message);
-        playerMessageHistory
-            .computeIfAbsent(player.getUniqueId(), ignored -> new CopyOnWriteArrayList<>())
-            .add(message);
+        final SyntheticPlayerState state = players.get(player.getUniqueId());
+        if (state != null)
+            state.messageHistory.add(message);
     }
 
     /**
@@ -165,9 +157,9 @@ final class AgentSyntheticPlayerStore
         if (drainedMessages.isEmpty())
             return;
 
-        playerMessageHistory
-            .computeIfAbsent(uuid, ignored -> new CopyOnWriteArrayList<>())
-            .addAll(drainedMessages);
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.messageHistory.addAll(drainedMessages);
     }
 
     /**
@@ -184,9 +176,9 @@ final class AgentSyntheticPlayerStore
         if (drainedComponents.isEmpty())
             return;
 
-        playerChatComponentHistory
-            .computeIfAbsent(uuid, ignored -> new CopyOnWriteArrayList<>())
-            .addAll(drainedComponents);
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.componentHistory.addAll(drainedComponents);
     }
 
     /**
@@ -195,11 +187,12 @@ final class AgentSyntheticPlayerStore
      * @param uuid
      *     Synthetic player UUID.
      * @return
-     *     Immutable empty list when unknown; otherwise tracked history list.
+     *     Immutable empty list when unknown; otherwise the tracked history list.
      */
     List<String> getPlayerMessages(UUID uuid)
     {
-        return playerMessageHistory.getOrDefault(uuid, List.of());
+        final SyntheticPlayerState state = players.get(uuid);
+        return state != null ? state.messageHistory : List.of();
     }
 
     /**
@@ -208,10 +201,40 @@ final class AgentSyntheticPlayerStore
      * @param uuid
      *     Synthetic player UUID.
      * @return
-     *     Immutable empty list when unknown; otherwise tracked history list.
+     *     Immutable empty list when unknown; otherwise the tracked history list.
      */
     List<String> getPlayerChatComponents(UUID uuid)
     {
-        return playerChatComponentHistory.getOrDefault(uuid, List.of());
+        final SyntheticPlayerState state = players.get(uuid);
+        return state != null ? state.componentHistory : List.of();
+    }
+
+    /**
+     * Per-player state colocating all mutable fields so lifecycle operations always touch a consistent
+     * view.
+     */
+    private static final class SyntheticPlayerState
+    {
+        /**
+         * Live Bukkit player instance.
+         */
+        final Player player;
+        /**
+         * Permission attachment, or {@code null} when no permissions have been assigned.
+         */
+        @Nullable PermissionAttachment permissionAttachment;
+        /**
+         * Accumulated plain-text message history (direct sends + NMS adapter drains).
+         */
+        final List<String> messageHistory = new CopyOnWriteArrayList<>();
+        /**
+         * Accumulated chat-component JSON history.
+         */
+        final List<String> componentHistory = new CopyOnWriteArrayList<>();
+
+        private SyntheticPlayerState(Player player)
+        {
+            this.player = player;
+        }
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
@@ -36,6 +36,10 @@ final class AgentSyntheticPlayerStore
      * Aggregated player message history by synthetic player UUID.
      */
     private final ConcurrentHashMap<UUID, List<String>> playerMessageHistory = new ConcurrentHashMap<>();
+    /**
+     * Aggregated player chat component history by synthetic player UUID.
+     */
+    private final ConcurrentHashMap<UUID, List<String>> playerChatComponentHistory = new ConcurrentHashMap<>();
 
     /**
      * Resolves a registered synthetic player.
@@ -67,6 +71,7 @@ final class AgentSyntheticPlayerStore
     {
         syntheticPlayers.put(uuid, player);
         playerMessageHistory.put(uuid, new CopyOnWriteArrayList<>());
+        playerChatComponentHistory.put(uuid, new CopyOnWriteArrayList<>());
     }
 
     /**
@@ -115,6 +120,7 @@ final class AgentSyntheticPlayerStore
     void removeSyntheticPlayer(UUID uuid)
     {
         playerMessageHistory.remove(uuid);
+        playerChatComponentHistory.remove(uuid);
         syntheticPlayers.remove(uuid);
     }
 
@@ -165,6 +171,25 @@ final class AgentSyntheticPlayerStore
     }
 
     /**
+     * Drains newly received adapter chat components and appends them to tracked history.
+     *
+     * @param nmsAdapter
+     *     Adapter used to drain NMS-level captured messages.
+     * @param uuid
+     *     Synthetic player UUID.
+     */
+    void capturePlayerChatComponents(IBotPlayerNmsAdapter nmsAdapter, UUID uuid)
+    {
+        final List<String> drainedComponents = nmsAdapter.drainChatComponents(uuid);
+        if (drainedComponents.isEmpty())
+            return;
+
+        playerChatComponentHistory
+            .computeIfAbsent(uuid, ignored -> new CopyOnWriteArrayList<>())
+            .addAll(drainedComponents);
+    }
+
+    /**
      * Returns tracked message history for the given synthetic player.
      *
      * @param uuid
@@ -175,5 +200,18 @@ final class AgentSyntheticPlayerStore
     List<String> getPlayerMessages(UUID uuid)
     {
         return playerMessageHistory.getOrDefault(uuid, List.of());
+    }
+
+    /**
+     * Returns tracked chat component history for the given synthetic player.
+     *
+     * @param uuid
+     *     Synthetic player UUID.
+     * @return
+     *     Immutable empty list when unknown; otherwise tracked history list.
+     */
+    List<String> getPlayerChatComponents(UUID uuid)
+    {
+        return playerChatComponentHistory.getOrDefault(uuid, List.of());
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -188,91 +188,6 @@ final class AgentWorldActions
     }
 
     /**
-     * Handles {@code LOAD_CHUNK} by force-loading the chunk at the given chunk coordinates.
-     *
-     * @param command
-     *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Success response, or error if the world does not exist.
-     * @throws Exception
-     *     Propagates main-thread execution failures.
-     */
-    AgentResponse handleLoadChunk(LoadChunkCommand command)
-        throws Exception
-    {
-        final String worldName = command.worldName();
-        final int x = command.x();
-        final int z = command.z();
-
-        mainThreadExecutor.callOnMainThread(() ->
-        {
-            final World world = Bukkit.getWorld(worldName);
-            if (world == null)
-                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            world.loadChunk(x, z, true);
-            return Boolean.TRUE;
-        });
-
-        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", "true"));
-    }
-
-    /**
-     * Handles {@code UNLOAD_CHUNK} by unloading the chunk at the given chunk coordinates.
-     *
-     * @param command
-     *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Success response, or error if the world does not exist.
-     * @throws Exception
-     *     Propagates main-thread execution failures.
-     */
-    AgentResponse handleUnloadChunk(UnloadChunkCommand command)
-        throws Exception
-    {
-        final String worldName = command.worldName();
-        final int x = command.x();
-        final int z = command.z();
-
-        final Boolean unloaded = mainThreadExecutor.callOnMainThread(() ->
-        {
-            final World world = Bukkit.getWorld(worldName);
-            if (world == null)
-                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            return world.unloadChunk(x, z);
-        });
-
-        return AgentResponses.successResponse(command.requestId(), Map.of("unloaded", unloaded.toString()));
-    }
-
-    /**
-     * Handles {@code IS_CHUNK_LOADED} by querying whether the chunk is currently loaded.
-     *
-     * @param command
-     *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Success response with {@code loaded} boolean, or error if the world does not exist.
-     * @throws Exception
-     *     Propagates main-thread execution failures.
-     */
-    AgentResponse handleIsChunkLoaded(IsChunkLoadedCommand command)
-        throws Exception
-    {
-        final String worldName = command.worldName();
-        final int x = command.x();
-        final int z = command.z();
-
-        final Boolean loaded = mainThreadExecutor.callOnMainThread(() ->
-        {
-            final World world = Bukkit.getWorld(worldName);
-            if (world == null)
-                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            return world.isChunkLoaded(x, z);
-        });
-
-        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", loaded.toString()));
-    }
-
-    /**
      * Handles {@code SET_BLOCK} by setting a block to the requested material.
      *
      * @param command
@@ -381,6 +296,91 @@ final class AgentWorldActions
     AgentResponse handleGetServerTick(GetServerTickCommand command)
     {
         return AgentResponses.successResponse(command.requestId(), Map.of("tick", Long.toString(tickCounter.get())));
+    }
+
+    /**
+     * Handles {@code LOAD_CHUNK} by force-loading the chunk at the given chunk coordinates.
+     *
+     * @param command
+     *     Typed command carrying world name and chunk coordinates.
+     * @return
+     *     Success response, or error if the world does not exist.
+     * @throws Exception
+     *     Propagates main-thread execution failures.
+     */
+    AgentResponse handleLoadChunk(LoadChunkCommand command)
+        throws Exception
+    {
+        final String worldName = command.worldName();
+        final int x = command.x();
+        final int z = command.z();
+
+        mainThreadExecutor.callOnMainThread(() ->
+        {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null)
+                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
+            world.loadChunk(x, z, true);
+            return Boolean.TRUE;
+        });
+
+        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", "true"));
+    }
+
+    /**
+     * Handles {@code UNLOAD_CHUNK} by unloading the chunk at the given chunk coordinates.
+     *
+     * @param command
+     *     Typed command carrying world name and chunk coordinates.
+     * @return
+     *     Success response, or error if the world does not exist.
+     * @throws Exception
+     *     Propagates main-thread execution failures.
+     */
+    AgentResponse handleUnloadChunk(UnloadChunkCommand command)
+        throws Exception
+    {
+        final String worldName = command.worldName();
+        final int x = command.x();
+        final int z = command.z();
+
+        final Boolean unloaded = mainThreadExecutor.callOnMainThread(() ->
+        {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null)
+                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
+            return world.unloadChunk(x, z);
+        });
+
+        return AgentResponses.successResponse(command.requestId(), Map.of("unloaded", unloaded.toString()));
+    }
+
+    /**
+     * Handles {@code IS_CHUNK_LOADED} by querying whether the chunk is currently loaded.
+     *
+     * @param command
+     *     Typed command carrying world name and chunk coordinates.
+     * @return
+     *     Success response with {@code loaded} boolean, or error if the world does not exist.
+     * @throws Exception
+     *     Propagates main-thread execution failures.
+     */
+    AgentResponse handleIsChunkLoaded(IsChunkLoadedCommand command)
+        throws Exception
+    {
+        final String worldName = command.worldName();
+        final int x = command.x();
+        final int z = command.z();
+
+        final Boolean loaded = mainThreadExecutor.callOnMainThread(() ->
+        {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null)
+                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
+            return world.isChunkLoaded(x, z);
+        });
+
+        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", loaded.toString()));
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -188,6 +188,91 @@ final class AgentWorldActions
     }
 
     /**
+     * Handles {@code LOAD_CHUNK} by force-loading the chunk at the given chunk coordinates.
+     *
+     * @param command
+     *     Typed command carrying world name and chunk coordinates.
+     * @return
+     *     Success response, or error if the world does not exist.
+     * @throws Exception
+     *     Propagates main-thread execution failures.
+     */
+    AgentResponse handleLoadChunk(LoadChunkCommand command)
+        throws Exception
+    {
+        final String worldName = command.worldName();
+        final int x = command.x();
+        final int z = command.z();
+
+        mainThreadExecutor.callOnMainThread(() ->
+        {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null)
+                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
+            world.loadChunk(x, z, true);
+            return Boolean.TRUE;
+        });
+
+        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", "true"));
+    }
+
+    /**
+     * Handles {@code UNLOAD_CHUNK} by unloading the chunk at the given chunk coordinates.
+     *
+     * @param command
+     *     Typed command carrying world name and chunk coordinates.
+     * @return
+     *     Success response, or error if the world does not exist.
+     * @throws Exception
+     *     Propagates main-thread execution failures.
+     */
+    AgentResponse handleUnloadChunk(UnloadChunkCommand command)
+        throws Exception
+    {
+        final String worldName = command.worldName();
+        final int x = command.x();
+        final int z = command.z();
+
+        final Boolean unloaded = mainThreadExecutor.callOnMainThread(() ->
+        {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null)
+                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
+            return world.unloadChunk(x, z);
+        });
+
+        return AgentResponses.successResponse(command.requestId(), Map.of("unloaded", unloaded.toString()));
+    }
+
+    /**
+     * Handles {@code IS_CHUNK_LOADED} by querying whether the chunk is currently loaded.
+     *
+     * @param command
+     *     Typed command carrying world name and chunk coordinates.
+     * @return
+     *     Success response with {@code loaded} boolean, or error if the world does not exist.
+     * @throws Exception
+     *     Propagates main-thread execution failures.
+     */
+    AgentResponse handleIsChunkLoaded(IsChunkLoadedCommand command)
+        throws Exception
+    {
+        final String worldName = command.worldName();
+        final int x = command.x();
+        final int z = command.z();
+
+        final Boolean loaded = mainThreadExecutor.callOnMainThread(() ->
+        {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null)
+                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
+            return world.isChunkLoaded(x, z);
+        });
+
+        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", loaded.toString()));
+    }
+
+    /**
      * Handles {@code SET_BLOCK} by setting a block to the requested material.
      *
      * @param command

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -299,12 +299,12 @@ final class AgentWorldActions
     }
 
     /**
-     * Handles {@code LOAD_CHUNK} by force-loading the chunk at the given chunk coordinates.
+     * Handles {@code LOAD_CHUNK} by loading (and generating if absent) the chunk at the given chunk coordinates.
      *
      * @param command
      *     Typed command carrying world name and chunk coordinates.
      * @return
-     *     Success response, or error if the world does not exist.
+     *     Success response with {@code loaded} boolean, or error if the world does not exist.
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -315,16 +315,15 @@ final class AgentWorldActions
         final int x = command.x();
         final int z = command.z();
 
-        mainThreadExecutor.callOnMainThread(() ->
+        final Boolean loaded = mainThreadExecutor.callOnMainThread(() ->
         {
             final World world = Bukkit.getWorld(worldName);
             if (world == null)
                 throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            world.loadChunk(x, z, true);
-            return Boolean.TRUE;
+            return world.loadChunk(x, z, true);
         });
 
-        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", "true"));
+        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", loaded.toString()));
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -398,4 +398,18 @@ final class AgentWorldActions
             "serverVersion", Bukkit.getVersion()
         ));
     }
+
+    /**
+     * Handles {@code GET_SERVER_PLATFORM} by returning the server platform name.
+     *
+     * @param requestId
+     *     Runtime request identifier.
+     * @return
+     *     Success response with {@code platform} (e.g. "Paper", "Spigot").
+     */
+    AgentResponse handleGetServerPlatform(String requestId)
+    {
+        final String platform = Bukkit.getName();
+        return AgentResponses.successResponse(requestId, Map.of("platform", platform));
+    }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -204,7 +204,7 @@ final class AgentWorldActions
         final int x = command.x();
         final int z = command.z();
 
-        mainThreadExecutor.callOnMainThread(() ->
+        final Boolean loaded = mainThreadExecutor.callOnMainThread(() ->
         {
             final World world = Bukkit.getWorld(worldName);
             if (world == null)

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -204,7 +204,7 @@ final class AgentWorldActions
         final int x = command.x();
         final int z = command.z();
 
-        final Boolean loaded = mainThreadExecutor.callOnMainThread(() ->
+        mainThreadExecutor.callOnMainThread(() ->
         {
             final World world = Bukkit.getWorld(worldName);
             if (world == null)
@@ -381,91 +381,6 @@ final class AgentWorldActions
     AgentResponse handleGetServerTick(GetServerTickCommand command)
     {
         return AgentResponses.successResponse(command.requestId(), Map.of("tick", Long.toString(tickCounter.get())));
-    }
-
-    /**
-     * Handles {@code LOAD_CHUNK} by force-loading the chunk at the given chunk coordinates.
-     *
-     * @param command
-     *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Success response, or error if the world does not exist.
-     * @throws Exception
-     *     Propagates main-thread execution failures.
-     */
-    AgentResponse handleLoadChunk(LoadChunkCommand command)
-        throws Exception
-    {
-        final String worldName = command.worldName();
-        final int x = command.x();
-        final int z = command.z();
-
-        mainThreadExecutor.callOnMainThread(() ->
-        {
-            final World world = Bukkit.getWorld(worldName);
-            if (world == null)
-                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            world.loadChunk(x, z, true);
-            return Boolean.TRUE;
-        });
-
-        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", "true"));
-    }
-
-    /**
-     * Handles {@code UNLOAD_CHUNK} by unloading the chunk at the given chunk coordinates.
-     *
-     * @param command
-     *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Success response, or error if the world does not exist.
-     * @throws Exception
-     *     Propagates main-thread execution failures.
-     */
-    AgentResponse handleUnloadChunk(UnloadChunkCommand command)
-        throws Exception
-    {
-        final String worldName = command.worldName();
-        final int x = command.x();
-        final int z = command.z();
-
-        final Boolean unloaded = mainThreadExecutor.callOnMainThread(() ->
-        {
-            final World world = Bukkit.getWorld(worldName);
-            if (world == null)
-                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            return world.unloadChunk(x, z);
-        });
-
-        return AgentResponses.successResponse(command.requestId(), Map.of("unloaded", unloaded.toString()));
-    }
-
-    /**
-     * Handles {@code IS_CHUNK_LOADED} by querying whether the chunk is currently loaded.
-     *
-     * @param command
-     *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Success response with {@code loaded} boolean, or error if the world does not exist.
-     * @throws Exception
-     *     Propagates main-thread execution failures.
-     */
-    AgentResponse handleIsChunkLoaded(IsChunkLoadedCommand command)
-        throws Exception
-    {
-        final String worldName = command.worldName();
-        final int x = command.x();
-        final int z = command.z();
-
-        final Boolean loaded = mainThreadExecutor.callOnMainThread(() ->
-        {
-            final World world = Bukkit.getWorld(worldName);
-            if (world == null)
-                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            return world.isChunkLoaded(x, z);
-        });
-
-        return AgentResponses.successResponse(command.requestId(), Map.of("loaded", loaded.toString()));
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -109,6 +109,15 @@ final class AgentWorldActions
         final String environmentValue = command.environment();
         final long seed = command.seed();
 
+        if (worldName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                "Argument 'worldName' must not be blank."
+            );
+        }
+
         final World world = mainThreadExecutor.callOnMainThread(() ->
         {
             final WorldCreator worldCreator = new WorldCreator(worldName);
@@ -140,6 +149,15 @@ final class AgentWorldActions
     {
         final String source = command.commandSource();
         final String rawCommand = command.command();
+
+        if (rawCommand.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                "Argument 'command' must not be blank."
+            );
+        }
 
         if (!source.equalsIgnoreCase("CONSOLE"))
         {
@@ -181,7 +199,7 @@ final class AgentWorldActions
             final World world = Bukkit.getWorld(worldName);
             if (world == null)
                 throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            return world.getBlockAt(x, y, z).getType().name();
+            return world.getBlockAt(x, y, z).getType().getKey().toString();
         });
 
         return AgentResponses.successResponse(command.requestId(), Map.of("material", materialName));
@@ -384,32 +402,15 @@ final class AgentWorldActions
     }
 
     /**
-     * Handles {@code GET_SERVER_PLATFORM} by returning the server implementation name and version.
+     * Handles {@code GET_SERVER_PLATFORM} by classifying the running server as PAPER, SPIGOT, or UNKNOWN.
      *
      * @param command
      *     Typed command carrying the request identifier.
      * @return
-     *     Success response containing {@code serverName} and {@code serverVersion}.
+     *     Success response containing {@code platform} (e.g. "PAPER", "SPIGOT", "UNKNOWN").
      */
     AgentResponse handleGetServerPlatform(GetServerPlatformCommand command)
     {
-        return AgentResponses.successResponse(command.requestId(), Map.of(
-            "serverName", Bukkit.getName(),
-            "serverVersion", Bukkit.getVersion()
-        ));
-    }
-
-    /**
-     * Handles {@code GET_SERVER_PLATFORM} by returning the server platform name.
-     *
-     * @param requestId
-     *     Runtime request identifier.
-     * @return
-     *     Success response with {@code platform} (e.g. "Paper", "Spigot").
-     */
-    AgentResponse handleGetServerPlatform(String requestId)
-    {
-        final String platform = Bukkit.getName();
-        return AgentResponses.successResponse(requestId, Map.of("platform", platform));
+        return AgentResponses.successResponse(command.requestId(), Map.of("platform", AgentPlatformDetector.detect()));
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -136,10 +136,12 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 playerActions,
                 menuActions,
                 eventActions,
-                getLogger(),
-                configuration.authToken(),
-                configuration.protocolVersion(),
-                configuration.expectedAgentSha256()
+                new AgentRequestDispatcher.Config(
+                    configuration.authToken(),
+                    configuration.protocolVersion(),
+                    configuration.expectedAgentSha256(),
+                    getLogger()
+                )
             );
 
             startTickLoop(worldActions);

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -128,13 +128,14 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 botPlayerNmsAdapter
             );
             final AgentEventCapture eventCapture = new AgentEventCapture(this, mainThreadExecutor);
+            final AgentEventActions eventActions = new AgentEventActions(eventCapture, objectMapper);
 
             requestDispatcher = new AgentRequestDispatcher(
                 objectMapper,
                 worldActions,
                 playerActions,
                 menuActions,
-                eventCapture,
+                eventActions,
                 getLogger(),
                 configuration.authToken(),
                 configuration.protocolVersion(),

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -127,7 +127,7 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 objectMapper,
                 botPlayerNmsAdapter
             );
-            final AgentEventCapture eventCapture = new AgentEventCapture(this);
+            final AgentEventCapture eventCapture = new AgentEventCapture(this, mainThreadExecutor);
 
             requestDispatcher = new AgentRequestDispatcher(
                 objectMapper,

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -127,12 +127,14 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 objectMapper,
                 botPlayerNmsAdapter
             );
+            final AgentEventCapture eventCapture = new AgentEventCapture(this);
 
             requestDispatcher = new AgentRequestDispatcher(
                 objectMapper,
                 worldActions,
                 playerActions,
                 menuActions,
+                eventCapture,
                 getLogger(),
                 configuration.authToken(),
                 configuration.protocolVersion(),

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
@@ -1,0 +1,199 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
+import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.RegisterEventListenerCommand;
+import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AgentEventActionsTest
+{
+    private static AgentEventActions createEventActions(AgentEventCapture eventCapture)
+    {
+        return new AgentEventActions(eventCapture, new ObjectMapper());
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldReturnInvalidArgumentWhenClassIsBlank()
+    {
+        // setup
+        final AgentEventActions actions = createEventActions(mock());
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-1", ""));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("eventClassName");
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldReturnInvalidArgumentWhenClassIsNotBukkitEvent()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("Class 'java.lang.String' is not a Bukkit Event."))
+            .when(eventCapture).registerListener("java.lang.String");
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-2", "java.lang.String"));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("not a Bukkit Event");
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldReturnInvalidArgumentWhenClassIsNotFound()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+        org.mockito.Mockito.doThrow(new ClassNotFoundException("com.example.NonExistent"))
+            .when(eventCapture).registerListener("com.example.NonExistent");
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-cnf", "com.example.NonExistent"));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldSucceedWhenClassIsRegistered()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-3", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        verify(eventCapture).registerListener("org.bukkit.event.Event");
+    }
+
+    @Test
+    void handleGetCapturedEvents_shouldReturnInvalidArgumentWhenClassIsBlank()
+        throws Exception
+    {
+        // setup
+        final AgentEventActions actions = createEventActions(mock());
+
+        // execute
+        final AgentResponse response =
+            actions.handleGetCapturedEvents(new GetCapturedEventsCommand("req-4", ""));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("eventClassName");
+    }
+
+    @Test
+    void handleGetCapturedEvents_shouldReturnSerializedEventsJson()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+        when(eventCapture.getCapturedEvents("org.bukkit.event.Event"))
+            .thenReturn(List.of(Map.of("isCancelled", "true")));
+
+        // execute
+        final AgentResponse response =
+            actions.handleGetCapturedEvents(new GetCapturedEventsCommand("req-5", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data().get("eventsJson")).contains("isCancelled");
+    }
+
+    @Test
+    void handleClearCapturedEvents_shouldSucceedAndClearWhenClassIsNotBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleClearCapturedEvents(new ClearCapturedEventsCommand("req-6", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        verify(eventCapture).clearCapturedEvents("org.bukkit.event.Event");
+    }
+
+    @Test
+    void handleClearCapturedEvents_shouldSucceedAndNoopWhenClassIsBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleClearCapturedEvents(new ClearCapturedEventsCommand("req-7", ""));
+
+        // verify - blank is silently ignored
+        assertThat(response.success()).isTrue();
+        verifyNoInteractions(eventCapture);
+    }
+
+    @Test
+    void handleUnregisterEventListener_shouldSucceedAndUnregisterWhenClassIsNotBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleUnregisterEventListener(
+                new UnregisterEventListenerCommand("req-8", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        verify(eventCapture).unregisterListener("org.bukkit.event.Event");
+    }
+
+    @Test
+    void handleUnregisterEventListener_shouldSucceedAndNoopWhenClassIsBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleUnregisterEventListener(new UnregisterEventListenerCommand("req-9", ""));
+
+        // verify - blank is silently ignored
+        assertThat(response.success()).isTrue();
+        verifyNoInteractions(eventCapture);
+    }
+}

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
@@ -1,0 +1,322 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.EventExecutor;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AgentEventCaptureTest
+{
+    @Test
+    void registerListener_shouldCaptureCancelledEventsIntoRegisteredEventList()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final PluginManager pluginManager = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
+
+        // execute
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            eventCapture.registerListener(TestCaptureEvent.class.getName());
+        }
+        verify(pluginManager).registerEvent(
+            eq(TestCaptureEvent.class),
+            any(Listener.class),
+            eq(EventPriority.MONITOR),
+            executorCaptor.capture(),
+            eq(plugin),
+            eq(false)
+        );
+        executorCaptor.getValue().execute(mock(Listener.class), new TestCaptureEvent("value", true));
+
+        // verify
+        final List<Map<String, String>> events = eventCapture.getCapturedEvents(TestCaptureEvent.class.getName());
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst())
+            .containsEntry("getValue", "value")
+            .containsEntry("isCancelled", "true");
+    }
+
+    @Test
+    void registerListener_shouldThrowExceptionWhenClassIsNotBukkitEvent()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final PluginManager pluginManager = mock();
+
+        // execute + verify
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            assertThatThrownBy(() -> eventCapture.registerListener(String.class.getName()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a Bukkit Event");
+        }
+    }
+
+    @Test
+    void clearCapturedEvents_shouldRemoveCapturedData()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final PluginManager pluginManager = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            fireOneTestCaptureEvent(eventCapture, pluginManager, plugin);
+
+            // execute
+            eventCapture.clearCapturedEvents(TestCaptureEvent.class.getName());
+
+            // verify
+            assertThat(eventCapture.getCapturedEvents(TestCaptureEvent.class.getName())).isEmpty();
+        }
+    }
+
+    @Test
+    void unregisterListener_shouldRemoveCapturedData()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final PluginManager pluginManager = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            fireOneTestCaptureEvent(eventCapture, pluginManager, plugin);
+
+            // execute
+            eventCapture.unregisterListener(TestCaptureEvent.class.getName());
+
+            // verify
+            assertThat(eventCapture.getCapturedEvents(TestCaptureEvent.class.getName())).isEmpty();
+        }
+    }
+
+    @Test
+    void registerListener_shouldBeIdempotentWhenListenerIsAlreadyRegistered()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final PluginManager pluginManager = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+
+            // execute
+            eventCapture.registerListener(TestCaptureEvent.class.getName());
+            eventCapture.registerListener(TestCaptureEvent.class.getName());
+        }
+
+        // verify: only one registerEvent call despite two registration attempts
+        verify(pluginManager).registerEvent(
+            eq(TestCaptureEvent.class),
+            any(Listener.class),
+            eq(EventPriority.MONITOR),
+            any(EventExecutor.class),
+            eq(plugin),
+            eq(false)
+        );
+    }
+
+    @Test
+    void getCapturedEvents_shouldReturnEmptyListForUnregisteredClass()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+
+        // execute
+        final List<Map<String, String>> events = eventCapture.getCapturedEvents("com.example.NonExistentEvent");
+
+        // verify
+        assertThat(events).isEmpty();
+    }
+
+    @Test
+    void registerListener_shouldThrowExceptionWhenClassIsNotFound()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final PluginManager pluginManager = mock();
+
+        // execute + verify
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            assertThatThrownBy(() -> eventCapture.registerListener("com.example.NonExistentEvent"))
+                .isInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    @Test
+    void captureEventForList_shouldSkipNullAndNonPrintableFieldValues()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final PluginManager pluginManager = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            eventCapture.registerListener(MixedFieldsEvent.class.getName());
+        }
+        verify(pluginManager).registerEvent(
+            eq(MixedFieldsEvent.class),
+            any(Listener.class),
+            eq(EventPriority.MONITOR),
+            executorCaptor.capture(),
+            eq(plugin),
+            eq(false)
+        );
+
+        // execute - fire event with string (printable) and list (not printable)
+        executorCaptor.getValue().execute(mock(Listener.class), new MixedFieldsEvent("hello", null));
+
+        // verify - only the string field should be captured
+        final List<Map<String, String>> events = eventCapture.getCapturedEvents(MixedFieldsEvent.class.getName());
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst()).containsKey("getLabel");
+        assertThat(events.getFirst()).doesNotContainKey("getNullValue");
+    }
+
+    private static void fireOneTestCaptureEvent(
+        AgentEventCapture eventCapture, PluginManager pluginManager, JavaPlugin plugin)
+        throws ClassNotFoundException, EventException
+    {
+        final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
+        eventCapture.registerListener(TestCaptureEvent.class.getName());
+        verify(pluginManager).registerEvent(
+            eq(TestCaptureEvent.class),
+            any(Listener.class),
+            eq(EventPriority.MONITOR),
+            executorCaptor.capture(),
+            eq(plugin),
+            eq(false)
+        );
+        executorCaptor.getValue().execute(mock(Listener.class), new TestCaptureEvent("value", false));
+    }
+
+    public static final class TestCaptureEvent extends Event
+    {
+        private static final HandlerList HANDLERS = new HandlerList();
+        private final String value;
+        private final boolean cancelled;
+
+        private TestCaptureEvent(String value, boolean cancelled)
+        {
+            this.value = value;
+            this.cancelled = cancelled;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        public boolean isCancelled()
+        {
+            return cancelled;
+        }
+
+        @Override
+        public HandlerList getHandlers()
+        {
+            return HANDLERS;
+        }
+
+        @SuppressWarnings("unused")
+        public static HandlerList getHandlerList()
+        {
+            return HANDLERS;
+        }
+    }
+
+    public static final class MixedFieldsEvent extends Event
+    {
+        private static final HandlerList HANDLERS = new HandlerList();
+        private final String label;
+        private final @org.jspecify.annotations.Nullable Object nullValue;
+
+        private MixedFieldsEvent(String label, @org.jspecify.annotations.Nullable Object nullValue)
+        {
+            this.label = label;
+            this.nullValue = nullValue;
+        }
+
+        public String getLabel()
+        {
+            return label;
+        }
+
+        @SuppressWarnings("unused")
+        public @org.jspecify.annotations.Nullable Object getNullValue()
+        {
+            return nullValue;
+        }
+
+        @Override
+        public HandlerList getHandlers()
+        {
+            return HANDLERS;
+        }
+
+        @SuppressWarnings("unused")
+        public static HandlerList getHandlerList()
+        {
+            return HANDLERS;
+        }
+    }
+}

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
@@ -3,9 +3,15 @@ package nl.pim16aap2.lightkeeper.agent.spigot;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
+import nl.pim16aap2.lightkeeper.protocol.CreatePlayerCommand;
+import nl.pim16aap2.lightkeeper.protocol.DropItemCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommandCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventoryCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessagesCommand;
 import nl.pim16aap2.lightkeeper.protocol.LeftClickBlockCommand;
+import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlockCommand;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlockCommand;
+import nl.pim16aap2.lightkeeper.protocol.TeleportPlayerCommand;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -22,9 +28,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 class AgentPlayerActionsTest
@@ -104,6 +112,211 @@ class AgentPlayerActionsTest
         assertThat(response.errorMessage()).contains("block face");
     }
 
+    @Test
+    void handleGetPlayerMessages_shouldDrainAndReturnMessageHistory()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mockPlayer(uuid);
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        when(fixture.nmsAdapter().drainReceivedMessages(uuid)).thenReturn(List.of("first", "second"));
+        final GetPlayerMessagesCommand command = new GetPlayerMessagesCommand("request-messages", uuid);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            response = fixture.playerActions().handleGetPlayerMessages(command);
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("messagesJson", "[\"first\",\"second\"]");
+    }
+
+    @Test
+    void handleGetPlayerInventory_shouldSerializeNonAirItems()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mockPlayer(uuid);
+        final PlayerInventory inventory = player.getInventory();
+        final ItemStack stone = mock();
+        when(stone.getType()).thenReturn(Material.STONE);
+        when(stone.getItemMeta()).thenReturn(null);
+        final ItemStack airItem = mock();
+        when(airItem.getType()).thenReturn(Material.AIR);
+        when(inventory.getContents()).thenReturn(new ItemStack[]{
+            null,
+            airItem,
+            stone
+        });
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        final GetPlayerInventoryCommand command = new GetPlayerInventoryCommand("request-inventory", uuid);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            response = fixture.playerActions().handleGetPlayerInventory(command);
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data().get("inventoryJson"))
+            .contains("\"slot\":2")
+            .contains("\"materialKey\":\"minecraft:stone\"")
+            .contains("\"lore\":[]");
+    }
+
+    @Test
+    void handleTeleportPlayer_shouldReturnErrorWhenWorldNameIsBlank()
+        throws Exception
+    {
+        // setup
+        final AgentPlayerActions playerActions = createPlayerActions();
+        final TeleportPlayerCommand command =
+            new TeleportPlayerCommand("request-tp-blank", UUID.randomUUID(), "   ", 0, 64, 0);
+
+        // execute
+        final AgentResponse response = playerActions.handleTeleportPlayer(command);
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("worldName");
+    }
+
+    @Test
+    void handlePlacePlayerBlock_shouldReturnErrorWhenMaterialIsUnknown()
+        throws Exception
+    {
+        // setup
+        final AgentPlayerActions playerActions = createPlayerActions();
+        final PlacePlayerBlockCommand command =
+            new PlacePlayerBlockCommand("request-place", UUID.randomUUID(), "not_a_real_material", 1, 64, 2);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Material> materialMockedStatic = mockStatic(Material.class))
+        {
+            materialMockedStatic.when(() -> Material.matchMaterial(anyString(), eq(true))).thenReturn(null);
+            response = playerActions.handlePlacePlayerBlock(command);
+        }
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("Unknown material");
+    }
+
+    @Test
+    void cleanupSyntheticPlayers_shouldRemoveAllRegisteredPlayers()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mockPlayer(uuid);
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+
+        // execute
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
+        {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            fixture.playerActions().cleanupSyntheticPlayers();
+        }
+
+        // verify
+        verify(fixture.nmsAdapter()).removePlayer(player);
+        assertThat(fixture.playerStore().syntheticPlayerIds()).isEmpty();
+    }
+
+    @Test
+    void cleanupSyntheticPlayers_shouldContinueCleanupWhenOnePlayerFails()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid1 = UUID.randomUUID();
+        final UUID uuid2 = UUID.randomUUID();
+        final Player player1 = mockPlayer(uuid1);
+        final Player player2 = mockPlayer(uuid2);
+        fixture.playerStore().registerSyntheticPlayer(uuid1, player1);
+        fixture.playerStore().registerSyntheticPlayer(uuid2, player2);
+        doThrow(new RuntimeException("removal failed")).when(fixture.nmsAdapter()).removePlayer(player1);
+
+        // execute
+        fixture.playerActions().cleanupSyntheticPlayers();
+
+        // verify - player2 should still be attempted
+        verify(fixture.nmsAdapter()).removePlayer(player2);
+    }
+
+    @Test
+    void handleDropItem_shouldReturnNotDroppedWhenMainHandIsEmpty()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mockPlayer(uuid);
+        final ItemStack emptyHand = mock();
+        when(emptyHand.getType()).thenReturn(Material.AIR);
+        when(player.getInventory().getItemInMainHand()).thenReturn(emptyHand);
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        final DropItemCommand command = new DropItemCommand("request-drop", uuid);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
+        {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            response = fixture.playerActions().handleDropItem(command);
+        }
+
+        // verify - no item to drop, so dropped=false
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("dropped", "false");
+    }
+
+    @Test
+    void handleCreatePlayer_shouldSpawnPlayerWithCoordinatesAndOptionalPermissions()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final World world = mock();
+        final Player player = mockPlayer(uuid);
+        when(player.getName()).thenReturn("testbot");
+        when(fixture.nmsAdapter().spawnPlayer(eq(uuid), eq("testbot"), eq(world), any())).thenReturn(player);
+        when(player.addAttachment(any())).thenReturn(mock());
+        final CreatePlayerCommand command = new CreatePlayerCommand(
+            "request-create", "testbot", uuid, "world", 10.0, 64.0, 20.0, null, "test.perm"
+        );
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
+        {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = fixture.playerActions().handleCreatePlayer(command);
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("uuid", uuid.toString());
+        assertThat(response.data()).containsEntry("name", "testbot");
+    }
+
     private static AgentPlayerActions createPlayerActions()
     {
         return createPlayerActionsFixture().playerActions();
@@ -112,6 +325,7 @@ class AgentPlayerActionsTest
     private static PlayerActionsFixture createPlayerActionsFixture()
     {
         final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final AgentMainThreadExecutor mainThreadExecutor = new AgentMainThreadExecutor(plugin);
         final AgentSyntheticPlayerStore playerStore = new AgentSyntheticPlayerStore();
         final ObjectMapper objectMapper = new ObjectMapper();
@@ -124,7 +338,7 @@ class AgentPlayerActionsTest
             objectMapper,
             nmsAdapter
         );
-        return new PlayerActionsFixture(playerActions, playerStore);
+        return new PlayerActionsFixture(playerActions, playerStore, nmsAdapter);
     }
 
     private static Player mockPlayer(UUID uuid)
@@ -144,7 +358,8 @@ class AgentPlayerActionsTest
 
     private record PlayerActionsFixture(
         AgentPlayerActions playerActions,
-        AgentSyntheticPlayerStore playerStore)
+        AgentSyntheticPlayerStore playerStore,
+        IBotPlayerNmsAdapter nmsAdapter)
     {
     }
 }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
@@ -138,6 +138,32 @@ class AgentPlayerActionsTest
     }
 
     @Test
+    void handleGetPlayerChatComponents_shouldDrainAndReturnComponentHistory()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mockPlayer(uuid);
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        when(fixture.nmsAdapter().drainChatComponents(uuid)).thenReturn(List.of("{\"text\":\"hello\"}"));
+        final nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand command =
+            new nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand("request-components", uuid);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            response = fixture.playerActions().handleGetPlayerChatComponents(command);
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("componentsJson", "[\"{\\\"text\\\":\\\"hello\\\"}\"]");
+    }
+
+    @Test
     void handleGetPlayerInventory_shouldSerializeNonAirItems()
         throws Exception
     {
@@ -347,7 +373,8 @@ class AgentPlayerActionsTest
         final World world = mock();
         final Block block = mock();
         final PlayerInventory inventory = mock();
-        final ItemStack item = new ItemStack(Material.STICK);
+        final ItemStack item = mock();
+        when(item.getType()).thenReturn(Material.STICK);
         when(player.getUniqueId()).thenReturn(uuid);
         when(player.getWorld()).thenReturn(world);
         when(player.getInventory()).thenReturn(inventory);

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.lightkeeper.protocol.CreatePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.DropItemCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommandCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventoryCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessagesCommand;
 import nl.pim16aap2.lightkeeper.protocol.LeftClickBlockCommand;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlockCommand;
@@ -147,8 +148,8 @@ class AgentPlayerActionsTest
         final Player player = mockPlayer(uuid);
         fixture.playerStore().registerSyntheticPlayer(uuid, player);
         when(fixture.nmsAdapter().drainChatComponents(uuid)).thenReturn(List.of("{\"text\":\"hello\"}"));
-        final nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand command =
-            new nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand("request-components", uuid);
+        final GetPlayerChatComponentsCommand command =
+            new GetPlayerChatComponentsCommand("request-components", uuid);
 
         // execute
         final AgentResponse response;

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -15,6 +15,7 @@ import nl.pim16aap2.lightkeeper.protocol.ExecuteCommandCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommandCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEventsCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetOpenMenuCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventoryCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessagesCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTickCommand;
@@ -122,7 +123,7 @@ class AgentRequestDispatcherTest
         when(fixture.playerActions().handleGetPlayerChatComponents(any()))
             .thenThrow(new IllegalArgumentException("Invalid UUID string: bad-uuid"));
         final String requestLine = toJson(
-            new nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand(
+            new GetPlayerChatComponentsCommand(
                 "request-invalid", UUID.randomUUID()));
 
         // execute
@@ -214,7 +215,7 @@ class AgentRequestDispatcherTest
         when(fixture.eventCapture().getCapturedEvents(eq(eventClass)))
             .thenReturn(List.of(Map.of("getEventName", "Event")));
         when(fixture.playerActions().handleGetPlayerChatComponents(
-            any(nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand.class)))
+            any(GetPlayerChatComponentsCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-27", Map.of()));
 
         // execute
@@ -254,7 +255,7 @@ class AgentRequestDispatcherTest
         fixture.dispatcher().handleRequestLine(
             toJson(new UnregisterEventListenerCommand("request-26", eventClass)), true);
         fixture.dispatcher().handleRequestLine(
-            toJson(new nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand("request-27", uuid)), true);
+            toJson(new GetPlayerChatComponentsCommand("request-27", uuid)), true);
 
         // verify
         verify(fixture.worldActions()).handleNewWorld(any(NewWorldCommand.class));
@@ -284,7 +285,7 @@ class AgentRequestDispatcherTest
         verify(fixture.eventCapture()).clearCapturedEvents(eventClass);
         verify(fixture.eventCapture()).unregisterListener(eventClass);
         verify(fixture.playerActions()).handleGetPlayerChatComponents(
-            any(nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand.class));
+            any(GetPlayerChatComponentsCommand.class));
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -114,6 +114,51 @@ class AgentRequestDispatcherTest
     }
 
     @Test
+    void handleRequestLine_shouldReturnInvalidArgumentWhenActionThrowsIllegalArgumentException()
+        throws Exception
+    {
+        // setup
+        final DispatcherFixture fixture = createDispatcherFixture();
+        when(fixture.playerActions().handleGetPlayerChatComponents(any()))
+            .thenThrow(new IllegalArgumentException("Invalid UUID string: bad-uuid"));
+        final String requestLine = toJson(
+            new nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand(
+                "request-invalid", UUID.randomUUID()));
+
+        // execute
+        final AgentRequestDispatcher.RequestDispatchResult result =
+            fixture.dispatcher().handleRequestLine(requestLine, true);
+
+        // verify
+        assertThat(result.response().success()).isFalse();
+        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(result.response().errorMessage()).contains("bad-uuid");
+        assertThat(result.handshakeCompleted()).isTrue();
+    }
+
+    @Test
+    void handleRequestLine_shouldReturnInvalidArgumentWhenActionThrowsValidationException()
+        throws Exception
+    {
+        // setup
+        final DispatcherFixture fixture = createDispatcherFixture();
+        when(fixture.playerActions().handleGetPlayerMessages(any()))
+            .thenThrow(new IllegalArgumentException("Invalid UUID string: not-a-uuid"));
+        final String requestLine = toJson(
+            new GetPlayerMessagesCommand("request-invalid-uuid", UUID.randomUUID()));
+
+        // execute
+        final AgentRequestDispatcher.RequestDispatchResult result =
+            fixture.dispatcher().handleRequestLine(requestLine, true);
+
+        // verify
+        assertThat(result.response().success()).isFalse();
+        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(result.response().errorMessage()).contains("Invalid UUID");
+        assertThat(result.handshakeCompleted()).isTrue();
+    }
+
+    @Test
     void handleRequestLine_shouldDispatchSupportedActionsToTheirHandlers()
         throws Exception
     {
@@ -168,6 +213,9 @@ class AgentRequestDispatcherTest
             .thenReturn(AgentResponses.successResponse("request-22", Map.of("dropped", "false")));
         when(fixture.eventCapture().getCapturedEvents(eq(eventClass)))
             .thenReturn(List.of(Map.of("getEventName", "Event")));
+        when(fixture.playerActions().handleGetPlayerChatComponents(
+            any(nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-27", Map.of()));
 
         // execute
         fixture.dispatcher().handleRequestLine(toJson(new NewWorldCommand("request-1", "w", "NORMAL", "NORMAL", 0L)), true);
@@ -205,6 +253,8 @@ class AgentRequestDispatcherTest
         fixture.dispatcher().handleRequestLine(toJson(new ClearCapturedEventsCommand("request-25", eventClass)), true);
         fixture.dispatcher().handleRequestLine(
             toJson(new UnregisterEventListenerCommand("request-26", eventClass)), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand("request-27", uuid)), true);
 
         // verify
         verify(fixture.worldActions()).handleNewWorld(any(NewWorldCommand.class));
@@ -233,6 +283,8 @@ class AgentRequestDispatcherTest
         verify(fixture.eventCapture()).getCapturedEvents(eventClass);
         verify(fixture.eventCapture()).clearCapturedEvents(eventClass);
         verify(fixture.eventCapture()).unregisterListener(eventClass);
+        verify(fixture.playerActions()).handleGetPlayerChatComponents(
+            any(nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand.class));
     }
 
     @Test
@@ -359,6 +411,74 @@ class AgentRequestDispatcherTest
         assertThat(result.response().requestId()).isEqualTo("request-4");
         assertThat(result.response().success()).isFalse();
         assertThat(result.response().errorCode()).isEqualTo("AGENT_SHA_MISMATCH");
+    }
+
+    @Test
+    void handleRequestLine_shouldReturnInvalidArgumentWhenRegisterEventListenerClassIsBlank()
+        throws Exception
+    {
+        // setup
+        final DispatcherFixture fixture = createDispatcherFixture();
+        final String requestLine = toJson(new RegisterEventListenerCommand("request-blank-class", ""));
+
+        // execute
+        final AgentRequestDispatcher.RequestDispatchResult result =
+            fixture.dispatcher().handleRequestLine(requestLine, true);
+
+        // verify
+        assertThat(result.response().success()).isFalse();
+        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(result.response().errorMessage()).contains("eventClassName");
+    }
+
+    @Test
+    void handleRequestLine_shouldReturnInvalidArgumentWhenGetCapturedEventsClassIsBlank()
+        throws Exception
+    {
+        // setup
+        final DispatcherFixture fixture = createDispatcherFixture();
+        final String requestLine = toJson(new GetCapturedEventsCommand("request-blank-events", ""));
+
+        // execute
+        final AgentRequestDispatcher.RequestDispatchResult result =
+            fixture.dispatcher().handleRequestLine(requestLine, true);
+
+        // verify
+        assertThat(result.response().success()).isFalse();
+        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(result.response().errorMessage()).contains("eventClassName");
+    }
+
+    @Test
+    void handleRequestLine_shouldSucceedClearCapturedEventsWithBlankClassName()
+        throws Exception
+    {
+        // setup
+        final DispatcherFixture fixture = createDispatcherFixture();
+        final String requestLine = toJson(new ClearCapturedEventsCommand("request-clear-blank", ""));
+
+        // execute
+        final AgentRequestDispatcher.RequestDispatchResult result =
+            fixture.dispatcher().handleRequestLine(requestLine, true);
+
+        // verify - blank is silently ignored, operation succeeds
+        assertThat(result.response().success()).isTrue();
+    }
+
+    @Test
+    void handleRequestLine_shouldSucceedUnregisterEventListenerWithBlankClassName()
+        throws Exception
+    {
+        // setup
+        final DispatcherFixture fixture = createDispatcherFixture();
+        final String requestLine = toJson(new UnregisterEventListenerCommand("request-unregister-blank", ""));
+
+        // execute
+        final AgentRequestDispatcher.RequestDispatchResult result =
+            fixture.dispatcher().handleRequestLine(requestLine, true);
+
+        // verify - blank is silently ignored, operation succeeds
+        assertThat(result.response().success()).isTrue();
     }
 
     private static AgentRequestDispatcher createDispatcher(String authToken, int protocolVersion, String expectedSha)

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -18,6 +18,7 @@ import nl.pim16aap2.lightkeeper.protocol.GetOpenMenuCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponentsCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventoryCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessagesCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetServerPlatformCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTickCommand;
 import nl.pim16aap2.lightkeeper.protocol.HandshakeCommand;
 import nl.pim16aap2.lightkeeper.protocol.IsChunkLoadedCommand;
@@ -217,6 +218,8 @@ class AgentRequestDispatcherTest
         when(fixture.playerActions().handleGetPlayerChatComponents(
             any(GetPlayerChatComponentsCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-27", Map.of()));
+        when(fixture.worldActions().handleGetServerPlatform(any(GetServerPlatformCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-28", Map.of()));
 
         // execute
         fixture.dispatcher().handleRequestLine(toJson(new NewWorldCommand("request-1", "w", "NORMAL", "NORMAL", 0L)), true);
@@ -256,6 +259,7 @@ class AgentRequestDispatcherTest
             toJson(new UnregisterEventListenerCommand("request-26", eventClass)), true);
         fixture.dispatcher().handleRequestLine(
             toJson(new GetPlayerChatComponentsCommand("request-27", uuid)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new GetServerPlatformCommand("request-28")), true);
 
         // verify
         verify(fixture.worldActions()).handleNewWorld(any(NewWorldCommand.class));
@@ -284,8 +288,8 @@ class AgentRequestDispatcherTest
         verify(fixture.eventCapture()).getCapturedEvents(eventClass);
         verify(fixture.eventCapture()).clearCapturedEvents(eventClass);
         verify(fixture.eventCapture()).unregisterListener(eventClass);
-        verify(fixture.playerActions()).handleGetPlayerChatComponents(
-            any(GetPlayerChatComponentsCommand.class));
+        verify(fixture.playerActions()).handleGetPlayerChatComponents(any(GetPlayerChatComponentsCommand.class));
+        verify(fixture.worldActions()).handleGetServerPlatform(any(GetServerPlatformCommand.class));
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -40,7 +40,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -213,8 +212,14 @@ class AgentRequestDispatcherTest
             .thenReturn(AgentResponses.successResponse("request-21", Map.of("inventoryJson", "[]")));
         when(fixture.playerActions().handleDropItem(any(DropItemCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-22", Map.of("dropped", "false")));
-        when(fixture.eventCapture().getCapturedEvents(eq(eventClass)))
-            .thenReturn(List.of(Map.of("getEventName", "Event")));
+        when(fixture.eventActions().handleRegisterEventListener(any(RegisterEventListenerCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-23", Map.of()));
+        when(fixture.eventActions().handleGetCapturedEvents(any(GetCapturedEventsCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-24", Map.of("eventsJson", "[{\"getEventName\":\"Event\"}]")));
+        when(fixture.eventActions().handleClearCapturedEvents(any(ClearCapturedEventsCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-25", Map.of()));
+        when(fixture.eventActions().handleUnregisterEventListener(any(UnregisterEventListenerCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-26", Map.of()));
         when(fixture.playerActions().handleGetPlayerChatComponents(
             any(GetPlayerChatComponentsCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-27", Map.of()));
@@ -284,10 +289,10 @@ class AgentRequestDispatcherTest
         verify(fixture.worldActions()).handleIsChunkLoaded(any(IsChunkLoadedCommand.class));
         verify(fixture.playerActions()).handleGetPlayerInventory(any(GetPlayerInventoryCommand.class));
         verify(fixture.playerActions()).handleDropItem(any(DropItemCommand.class));
-        verify(fixture.eventCapture()).registerListener(eventClass);
-        verify(fixture.eventCapture()).getCapturedEvents(eventClass);
-        verify(fixture.eventCapture()).clearCapturedEvents(eventClass);
-        verify(fixture.eventCapture()).unregisterListener(eventClass);
+        verify(fixture.eventActions()).handleRegisterEventListener(any(RegisterEventListenerCommand.class));
+        verify(fixture.eventActions()).handleGetCapturedEvents(any(GetCapturedEventsCommand.class));
+        verify(fixture.eventActions()).handleClearCapturedEvents(any(ClearCapturedEventsCommand.class));
+        verify(fixture.eventActions()).handleUnregisterEventListener(any(UnregisterEventListenerCommand.class));
         verify(fixture.playerActions()).handleGetPlayerChatComponents(any(GetPlayerChatComponentsCommand.class));
         verify(fixture.worldActions()).handleGetServerPlatform(any(GetServerPlatformCommand.class));
     }
@@ -298,8 +303,12 @@ class AgentRequestDispatcherTest
     {
         // setup
         final DispatcherFixture fixture = createDispatcherFixture();
-        doThrow(new IllegalArgumentException("Class 'java.lang.String' is not a Bukkit Event."))
-            .when(fixture.eventCapture()).registerListener("java.lang.String");
+        when(fixture.eventActions().handleRegisterEventListener(any(RegisterEventListenerCommand.class)))
+            .thenReturn(AgentResponses.errorResponse(
+                "request-event",
+                nl.pim16aap2.lightkeeper.protocol.AgentErrorCode.INVALID_ARGUMENT,
+                "Class 'java.lang.String' is not a Bukkit Event."
+            ));
         final String requestLine = toJson(new RegisterEventListenerCommand("request-event", "java.lang.String"));
 
         // execute
@@ -418,74 +427,6 @@ class AgentRequestDispatcherTest
         assertThat(result.response().errorCode()).isEqualTo("AGENT_SHA_MISMATCH");
     }
 
-    @Test
-    void handleRequestLine_shouldReturnInvalidArgumentWhenRegisterEventListenerClassIsBlank()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new RegisterEventListenerCommand("request-blank-class", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify
-        assertThat(result.response().success()).isFalse();
-        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
-        assertThat(result.response().errorMessage()).contains("eventClassName");
-    }
-
-    @Test
-    void handleRequestLine_shouldReturnInvalidArgumentWhenGetCapturedEventsClassIsBlank()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new GetCapturedEventsCommand("request-blank-events", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify
-        assertThat(result.response().success()).isFalse();
-        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
-        assertThat(result.response().errorMessage()).contains("eventClassName");
-    }
-
-    @Test
-    void handleRequestLine_shouldSucceedClearCapturedEventsWithBlankClassName()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new ClearCapturedEventsCommand("request-clear-blank", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify - blank is silently ignored, operation succeeds
-        assertThat(result.response().success()).isTrue();
-    }
-
-    @Test
-    void handleRequestLine_shouldSucceedUnregisterEventListenerWithBlankClassName()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new UnregisterEventListenerCommand("request-unregister-blank", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify - blank is silently ignored, operation succeeds
-        assertThat(result.response().success()).isTrue();
-    }
-
     private static AgentRequestDispatcher createDispatcher(String authToken, int protocolVersion, String expectedSha)
     {
         final ObjectMapper objectMapper = new ObjectMapper()
@@ -512,13 +453,14 @@ class AgentRequestDispatcherTest
             nmsAdapter
         );
         final AgentEventCapture eventCapture = mock();
+        final AgentEventActions eventActions = new AgentEventActions(eventCapture, objectMapper);
 
         return new AgentRequestDispatcher(
             objectMapper,
             worldActions,
             playerActions,
             menuActions,
-            eventCapture,
+            eventActions,
             Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
             authToken,
             protocolVersion,
@@ -533,19 +475,19 @@ class AgentRequestDispatcherTest
         final AgentWorldActions worldActions = mock();
         final AgentPlayerActions playerActions = mock();
         final AgentMenuActions menuActions = mock();
-        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions eventActions = mock();
         final AgentRequestDispatcher dispatcher = new AgentRequestDispatcher(
             objectMapper,
             worldActions,
             playerActions,
             menuActions,
-            eventCapture,
+            eventActions,
             Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
             "token",
             1,
             ""
         );
-        return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions, eventCapture);
+        return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions, eventActions);
     }
 
     private record DispatcherFixture(
@@ -553,7 +495,7 @@ class AgentRequestDispatcherTest
         AgentWorldActions worldActions,
         AgentPlayerActions playerActions,
         AgentMenuActions menuActions,
-        AgentEventCapture eventCapture)
+        AgentEventActions eventActions)
     {
     }
 

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -6,28 +6,39 @@ import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import nl.pim16aap2.lightkeeper.protocol.IAgentCommand;
 import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
 import nl.pim16aap2.lightkeeper.protocol.BlockTypeCommand;
+import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEventsCommand;
 import nl.pim16aap2.lightkeeper.protocol.ClickMenuSlotCommand;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.DragMenuSlotsCommand;
+import nl.pim16aap2.lightkeeper.protocol.DropItemCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecuteCommandCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommandCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEventsCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetOpenMenuCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventoryCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessagesCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTickCommand;
 import nl.pim16aap2.lightkeeper.protocol.HandshakeCommand;
+import nl.pim16aap2.lightkeeper.protocol.IsChunkLoadedCommand;
 import nl.pim16aap2.lightkeeper.protocol.LeftClickBlockCommand;
+import nl.pim16aap2.lightkeeper.protocol.LoadChunkCommand;
 import nl.pim16aap2.lightkeeper.protocol.MainWorldCommand;
 import nl.pim16aap2.lightkeeper.protocol.NewWorldCommand;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlockCommand;
+import nl.pim16aap2.lightkeeper.protocol.RegisterEventListenerCommand;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlockCommand;
 import nl.pim16aap2.lightkeeper.protocol.SetBlockCommand;
+import nl.pim16aap2.lightkeeper.protocol.TeleportPlayerCommand;
+import nl.pim16aap2.lightkeeper.protocol.UnloadChunkCommand;
+import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicksCommand;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -109,6 +120,7 @@ class AgentRequestDispatcherTest
         // setup
         final DispatcherFixture fixture = createDispatcherFixture();
         final UUID uuid = UUID.randomUUID();
+        final String eventClass = "org.bukkit.event.Event";
 
         when(fixture.worldActions().handleNewWorld(any(NewWorldCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-1", Map.of()));
@@ -142,24 +154,57 @@ class AgentRequestDispatcherTest
             .thenReturn(AgentResponses.successResponse("request-15", Map.of()));
         when(fixture.worldActions().handleGetServerTick(any(GetServerTickCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-16", Map.of()));
+        when(fixture.playerActions().handleTeleportPlayer(any(TeleportPlayerCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-17", Map.of()));
+        when(fixture.worldActions().handleLoadChunk(any(LoadChunkCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-18", Map.of()));
+        when(fixture.worldActions().handleUnloadChunk(any(UnloadChunkCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-19", Map.of("unloaded", "true")));
+        when(fixture.worldActions().handleIsChunkLoaded(any(IsChunkLoadedCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-20", Map.of("loaded", "true")));
+        when(fixture.playerActions().handleGetPlayerInventory(any(GetPlayerInventoryCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-21", Map.of("inventoryJson", "[]")));
+        when(fixture.playerActions().handleDropItem(any(DropItemCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-22", Map.of("dropped", "false")));
+        when(fixture.eventCapture().getCapturedEvents(eq(eventClass)))
+            .thenReturn(List.of(Map.of("getEventName", "Event")));
 
         // execute
         fixture.dispatcher().handleRequestLine(toJson(new NewWorldCommand("request-1", "w", "NORMAL", "NORMAL", 0L)), true);
-        fixture.dispatcher().handleRequestLine(toJson(new ExecuteCommandCommand("request-2", "CONSOLE", "time set day")), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new ExecuteCommandCommand("request-2", "CONSOLE", "time set day")), true);
         fixture.dispatcher().handleRequestLine(toJson(new BlockTypeCommand("request-3", "world", 0, 64, 0)), true);
-        fixture.dispatcher().handleRequestLine(toJson(new SetBlockCommand("request-4", "world", 0, 64, 0, "stone")), true);
-        fixture.dispatcher().handleRequestLine(toJson(new CreatePlayerCommand("request-5", "bot", uuid, "world", null, null, null, null, null)), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new SetBlockCommand("request-4", "world", 0, 64, 0, "stone")), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new CreatePlayerCommand("request-5", "bot", uuid, "world", null, null, null, null, null)), true);
         fixture.dispatcher().handleRequestLine(toJson(new RemovePlayerCommand("request-6", uuid)), true);
-        fixture.dispatcher().handleRequestLine(toJson(new ExecutePlayerCommandCommand("request-7", uuid, "gamemode creative")), true);
-        fixture.dispatcher().handleRequestLine(toJson(new PlacePlayerBlockCommand("request-8", uuid, "stone", 0, 64, 0)), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new ExecutePlayerCommandCommand("request-7", uuid, "gamemode creative")), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new PlacePlayerBlockCommand("request-8", uuid, "stone", 0, 64, 0)), true);
         fixture.dispatcher().handleRequestLine(toJson(new LeftClickBlockCommand("request-9", uuid, 0, 64, 0, "UP")), true);
-        fixture.dispatcher().handleRequestLine(toJson(new RightClickBlockCommand("request-10", uuid, 0, 64, 0, "UP")), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new RightClickBlockCommand("request-10", uuid, 0, 64, 0, "UP")), true);
         fixture.dispatcher().handleRequestLine(toJson(new GetOpenMenuCommand("request-11", uuid)), true);
         fixture.dispatcher().handleRequestLine(toJson(new ClickMenuSlotCommand("request-12", uuid, 0, "LEFT")), true);
-        fixture.dispatcher().handleRequestLine(toJson(new DragMenuSlotsCommand("request-13", uuid, "stone", new int[]{0, 1})), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new DragMenuSlotsCommand("request-13", uuid, "stone", new int[]{0, 1})), true);
         fixture.dispatcher().handleRequestLine(toJson(new GetPlayerMessagesCommand("request-14", uuid)), true);
         fixture.dispatcher().handleRequestLine(toJson(new WaitTicksCommand("request-15", 0)), true);
         fixture.dispatcher().handleRequestLine(toJson(new GetServerTickCommand("request-16")), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new TeleportPlayerCommand("request-17", uuid, "world", 0, 64, 0)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new LoadChunkCommand("request-18", "world", 0, 0)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new UnloadChunkCommand("request-19", "world", 0, 0)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new IsChunkLoadedCommand("request-20", "world", 0, 0)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new GetPlayerInventoryCommand("request-21", uuid)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new DropItemCommand("request-22", uuid)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new RegisterEventListenerCommand("request-23", eventClass)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new GetCapturedEventsCommand("request-24", eventClass)), true);
+        fixture.dispatcher().handleRequestLine(toJson(new ClearCapturedEventsCommand("request-25", eventClass)), true);
+        fixture.dispatcher().handleRequestLine(
+            toJson(new UnregisterEventListenerCommand("request-26", eventClass)), true);
 
         // verify
         verify(fixture.worldActions()).handleNewWorld(any(NewWorldCommand.class));
@@ -178,6 +223,36 @@ class AgentRequestDispatcherTest
         verify(fixture.playerActions()).handleGetPlayerMessages(any(GetPlayerMessagesCommand.class));
         verify(fixture.worldActions()).handleWaitTicks(any(WaitTicksCommand.class));
         verify(fixture.worldActions()).handleGetServerTick(any(GetServerTickCommand.class));
+        verify(fixture.playerActions()).handleTeleportPlayer(any(TeleportPlayerCommand.class));
+        verify(fixture.worldActions()).handleLoadChunk(any(LoadChunkCommand.class));
+        verify(fixture.worldActions()).handleUnloadChunk(any(UnloadChunkCommand.class));
+        verify(fixture.worldActions()).handleIsChunkLoaded(any(IsChunkLoadedCommand.class));
+        verify(fixture.playerActions()).handleGetPlayerInventory(any(GetPlayerInventoryCommand.class));
+        verify(fixture.playerActions()).handleDropItem(any(DropItemCommand.class));
+        verify(fixture.eventCapture()).registerListener(eventClass);
+        verify(fixture.eventCapture()).getCapturedEvents(eventClass);
+        verify(fixture.eventCapture()).clearCapturedEvents(eventClass);
+        verify(fixture.eventCapture()).unregisterListener(eventClass);
+    }
+
+    @Test
+    void handleRequestLine_shouldReturnInvalidArgumentWhenEventClassIsNotValid()
+        throws Exception
+    {
+        // setup
+        final DispatcherFixture fixture = createDispatcherFixture();
+        doThrow(new IllegalArgumentException("Class 'java.lang.String' is not a Bukkit Event."))
+            .when(fixture.eventCapture()).registerListener("java.lang.String");
+        final String requestLine = toJson(new RegisterEventListenerCommand("request-event", "java.lang.String"));
+
+        // execute
+        final AgentRequestDispatcher.RequestDispatchResult result =
+            fixture.dispatcher().handleRequestLine(requestLine, true);
+
+        // verify
+        assertThat(result.response().success()).isFalse();
+        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(result.response().errorMessage()).contains("not a Bukkit Event");
     }
 
     @Test
@@ -311,12 +386,14 @@ class AgentRequestDispatcherTest
             objectMapper,
             nmsAdapter
         );
+        final AgentEventCapture eventCapture = mock();
 
         return new AgentRequestDispatcher(
             objectMapper,
             worldActions,
             playerActions,
             menuActions,
+            eventCapture,
             Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
             authToken,
             protocolVersion,
@@ -331,24 +408,27 @@ class AgentRequestDispatcherTest
         final AgentWorldActions worldActions = mock();
         final AgentPlayerActions playerActions = mock();
         final AgentMenuActions menuActions = mock();
+        final AgentEventCapture eventCapture = mock();
         final AgentRequestDispatcher dispatcher = new AgentRequestDispatcher(
             objectMapper,
             worldActions,
             playerActions,
             menuActions,
+            eventCapture,
             Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
             "token",
             1,
             ""
         );
-        return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions);
+        return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions, eventCapture);
     }
 
     private record DispatcherFixture(
         AgentRequestDispatcher dispatcher,
         AgentWorldActions worldActions,
         AgentPlayerActions playerActions,
-        AgentMenuActions menuActions)
+        AgentMenuActions menuActions,
+        AgentEventCapture eventCapture)
     {
     }
 

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -461,10 +461,12 @@ class AgentRequestDispatcherTest
             playerActions,
             menuActions,
             eventActions,
-            Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
-            authToken,
-            protocolVersion,
-            expectedSha
+            new AgentRequestDispatcher.Config(
+                authToken,
+                protocolVersion,
+                expectedSha,
+                Logger.getLogger(AgentRequestDispatcherTest.class.getName())
+            )
         );
     }
 
@@ -482,10 +484,12 @@ class AgentRequestDispatcherTest
             playerActions,
             menuActions,
             eventActions,
-            Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
-            "token",
-            1,
-            ""
+            new AgentRequestDispatcher.Config(
+                "token",
+                1,
+                "",
+                Logger.getLogger(AgentRequestDispatcherTest.class.getName())
+            )
         );
         return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions, eventActions);
     }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
@@ -54,6 +54,7 @@ class AgentSyntheticPlayerStoreTest
         final PermissionAttachment attachment = mock();
         final UUID uuid = UUID.randomUUID();
         when(player.addAttachment(plugin)).thenReturn(attachment);
+        store.registerSyntheticPlayer(uuid, player);
 
         // execute
         store.setPermissions(plugin, uuid, player, "perm.one, perm.two, ,perm.three");
@@ -75,6 +76,7 @@ class AgentSyntheticPlayerStoreTest
         final PermissionAttachment attachment = mock();
         final UUID uuid = UUID.randomUUID();
         when(player.addAttachment(plugin)).thenReturn(attachment);
+        store.registerSyntheticPlayer(uuid, player);
         store.setPermissions(plugin, uuid, player, "perm.one");
 
         // execute
@@ -92,6 +94,7 @@ class AgentSyntheticPlayerStoreTest
         final Player player = mock();
         final UUID uuid = UUID.randomUUID();
         when(player.getUniqueId()).thenReturn(uuid);
+        store.registerSyntheticPlayer(uuid, player);
 
         // execute
         store.sendTrackedMessage(player, "hello");
@@ -111,6 +114,7 @@ class AgentSyntheticPlayerStoreTest
         when(adapter.drainReceivedMessages(uuid)).thenReturn(List.of("first", "second"));
         final Player player = mock();
         when(player.getUniqueId()).thenReturn(uuid);
+        store.registerSyntheticPlayer(uuid, player);
         store.sendTrackedMessage(player, "existing");
 
         // execute
@@ -118,6 +122,45 @@ class AgentSyntheticPlayerStoreTest
 
         // verify
         assertThat(store.getPlayerMessages(uuid)).containsExactly("existing", "first", "second");
+    }
+
+    @Test
+    void capturePlayerChatComponents_shouldAppendDrainedComponents()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final IBotPlayerNmsAdapter adapter = mock();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(adapter.drainChatComponents(uuid)).thenReturn(List.of("{\"text\":\"hello\"}"));
+        store.registerSyntheticPlayer(uuid, player);
+
+        // execute
+        store.capturePlayerChatComponents(adapter, uuid);
+
+        // verify
+        assertThat(store.getPlayerChatComponents(uuid)).containsExactly("{\"text\":\"hello\"}");
+    }
+
+    @Test
+    void capturePlayerChatComponents_shouldKeepHistoryWhenNoComponentsWereDrained()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final IBotPlayerNmsAdapter adapter = mock();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(adapter.drainChatComponents(uuid))
+            .thenReturn(List.of("{\"text\":\"hello\"}"))
+            .thenReturn(List.of());
+        store.registerSyntheticPlayer(uuid, player);
+        store.capturePlayerChatComponents(adapter, uuid);
+
+        // execute
+        store.capturePlayerChatComponents(adapter, uuid);
+
+        // verify
+        assertThat(store.getPlayerChatComponents(uuid)).containsExactly("{\"text\":\"hello\"}");
     }
 
     @Test
@@ -137,5 +180,51 @@ class AgentSyntheticPlayerStoreTest
         assertThat(store.getPlayerMessages(uuid)).isEmpty();
         assertThatThrownBy(() -> store.getRequiredPlayer(uuid))
             .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void capturePlayerMessages_shouldNotAppendWhenDrainReturnsEmpty()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final IBotPlayerNmsAdapter adapter = mock();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(adapter.drainReceivedMessages(uuid)).thenReturn(List.of());
+        store.registerSyntheticPlayer(uuid, player);
+        store.sendTrackedMessage(player, "existing");
+
+        // execute
+        store.capturePlayerMessages(adapter, uuid);
+
+        // verify - history unchanged when drain is empty
+        assertThat(store.getPlayerMessages(uuid)).containsExactly("existing");
+    }
+
+    @Test
+    void removePermissionAttachment_shouldBeNoOpWhenNoAttachmentWasSet()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+
+        // execute + verify - should not throw
+        store.removePermissionAttachment(uuid, player);
+        verifyNoInteractions(player);
+    }
+
+    @Test
+    void getPlayerChatComponents_shouldReturnEmptyListForUnknownPlayer()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+
+        // execute
+        final List<String> components = store.getPlayerChatComponents(UUID.randomUUID());
+
+        // verify
+        assertThat(components).isEmpty();
     }
 }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
@@ -2,9 +2,15 @@ package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTickCommand;
+import nl.pim16aap2.lightkeeper.protocol.IsChunkLoadedCommand;
+import nl.pim16aap2.lightkeeper.protocol.LoadChunkCommand;
+import nl.pim16aap2.lightkeeper.protocol.UnloadChunkCommand;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicksCommand;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -71,6 +77,75 @@ class AgentWorldActionsTest
         assertThat(response.success()).isTrue();
         assertThat(response.data()).containsEntry("startTick", "9");
         assertThat(response.data()).containsEntry("endTick", "9");
+    }
+
+    @Test
+    void handleLoadChunk_shouldLoadRequestedChunk()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleLoadChunk(new LoadChunkCommand("request-load", "world", 2, 3));
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("loaded", "true");
+        verify(world).loadChunk(2, 3, true);
+    }
+
+    @Test
+    void handleUnloadChunk_shouldReturnWorldUnloadResult()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        when(world.unloadChunk(4, 5)).thenReturn(false);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleUnloadChunk(new UnloadChunkCommand("request-unload", "world", 4, 5));
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("unloaded", "false");
+    }
+
+    @Test
+    void handleIsChunkLoaded_shouldReturnWorldLoadedResult()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        when(world.isChunkLoaded(6, 7)).thenReturn(true);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleIsChunkLoaded(new IsChunkLoadedCommand("request-loaded", "world", 6, 7));
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("loaded", "true");
     }
 
     private static AgentWorldActions createWorldActions(AtomicLong tickCounter)

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
@@ -1,12 +1,16 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
+import nl.pim16aap2.lightkeeper.protocol.ExecuteCommandCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTickCommand;
 import nl.pim16aap2.lightkeeper.protocol.IsChunkLoadedCommand;
 import nl.pim16aap2.lightkeeper.protocol.LoadChunkCommand;
+import nl.pim16aap2.lightkeeper.protocol.NewWorldCommand;
+import nl.pim16aap2.lightkeeper.protocol.SetBlockCommand;
 import nl.pim16aap2.lightkeeper.protocol.UnloadChunkCommand;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicksCommand;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,8 @@ import org.mockito.MockedStatic;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class AgentWorldActionsTest
@@ -46,6 +52,42 @@ class AgentWorldActionsTest
         // verify
         assertThat(response.success()).isTrue();
         assertThat(response.data()).containsEntry("tick", "17");
+    }
+
+    @Test
+    void detectServerPlatform_shouldTreatCraftBukkitServerClassAsSpigot()
+    {
+        // setup
+        final String serverClassName = "org.bukkit.craftbukkit.v1_21_R7.CraftServer";
+
+        // execute
+        final String result = AgentPlatformDetector.detect(
+            "CraftBukkit",
+            "1.21.11-R0.1-SNAPSHOT",
+            serverClassName,
+            false
+        );
+
+        // verify
+        assertThat(result).isEqualTo("SPIGOT");
+    }
+
+    @Test
+    void detectServerPlatform_shouldPreferPaperWhenPaperClassIsPresent()
+    {
+        // setup
+        final String serverClassName = "org.bukkit.craftbukkit.v1_21_R7.CraftServer";
+
+        // execute
+        final String result = AgentPlatformDetector.detect(
+            "CraftBukkit",
+            "1.21.11-R0.1-SNAPSHOT",
+            serverClassName,
+            true
+        );
+
+        // verify
+        assertThat(result).isEqualTo("PAPER");
     }
 
     @Test
@@ -146,6 +188,197 @@ class AgentWorldActionsTest
         // verify
         assertThat(response.success()).isTrue();
         assertThat(response.data()).containsEntry("loaded", "true");
+    }
+
+    @Test
+    void detectServerPlatform_shouldPreferPaperClassSignal()
+    {
+        // execute
+        final String platform = AgentPlatformDetector.detect(
+            "CraftBukkit",
+            "git-Spigot-abc",
+            "org.bukkit.craftbukkit.CraftServer",
+            true
+        );
+
+        // verify
+        assertThat(platform).isEqualTo("PAPER");
+    }
+
+    @Test
+    void detectServerPlatform_shouldMapCraftBukkitServerToSpigot()
+    {
+        // execute
+        final String platform = AgentPlatformDetector.detect(
+            "CraftBukkit",
+            "1.21.11-R0.1-SNAPSHOT",
+            "org.bukkit.craftbukkit.CraftServer",
+            false
+        );
+
+        // verify
+        assertThat(platform).isEqualTo("SPIGOT");
+    }
+
+    @Test
+    void detectServerPlatform_shouldReturnUnknownWhenNeitherPaperNorSpigotIdentifiersFound()
+    {
+        // execute
+        final String platform = AgentPlatformDetector.detect(
+            "SomeOtherServer",
+            "1.21.11-R0.1-SNAPSHOT",
+            "com.someother.SomeServer",
+            false
+        );
+
+        // verify
+        assertThat(platform).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    void detectServerPlatform_shouldReturnPaperWhenBukkitNameContainsPaper()
+    {
+        // execute
+        final String platform = AgentPlatformDetector.detect(
+            "Paper",
+            "1.21.11-R0.1-SNAPSHOT",
+            "com.someserver.SomeServer",
+            false
+        );
+
+        // verify
+        assertThat(platform).isEqualTo("PAPER");
+    }
+
+    @Test
+    void detectServerPlatform_shouldReturnSpigotWhenVersionContainsSpigot()
+    {
+        // execute
+        final String platform = AgentPlatformDetector.detect(
+            "CraftBukkit",
+            "git-Spigot-1.21.11-R0.1",
+            "com.someserver.SomeServer",
+            false
+        );
+
+        // verify
+        assertThat(platform).isEqualTo("SPIGOT");
+    }
+
+    @Test
+    void handleWaitTicks_shouldReturnInterruptedWhenThreadIsInterrupted()
+        throws Exception
+    {
+        // setup
+        final AtomicLong tickCounter = new AtomicLong(0L);
+        final AgentWorldActions worldActions = createWorldActions(tickCounter);
+        final java.util.concurrent.atomic.AtomicReference<AgentResponse>
+            responseRef = new java.util.concurrent.atomic.AtomicReference<>();
+
+        // execute - run in a thread and interrupt it while waiting for ticks
+        final Thread waitingThread = Thread.ofPlatform().unstarted(() ->
+            responseRef.set(worldActions.handleWaitTicks(new WaitTicksCommand("request-interrupted", 1000)))
+        );
+        waitingThread.start();
+        Thread.sleep(50);
+        waitingThread.interrupt();
+        waitingThread.join(2000);
+
+        // verify
+        final AgentResponse response = responseRef.get();
+        assertThat(response).isNotNull();
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INTERRUPTED");
+    }
+
+    @Test
+    void handleExecuteCommand_shouldReturnErrorWhenCommandIsBlank()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+
+        // execute
+        final AgentResponse response =
+            worldActions.handleExecuteCommand(new ExecuteCommandCommand("request-blank", "CONSOLE", "   "));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("command");
+    }
+
+    @Test
+    void handleExecuteCommand_shouldReturnErrorWhenSourceIsNotConsole()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+
+        // execute
+        final AgentResponse response =
+            worldActions.handleExecuteCommand(new ExecuteCommandCommand("request-source", "PLAYER", "help"));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("UNSUPPORTED_SOURCE");
+    }
+
+    @Test
+    void handleNewWorld_shouldReturnErrorWhenWorldNameIsBlank()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+
+        // execute
+        final AgentResponse response =
+            worldActions.handleNewWorld(new NewWorldCommand("request-blank-world", "   ", "NORMAL", "NORMAL", 0L));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("worldName");
+    }
+
+    @Test
+    void handleSetBlock_shouldReturnErrorWhenMaterialIsBlank()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+
+        // execute
+        final AgentResponse response =
+            worldActions.handleSetBlock(new SetBlockCommand("request-blank-mat", "world", 0, 64, 0, "   "));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+    }
+
+    @Test
+    void handleSetBlock_shouldReturnErrorWhenMaterialIsUnknown()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class);
+             MockedStatic<Material> materialMockedStatic = mockStatic(Material.class))
+        {
+            materialMockedStatic.when(() -> Material.matchMaterial(anyString(), eq(true))).thenReturn(null);
+            response = worldActions.handleSetBlock(
+                new SetBlockCommand("request-unknown-mat", "world", 0, 64, 0, "not_a_material")
+            );
+        }
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("Unknown material");
     }
 
     private static AgentWorldActions createWorldActions(AtomicLong tickCounter)

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
@@ -80,12 +80,13 @@ class AgentWorldActionsTest
     }
 
     @Test
-    void handleLoadChunk_shouldLoadRequestedChunk()
+    void handleLoadChunk_shouldReturnWorldLoadResult()
         throws Exception
     {
         // setup
         final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
         final World world = mock();
+        when(world.loadChunk(2, 3, true)).thenReturn(true);
 
         // execute
         final AgentResponse response;
@@ -100,6 +101,29 @@ class AgentWorldActionsTest
         assertThat(response.success()).isTrue();
         assertThat(response.data()).containsEntry("loaded", "true");
         verify(world).loadChunk(2, 3, true);
+    }
+
+    @Test
+    void handleLoadChunk_shouldReturnFalseWhenLoadFails()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        when(world.loadChunk(2, 3, true)).thenReturn(false);
+
+        // execute
+        final AgentResponse response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleLoadChunk(new LoadChunkCommand("request-load", "world", 2, 3));
+        }
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).containsEntry("loaded", "false");
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshot.java
@@ -1,0 +1,18 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import java.util.Map;
+
+/**
+ * Snapshot of a captured Bukkit event.
+ *
+ * @param eventClassName
+ *     The full class name of the event.
+ * @param data
+ *     The captured event data (getter/is-method results).
+ */
+public record CapturedEventSnapshot(
+    String eventClassName,
+    Map<String, String> data
+)
+{
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ChatComponentSnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ChatComponentSnapshot.java
@@ -1,0 +1,13 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+/**
+ * Snapshot of a chat component.
+ *
+ * @param json
+ *     The raw JSON representation of the component.
+ */
+public record ChatComponentSnapshot(
+    String json
+)
+{
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandle.java
@@ -1,0 +1,49 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Handle for a dynamic event capture session.
+ */
+public final class EventCaptureHandle implements AutoCloseable
+{
+    private final IFrameworkGatewayView frameworkGateway;
+    private final String eventClassName;
+
+    EventCaptureHandle(IFrameworkGatewayView frameworkGateway, String eventClassName)
+    {
+        this.frameworkGateway = Objects.requireNonNull(frameworkGateway, "frameworkGateway");
+        this.eventClassName = Objects.requireNonNull(eventClassName, "eventClassName");
+    }
+
+    /**
+     * Gets all captured events since the last clear or registration.
+     *
+     * @return List of captured event snapshots.
+     */
+    public List<CapturedEventSnapshot> getCapturedEvents()
+    {
+        return frameworkGateway.getCapturedEvents(eventClassName);
+    }
+
+    /**
+     * Clears all captured events for this session.
+     *
+     * @return This handle for fluent chaining.
+     */
+    public EventCaptureHandle clear()
+    {
+        frameworkGateway.clearCapturedEvents(eventClassName);
+        return this;
+    }
+
+    /**
+     * Stops capturing events and unregisters the listener.
+     */
+    @Override
+    public void close()
+    {
+        frameworkGateway.unregisterEventListener(eventClassName);
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/FrameworkHandleFactory.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/FrameworkHandleFactory.java
@@ -36,4 +36,12 @@ public final class FrameworkHandleFactory
     {
         return new MenuHandle(frameworkGateway, playerHandle);
     }
+
+    /**
+     * Creates an event capture handle.
+     */
+    public static EventCaptureHandle eventCaptureHandle(IFrameworkGatewayView frameworkGateway, String eventClassName)
+    {
+        return new EventCaptureHandle(frameworkGateway, eventClassName);
+    }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -98,6 +98,11 @@ public interface IFrameworkGatewayView
     List<String> playerMessages(UUID playerId);
 
     /**
+     * Gets captured chat components for a player.
+     */
+    List<ChatComponentSnapshot> playerChatComponents(UUID playerId);
+
+    /**
      * Gets player inventory snapshot.
      */
     InventorySnapshot playerInventory(UUID playerId);

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -29,8 +29,10 @@ public interface IFrameworkGatewayView
 
     /**
      * Teleports a synthetic player.
+     *
+     * @return True if the teleport succeeded, false if it was blocked (e.g. a cancelled teleport event).
      */
-    void teleportPlayer(UUID uuid, String worldName, double x, double y, double z);
+    boolean teleportPlayer(UUID uuid, String worldName, double x, double y, double z);
 
     /**
      * Places a block as a synthetic player.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -96,4 +96,34 @@ public interface IFrameworkGatewayView
      * Gets received message history for a player.
      */
     List<String> playerMessages(UUID playerId);
+
+    /**
+     * Gets player inventory snapshot.
+     */
+    InventorySnapshot playerInventory(UUID playerId);
+
+    /**
+     * Drops item from player's main hand.
+     */
+    boolean dropItem(UUID playerId);
+
+    /**
+     * Registers an event listener.
+     */
+    void registerEventListener(String eventClassName);
+
+    /**
+     * Gets captured events for a class.
+     */
+    List<CapturedEventSnapshot> getCapturedEvents(String eventClassName);
+
+    /**
+     * Clears captured events for a class.
+     */
+    void clearCapturedEvents(String eventClassName);
+
+    /**
+     * Unregisters an event listener.
+     */
+    void unregisterEventListener(String eventClassName);
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -39,8 +39,10 @@ public interface IFrameworkGatewayView
 
     /**
      * Loads a chunk.
+     *
+     * @return True if the chunk was loaded successfully.
      */
-    void loadChunk(String worldName, int x, int z);
+    boolean loadChunk(String worldName, int x, int z);
 
     /**
      * Unloads a chunk.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -28,9 +28,29 @@ public interface IFrameworkGatewayView
     void executePlayerCommand(UUID playerId, String command);
 
     /**
+     * Teleports a synthetic player.
+     */
+    void teleportPlayer(UUID uuid, String worldName, double x, double y, double z);
+
+    /**
      * Places a block as a synthetic player.
      */
     void placePlayerBlock(UUID playerId, String material, int x, int y, int z);
+
+    /**
+     * Loads a chunk.
+     */
+    void loadChunk(String worldName, int x, int z);
+
+    /**
+     * Unloads a chunk.
+     */
+    boolean unloadChunk(String worldName, int x, int z);
+
+    /**
+     * Checks if a chunk is loaded.
+     */
+    boolean isChunkLoaded(String worldName, int x, int z);
 
     /**
      * Fires a left-click block interaction as a synthetic player.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
@@ -108,6 +108,15 @@ public interface ILightkeeperFramework extends AutoCloseable
      */
     void restartServer();
 
+    /**
+     * Starts capturing Bukkit events of the specified type.
+     *
+     * @param eventClassName
+     *     The full class name of the event to capture (e.g. "org.bukkit.event.player.PlayerMoveEvent").
+     * @return A handle to manage the capture session.
+     */
+    EventCaptureHandle captureEvents(String eventClassName);
+
     @Override
     void close();
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
@@ -99,6 +99,13 @@ public interface ILightkeeperFramework extends AutoCloseable
     List<String> serverOutput();
 
     /**
+     * Gets the server platform (e.g. PAPER, SPIGOT).
+     *
+     * @return Server platform.
+     */
+    Platform platform();
+
+    /**
      * Crashes the Minecraft server immediately.
      */
     void crashServer();

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/InventorySnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/InventorySnapshot.java
@@ -1,0 +1,29 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import java.util.List;
+
+/**
+ * Snapshot of a player's inventory.
+ *
+ * @param items
+ *     List of non-air item snapshots in the inventory.
+ */
+public record InventorySnapshot(
+    List<MenuItemSnapshot> items
+)
+{
+    /**
+     * Finds an item in the inventory by material key.
+     *
+     * @param materialKey
+     *     The material key to look for (e.g. "minecraft:stone").
+     * @return The item snapshot, or null if not found.
+     */
+    public MenuItemSnapshot findItem(String materialKey)
+    {
+        return items.stream()
+            .filter(item -> item.materialKey().equalsIgnoreCase(materialKey))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/InventorySnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/InventorySnapshot.java
@@ -1,6 +1,10 @@
 package nl.pim16aap2.lightkeeper.framework;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Snapshot of a player's inventory.
@@ -13,14 +17,49 @@ public record InventorySnapshot(
 )
 {
     /**
+     * Creates a snapshot with a defensive immutable copy of the item list.
+     */
+    public InventorySnapshot
+    {
+        items = List.copyOf(Objects.requireNonNull(items, "items may not be null."));
+    }
+
+    /**
+     * Creates an {@link InventorySnapshot} from the raw item-map list returned by the agent RPC.
+     *
+     * <p>Each map must contain {@code slot} (Number), {@code materialKey} (String), optionally
+     * {@code displayName} (String), and optionally {@code lore} (List&lt;String&gt;).
+     *
+     * @param itemMaps
+     *     Raw item maps from {@code UdsAgentClient#getPlayerInventory}.
+     * @return
+     *     Inventory snapshot.
+     */
+    @SuppressWarnings("unchecked")
+    public static InventorySnapshot fromItemMaps(List<Map<String, Object>> itemMaps)
+    {
+        Objects.requireNonNull(itemMaps, "itemMaps may not be null.");
+        final List<MenuItemSnapshot> items = itemMaps.stream().map(m ->
+        {
+            final int slot = ((Number) m.get("slot")).intValue();
+            final String materialKey = (String) m.getOrDefault("materialKey", "");
+            final String displayName = (String) m.getOrDefault("displayName", "");
+            final List<String> lore = (List<String>) m.getOrDefault("lore", List.of());
+            return new MenuItemSnapshot(slot, materialKey, displayName == null ? "" : displayName, lore);
+        }).toList();
+        return new InventorySnapshot(items);
+    }
+
+    /**
      * Finds an item in the inventory by material key.
      *
      * @param materialKey
      *     The material key to look for (e.g. "minecraft:stone").
      * @return The item snapshot, or null if not found.
      */
-    public MenuItemSnapshot findItem(String materialKey)
+    public @Nullable MenuItemSnapshot findItem(String materialKey)
     {
+        Objects.requireNonNull(materialKey, "materialKey may not be null.");
         return items.stream()
             .filter(item -> item.materialKey().equalsIgnoreCase(materialKey))
             .findFirst()

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/Platform.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/Platform.java
@@ -1,0 +1,11 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+/**
+ * Supported Minecraft server platforms.
+ */
+public enum Platform
+{
+    PAPER,
+    SPIGOT,
+    UNKNOWN
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -73,6 +73,26 @@ public final class PlayerHandle
     }
 
     /**
+     * Teleports this player to target coordinates in a world.
+     *
+     * @param world
+     *     Target world.
+     * @param x
+     *     X coordinate.
+     * @param y
+     *     Y coordinate.
+     * @param z
+     *     Z coordinate.
+     * @return This handle for fluent chaining.
+     */
+    public PlayerHandle teleport(WorldHandle world, double x, double y, double z)
+    {
+        Objects.requireNonNull(world, "world may not be null.");
+        frameworkGateway.teleportPlayer(uniqueId, world.name(), x, y, z);
+        return this;
+    }
+
+    /**
      * Places a block from this player perspective.
      *
      * @param materialKey

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -206,6 +206,26 @@ public final class PlayerHandle
     }
 
     /**
+     * Gets a snapshot of this player's inventory.
+     *
+     * @return Inventory snapshot.
+     */
+    public InventorySnapshot inventory()
+    {
+        return frameworkGateway.playerInventory(uniqueId);
+    }
+
+    /**
+     * Simulates the player dropping their main hand item.
+     *
+     * @return True if the drop event was cancelled.
+     */
+    public boolean dropMainHandItem()
+    {
+        return frameworkGateway.dropItem(uniqueId);
+    }
+
+    /**
      * Waits for at least the requested number of server ticks.
      *
      * @param ticks

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -83,13 +83,12 @@ public final class PlayerHandle
      *     Y coordinate.
      * @param z
      *     Z coordinate.
-     * @return This handle for fluent chaining.
+     * @return True if the teleport succeeded, false if it was blocked (e.g. a cancelled teleport event).
      */
-    public PlayerHandle teleport(WorldHandle world, double x, double y, double z)
+    public boolean teleport(WorldHandle world, double x, double y, double z)
     {
         Objects.requireNonNull(world, "world may not be null.");
-        frameworkGateway.teleportPlayer(uniqueId, world.name(), x, y, z);
-        return this;
+        return frameworkGateway.teleportPlayer(uniqueId, world.name(), x, y, z);
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -294,6 +294,16 @@ public final class PlayerHandle
     }
 
     /**
+     * Gets a list of captured chat components for this player.
+     *
+     * @return Captured chat components.
+     */
+    public List<ChatComponentSnapshot> chatComponents()
+    {
+        return frameworkGateway.playerChatComponents(uniqueId);
+    }
+
+    /**
      * Gets all recorded messages flattened into a single multi-line string.
      *
      * @return Received messages joined with line separators.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -218,7 +218,9 @@ public final class PlayerHandle
     /**
      * Simulates the player dropping their main hand item.
      *
-     * @return True if the drop event was cancelled.
+     * @return {@code true} when no plugin cancelled the drop event (i.e., the item would have been dropped
+     *     in production). Note: the item entity is always created and removed to satisfy the Bukkit API
+     *     constraint; this return value reflects whether a plugin would have allowed the drop.
      */
     public boolean dropMainHandItem()
     {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -83,12 +83,18 @@ public final class PlayerHandle
      *     Y coordinate.
      * @param z
      *     Z coordinate.
-     * @return True if the teleport succeeded, false if it was blocked (e.g. a cancelled teleport event).
+     * @return This handle for fluent chaining.
+     * @throws IllegalStateException
+     *     If the server rejected the teleport (e.g. a plugin cancelled the teleport event).
      */
-    public boolean teleport(WorldHandle world, double x, double y, double z)
+    public PlayerHandle teleport(WorldHandle world, double x, double y, double z)
     {
         Objects.requireNonNull(world, "world may not be null.");
-        return frameworkGateway.teleportPlayer(uniqueId, world.name(), x, y, z);
+        if (!frameworkGateway.teleportPlayer(uniqueId, world.name(), x, y, z))
+            throw new IllegalStateException(
+                "Teleport of player '%s' to [%.2f, %.2f, %.2f] in world '%s' was rejected by the server.".formatted(
+                    name, x, y, z, world.name()));
+        return this;
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
@@ -63,11 +63,16 @@ public final class WorldHandle
      *     Chunk X coordinate.
      * @param chunkZ
      *     Chunk Z coordinate.
-     * @return True if the chunk was loaded successfully.
+     * @return This handle for fluent chaining.
+     * @throws IllegalStateException
+     *     If the server failed to load the chunk.
      */
-    public boolean loadChunk(int chunkX, int chunkZ)
+    public WorldHandle loadChunk(int chunkX, int chunkZ)
     {
-        return frameworkGateway.loadChunk(name, chunkX, chunkZ);
+        if (!frameworkGateway.loadChunk(name, chunkX, chunkZ))
+            throw new IllegalStateException(
+                "Failed to load chunk [%d, %d] in world '%s'.".formatted(chunkX, chunkZ, name));
+        return this;
     }
 
     /**
@@ -77,11 +82,17 @@ public final class WorldHandle
      *     Chunk X coordinate.
      * @param chunkZ
      *     Chunk Z coordinate.
-     * @return True if the chunk was successfully unloaded.
+     * @return This handle for fluent chaining.
+     * @throws IllegalStateException
+     *     If the server refused to unload the chunk (e.g. because it is still in use).
      */
-    public boolean unloadChunk(int chunkX, int chunkZ)
+    public WorldHandle unloadChunk(int chunkX, int chunkZ)
     {
-        return frameworkGateway.unloadChunk(name, chunkX, chunkZ);
+        if (!frameworkGateway.unloadChunk(name, chunkX, chunkZ))
+            throw new IllegalStateException(
+                "Failed to unload chunk [%d, %d] in world '%s'; the chunk may still be in use.".formatted(
+                    chunkX, chunkZ, name));
+        return this;
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
@@ -55,4 +55,47 @@ public final class WorldHandle
         Objects.requireNonNull(position, "position may not be null.");
         frameworkGateway.setBlock(name, position, material);
     }
+
+    /**
+     * Loads a chunk.
+     *
+     * @param chunkX
+     *     Chunk X coordinate.
+     * @param chunkZ
+     *     Chunk Z coordinate.
+     * @return This handle for fluent chaining.
+     */
+    public WorldHandle loadChunk(int chunkX, int chunkZ)
+    {
+        frameworkGateway.loadChunk(name, chunkX, chunkZ);
+        return this;
+    }
+
+    /**
+     * Unloads a chunk.
+     *
+     * @param chunkX
+     *     Chunk X coordinate.
+     * @param chunkZ
+     *     Chunk Z coordinate.
+     * @return True if the chunk was successfully unloaded.
+     */
+    public boolean unloadChunk(int chunkX, int chunkZ)
+    {
+        return frameworkGateway.unloadChunk(name, chunkX, chunkZ);
+    }
+
+    /**
+     * Checks if a chunk is loaded.
+     *
+     * @param chunkX
+     *     Chunk X coordinate.
+     * @param chunkZ
+     *     Chunk Z coordinate.
+     * @return True if the chunk is loaded.
+     */
+    public boolean isChunkLoaded(int chunkX, int chunkZ)
+    {
+        return frameworkGateway.isChunkLoaded(name, chunkX, chunkZ);
+    }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
@@ -57,18 +57,17 @@ public final class WorldHandle
     }
 
     /**
-     * Loads a chunk.
+     * Loads a chunk, generating it if it does not exist yet.
      *
      * @param chunkX
      *     Chunk X coordinate.
      * @param chunkZ
      *     Chunk Z coordinate.
-     * @return This handle for fluent chaining.
+     * @return True if the chunk was loaded successfully.
      */
-    public WorldHandle loadChunk(int chunkX, int chunkZ)
+    public boolean loadChunk(int chunkX, int chunkZ)
     {
-        frameworkGateway.loadChunk(name, chunkX, chunkZ);
-        return this;
+        return frameworkGateway.loadChunk(name, chunkX, chunkZ);
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperFrameworkAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperFrameworkAssert.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.lightkeeper.framework.assertions;
 
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.Platform;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
@@ -28,6 +29,32 @@ public final class LightkeeperFrameworkAssert
     public ListAssert<String> serverOutput()
     {
         return Assertions.assertThat(nonNullActual().serverOutput());
+    }
+
+    /**
+     * Asserts that the server is running on Paper.
+     *
+     * @return This assertion for fluent chaining.
+     */
+    public LightkeeperFrameworkAssert isPaper()
+    {
+        final var actual = nonNullActual();
+        if (actual.platform() != Platform.PAPER)
+            failWithMessage("Expected server platform to be PAPER but was %s.", actual.platform());
+        return this;
+    }
+
+    /**
+     * Asserts that the server is running on Spigot.
+     *
+     * @return This assertion for fluent chaining.
+     */
+    public LightkeeperFrameworkAssert isSpigot()
+    {
+        final var actual = nonNullActual();
+        if (actual.platform() != Platform.SPIGOT)
+            failWithMessage("Expected server platform to be SPIGOT but was %s.", actual.platform());
+        return this;
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
@@ -88,6 +88,27 @@ public final class PlayerHandleAssert extends AbstractAssert<PlayerHandleAssert,
     }
 
     /**
+     * Asserts that at least one captured chat component contains clickable text matching the fragment.
+     *
+     * @param expectedText
+     *     Required text fragment that should be clickable.
+     * @return This assertion for fluent chaining.
+     */
+    public PlayerHandleAssert hasClickableChatText(String expectedText)
+    {
+        final var actual = nonNullActual();
+        final boolean found = actual.chatComponents().stream()
+            .anyMatch(component -> component.json().contains(expectedText) &&
+                component.json().contains("clickEvent"));
+        if (!found)
+        {
+            failWithMessage("Expected player '%s' to receive clickable chat text matching '%s', but none was found.",
+                actual.name(), expectedText);
+        }
+        return this;
+    }
+
+    /**
      * Returns an AssertJ string assertion over all received messages concatenated into one text block.
      *
      * @return AssertJ string assertion.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
@@ -1,11 +1,14 @@
 package nl.pim16aap2.lightkeeper.framework.assertions;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -97,13 +100,28 @@ public final class PlayerHandleAssert extends AbstractAssert<PlayerHandleAssert,
     public PlayerHandleAssert hasClickableChatText(String expectedText)
     {
         final var actual = nonNullActual();
-        final boolean found = actual.chatComponents().stream()
-            .anyMatch(component -> component.json().contains(expectedText) &&
-                component.json().contains("clickEvent"));
+        final ObjectMapper mapper = new ObjectMapper();
+        final boolean found = actual.chatComponents().stream().anyMatch(component ->
+        {
+            if (!component.json().contains(expectedText))
+                return false;
+            try
+            {
+                final JsonNode root = mapper.readTree(component.json());
+                return root.has("clickEvent");
+            }
+            catch (IOException ignored)
+            {
+                return false;
+            }
+        });
         if (!found)
         {
-            failWithMessage("Expected player '%s' to receive clickable chat text matching '%s', but none was found.",
-                actual.name(), expectedText);
+            failWithMessage(
+                "Expected player '%s' to have a clickable chat text matching '%s', "
+                    + "but no component with a top-level clickEvent field and that text was found.",
+                actual.name(), expectedText
+            );
         }
         return this;
     }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
@@ -34,6 +34,44 @@ public final class PlayerHandleAssert extends AbstractAssert<PlayerHandleAssert,
     }
 
     /**
+     * Asserts that the player has an item with the specified material in their inventory.
+     *
+     * @param materialKey
+     *     Material key (e.g. "minecraft:stone").
+     * @return This assertion for fluent chaining.
+     */
+    public PlayerHandleAssert hasItemInInventory(String materialKey)
+    {
+        final var actual = nonNullActual();
+        final var item = actual.inventory().findItem(materialKey);
+        if (item == null)
+        {
+            failWithMessage("Expected player '%s' to have item '%s' in inventory, but it was not found.",
+                actual.name(), materialKey);
+        }
+        return this;
+    }
+
+    /**
+     * Asserts that the player does not have an item with the specified material in their inventory.
+     *
+     * @param materialKey
+     *     Material key (e.g. "minecraft:stone").
+     * @return This assertion for fluent chaining.
+     */
+    public PlayerHandleAssert doesNotHaveItemInInventory(String materialKey)
+    {
+        final var actual = nonNullActual();
+        final var item = actual.inventory().findItem(materialKey);
+        if (item != null)
+        {
+            failWithMessage("Expected player '%s' to not have item '%s' in inventory, but it was found at slot %d.",
+                actual.name(), materialKey, item.slot());
+        }
+        return this;
+    }
+
+    /**
      * Asserts that at least one received message contains the requested text fragment.
      *
      * @param expectedFragment

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldHandleAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldHandleAssert.java
@@ -75,6 +75,46 @@ public final class WorldHandleAssert extends AbstractAssert<WorldHandleAssert, @
         return this;
     }
 
+    /**
+     * Asserts that a chunk is loaded at the target coordinates.
+     *
+     * @param chunkX
+     *     Chunk X coordinate.
+     * @param chunkZ
+     *     Chunk Z coordinate.
+     * @return This assertion for fluent chaining.
+     */
+    public WorldHandleAssert hasLoadedChunkAt(int chunkX, int chunkZ)
+    {
+        final var actual = nonNullActual();
+        if (!actual.isChunkLoaded(chunkX, chunkZ))
+        {
+            failWithMessage("Expected chunk [%d, %d] in world '%s' to be loaded, but it was not.",
+                chunkX, chunkZ, actual.name());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts that a chunk is not loaded at the target coordinates.
+     *
+     * @param chunkX
+     *     Chunk X coordinate.
+     * @param chunkZ
+     *     Chunk Z coordinate.
+     * @return This assertion for fluent chaining.
+     */
+    public WorldHandleAssert doesNotHaveLoadedChunkAt(int chunkX, int chunkZ)
+    {
+        final var actual = nonNullActual();
+        if (actual.isChunkLoaded(chunkX, chunkZ))
+        {
+            failWithMessage("Expected chunk [%d, %d] in world '%s' to be unloaded, but it was loaded.",
+                chunkX, chunkZ, actual.name());
+        }
+        return this;
+    }
+
     @SuppressWarnings({"NullAway", "DataFlowIssue"}) // we call isNotNull() first, so actual is not null after that
     private WorldHandle nonNullActual()
     {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -408,7 +408,7 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     {
         ensureOpen();
         Objects.requireNonNull(playerId, "playerId may not be null.");
-        return agentClient.playerInventory(playerId);
+        return InventorySnapshot.fromItemMaps(agentClient.getPlayerInventory(playerId));
     }
 
     @Override
@@ -430,7 +430,9 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     public List<CapturedEventSnapshot> getCapturedEvents(String eventClassName)
     {
         ensureOpen();
-        return agentClient.getCapturedEvents(eventClassName);
+        return agentClient.getCapturedEvents(eventClassName).stream()
+            .map(data -> new CapturedEventSnapshot(eventClassName, data))
+            .toList();
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -287,11 +287,11 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
-    public void loadChunk(String worldName, int x, int z)
+    public boolean loadChunk(String worldName, int x, int z)
     {
         ensureOpen();
         Objects.requireNonNull(worldName, "worldName may not be null.");
-        agentClient.loadChunk(worldName, x, z);
+        return agentClient.loadChunk(worldName, x, z);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
 import nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.CommandResult;
 import nl.pim16aap2.lightkeeper.framework.CommandSource;
 import nl.pim16aap2.lightkeeper.framework.Condition;
@@ -392,6 +393,14 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         ensureOpen();
         Objects.requireNonNull(playerId, "playerId may not be null.");
         return agentClient.playerMessages(playerId);
+    }
+
+    @Override
+    public List<ChatComponentSnapshot> playerChatComponents(UUID playerId)
+    {
+        ensureOpen();
+        Objects.requireNonNull(playerId, "playerId may not be null.");
+        return agentClient.playerChatComponents(playerId);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -267,6 +267,15 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
+    public void teleportPlayer(UUID uuid, String worldName, double x, double y, double z)
+    {
+        ensureOpen();
+        Objects.requireNonNull(uuid, "uuid may not be null.");
+        Objects.requireNonNull(worldName, "worldName may not be null.");
+        agentClient.teleportPlayer(uuid, worldName, x, y, z);
+    }
+
+    @Override
     public void placePlayerBlock(UUID playerId, String material, int x, int y, int z)
     {
         ensureOpen();
@@ -275,6 +284,30 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         if (trimmedMaterial.isEmpty())
             throw new IllegalArgumentException("material may not be blank.");
         agentClient.placePlayerBlock(playerId, trimmedMaterial, x, y, z);
+    }
+
+    @Override
+    public void loadChunk(String worldName, int x, int z)
+    {
+        ensureOpen();
+        Objects.requireNonNull(worldName, "worldName may not be null.");
+        agentClient.loadChunk(worldName, x, z);
+    }
+
+    @Override
+    public boolean unloadChunk(String worldName, int x, int z)
+    {
+        ensureOpen();
+        Objects.requireNonNull(worldName, "worldName may not be null.");
+        return agentClient.unloadChunk(worldName, x, z);
+    }
+
+    @Override
+    public boolean isChunkLoaded(String worldName, int x, int z)
+    {
+        ensureOpen();
+        Objects.requireNonNull(worldName, "worldName may not be null.");
+        return agentClient.isChunkLoaded(worldName, x, z);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -1,12 +1,15 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot;
 import nl.pim16aap2.lightkeeper.framework.CommandResult;
 import nl.pim16aap2.lightkeeper.framework.CommandSource;
 import nl.pim16aap2.lightkeeper.framework.Condition;
+import nl.pim16aap2.lightkeeper.framework.EventCaptureHandle;
 import nl.pim16aap2.lightkeeper.framework.FrameworkHandleFactory;
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.IPlayerBuilder;
 import nl.pim16aap2.lightkeeper.framework.IWorldBuilder;
+import nl.pim16aap2.lightkeeper.framework.InventorySnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuSnapshot;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
@@ -389,6 +392,59 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         ensureOpen();
         Objects.requireNonNull(playerId, "playerId may not be null.");
         return agentClient.playerMessages(playerId);
+    }
+
+    @Override
+    public EventCaptureHandle captureEvents(String eventClassName)
+    {
+        ensureOpen();
+        Objects.requireNonNull(eventClassName, "eventClassName may not be null.");
+        agentClient.registerEventListener(eventClassName);
+        return FrameworkHandleFactory.eventCaptureHandle(this, eventClassName);
+    }
+
+    @Override
+    public InventorySnapshot playerInventory(UUID playerId)
+    {
+        ensureOpen();
+        Objects.requireNonNull(playerId, "playerId may not be null.");
+        return agentClient.playerInventory(playerId);
+    }
+
+    @Override
+    public boolean dropItem(UUID playerId)
+    {
+        ensureOpen();
+        Objects.requireNonNull(playerId, "playerId may not be null.");
+        return agentClient.dropItem(playerId);
+    }
+
+    @Override
+    public void registerEventListener(String eventClassName)
+    {
+        ensureOpen();
+        agentClient.registerEventListener(eventClassName);
+    }
+
+    @Override
+    public List<CapturedEventSnapshot> getCapturedEvents(String eventClassName)
+    {
+        ensureOpen();
+        return agentClient.getCapturedEvents(eventClassName);
+    }
+
+    @Override
+    public void clearCapturedEvents(String eventClassName)
+    {
+        ensureOpen();
+        agentClient.clearCapturedEvents(eventClassName);
+    }
+
+    @Override
+    public void unregisterEventListener(String eventClassName)
+    {
+        ensureOpen();
+        agentClient.unregisterEventListener(eventClassName);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -267,12 +267,12 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
-    public void teleportPlayer(UUID uuid, String worldName, double x, double y, double z)
+    public boolean teleportPlayer(UUID uuid, String worldName, double x, double y, double z)
     {
         ensureOpen();
         Objects.requireNonNull(uuid, "uuid may not be null.");
         Objects.requireNonNull(worldName, "worldName may not be null.");
-        agentClient.teleportPlayer(uuid, worldName, x, y, z);
+        return agentClient.teleportPlayer(uuid, worldName, x, y, z);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -12,6 +12,7 @@ import nl.pim16aap2.lightkeeper.framework.IPlayerBuilder;
 import nl.pim16aap2.lightkeeper.framework.IWorldBuilder;
 import nl.pim16aap2.lightkeeper.framework.InventorySnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuSnapshot;
+import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
@@ -463,6 +464,13 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     {
         ensureOpen();
         return minecraftServerProcess.snapshotOutputLines();
+    }
+
+    @Override
+    public Platform platform()
+    {
+        ensureOpen();
+        return agentClient.serverPlatform();
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -96,17 +96,6 @@ final class UdsAgentClient implements AutoCloseable
         return getRequiredData(response, "worldName");
     }
 
-    Platform serverPlatform()
-    {
-        final AgentResponse response = send(AgentAction.GET_SERVER_PLATFORM, Map.of());
-        final String platformName = getRequiredData(response, "platform").toLowerCase(java.util.Locale.ROOT);
-        if (platformName.contains("paper"))
-            return Platform.PAPER;
-        if (platformName.contains("spigot"))
-            return Platform.SPIGOT;
-        return Platform.UNKNOWN;
-    }
-
     String newWorld(WorldSpec worldSpec)
     {
         final AgentResponse response = send(new NewWorldCommand(
@@ -366,10 +355,15 @@ final class UdsAgentClient implements AutoCloseable
         send(new UnregisterEventListenerCommand(nextRequestId(), eventClassName));
     }
 
-    String serverPlatform()
+    Platform serverPlatform()
     {
         final AgentResponse response = send(new GetServerPlatformCommand(nextRequestId()));
-        return getRequiredData(response, "serverName");
+        final String platformName = getRequiredData(response, "platform").toLowerCase(java.util.Locale.ROOT);
+        if (platformName.contains("paper"))
+            return Platform.PAPER;
+        if (platformName.contains("spigot") || platformName.contains("craftbukkit"))
+            return Platform.SPIGOT;
+        return Platform.UNKNOWN;
     }
 
     synchronized AgentResponse send(IAgentCommand command)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -240,7 +240,8 @@ final class UdsAgentClient implements AutoCloseable
             return new MenuSnapshot(false, "", List.of());
 
         final String title = getRequiredData(response, "title");
-        final MenuItemSnapshot[] items = parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
+        final MenuItemSnapshot[] items =
+            parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
         return new MenuSnapshot(true, title, List.of(items));
     }
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -271,9 +271,10 @@ final class UdsAgentClient implements AutoCloseable
         send(new LoadChunkCommand(nextRequestId(), worldName, x, z));
     }
 
-    void unloadChunk(String worldName, int x, int z)
+    boolean unloadChunk(String worldName, int x, int z)
     {
-        send(new UnloadChunkCommand(nextRequestId(), worldName, x, z));
+        final AgentResponse response = send(new UnloadChunkCommand(nextRequestId(), worldName, x, z));
+        return Boolean.parseBoolean(getRequiredData(response, "unloaded"));
     }
 
     boolean isChunkLoaded(String worldName, int x, int z)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -266,9 +266,10 @@ final class UdsAgentClient implements AutoCloseable
         send(new TeleportPlayerCommand(nextRequestId(), uuid, worldName, x, y, z));
     }
 
-    void loadChunk(String worldName, int x, int z)
+    boolean loadChunk(String worldName, int x, int z)
     {
-        send(new LoadChunkCommand(nextRequestId(), worldName, x, z));
+        final AgentResponse response = send(new LoadChunkCommand(nextRequestId(), worldName, x, z));
+        return Boolean.parseBoolean(getRequiredData(response, "loaded"));
     }
 
     boolean unloadChunk(String worldName, int x, int z)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -51,6 +51,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
+import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
@@ -61,6 +62,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -70,8 +75,26 @@ final class UdsAgentClient implements AutoCloseable
 {
     private static final System.Logger LOG = System.getLogger(UdsAgentClient.class.getName());
 
+    /**
+     * Maximum time to wait for a single agent response. Matches the agent-side WAIT_TICKS_TIMEOUT_MILLIS
+     * so WAIT_TICKS is the longest action that can legitimately take close to this limit.
+     *
+     * <p>Unix Domain Sockets do not support SO_TIMEOUT, so the timeout is enforced by a watchdog that
+     * closes the channel directly; this causes {@link AsynchronousCloseException} on the blocked read.
+     */
+    private static final int SEND_TIMEOUT_MS = 120_000;
+
     private final ObjectMapper objectMapper = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    /**
+     * Single-thread watchdog executor that closes the socket channel when a read takes longer than
+     * {@link #SEND_TIMEOUT_MS}. Closing the channel directly (not via {@link #close()}) avoids deadlock
+     * with the {@code synchronized} monitor held by {@link #send}.
+     */
+    private final ScheduledExecutorService readTimeoutWatchdog = Executors.newSingleThreadScheduledExecutor(
+        Thread.ofPlatform().name("lk-read-timeout-watchdog").daemon(true).factory()
+    );
 
     private final Path socketPath;
     private final AtomicLong requestCounter = new AtomicLong(0L);
@@ -370,6 +393,25 @@ final class UdsAgentClient implements AutoCloseable
     {
         final BufferedWriter out = Objects.requireNonNull(writer, "Client is not connected.");
         final BufferedReader in = Objects.requireNonNull(reader, "Client is not connected.");
+
+        // Capture the channel reference before the read; the watchdog closes it directly to avoid
+        // deadlocking on this synchronized method's monitor.
+        final SocketChannel channelSnapshot = this.socketChannel;
+        final ScheduledFuture<?> watchdog = readTimeoutWatchdog.schedule(() ->
+        {
+            if (channelSnapshot != null)
+            {
+                try
+                {
+                    channelSnapshot.close();
+                }
+                catch (IOException ignored)
+                {
+                    // Best-effort: the channel may already be closed.
+                }
+            }
+        }, SEND_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
         try
         {
             out.write(objectMapper.writeValueAsString(command));
@@ -408,12 +450,24 @@ final class UdsAgentClient implements AutoCloseable
 
             return response;
         }
+        catch (AsynchronousCloseException exception)
+        {
+            throw new IllegalStateException(
+                "Agent did not respond within %d ms for action '%s' via socket '%s'."
+                    .formatted(SEND_TIMEOUT_MS, command.getClass().getSimpleName(), socketPath),
+                exception
+            );
+        }
         catch (IOException exception)
         {
             throw new IllegalStateException(
                 "Failed to communicate with agent via socket '%s'.".formatted(socketPath),
                 exception
             );
+        }
+        finally
+        {
+            watchdog.cancel(false);
         }
     }
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -6,6 +6,7 @@ import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.CommandSource;
 import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuSnapshot;
+import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.IAgentCommand;
@@ -93,6 +94,17 @@ final class UdsAgentClient implements AutoCloseable
     {
         final AgentResponse response = send(new MainWorldCommand(nextRequestId()));
         return getRequiredData(response, "worldName");
+    }
+
+    Platform serverPlatform()
+    {
+        final AgentResponse response = send(AgentAction.GET_SERVER_PLATFORM, Map.of());
+        final String platformName = getRequiredData(response, "platform").toLowerCase(java.util.Locale.ROOT);
+        if (platformName.contains("paper"))
+            return Platform.PAPER;
+        if (platformName.contains("spigot"))
+            return Platform.SPIGOT;
+        return Platform.UNKNOWN;
     }
 
     String newWorld(WorldSpec worldSpec)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -44,6 +44,8 @@ import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicksCommand;
 import org.jspecify.annotations.Nullable;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -238,16 +240,8 @@ final class UdsAgentClient implements AutoCloseable
             return new MenuSnapshot(false, "", List.of());
 
         final String title = getRequiredData(response, "title");
-        final String itemsJson = response.data().getOrDefault("itemsJson", "[]");
-        try
-        {
-            final MenuItemSnapshot[] items = objectMapper.readValue(itemsJson, MenuItemSnapshot[].class);
-            return new MenuSnapshot(true, title, List.of(items));
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse menu snapshot JSON.", exception);
-        }
+        final MenuItemSnapshot[] items = parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
+        return new MenuSnapshot(true, title, List.of(items));
     }
 
     void clickMenuSlot(UUID uuid, int slot)
@@ -268,33 +262,15 @@ final class UdsAgentClient implements AutoCloseable
     List<String> playerMessages(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerMessagesCommand(nextRequestId(), uuid));
-        final String messagesJson = response.data().getOrDefault("messagesJson", "[]");
-        try
-        {
-            final String[] messages = objectMapper.readValue(messagesJson, String[].class);
-            return List.of(messages);
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse player messages JSON.", exception);
-        }
+        return List.of(parseJsonField(response, "messagesJson", new TypeReference<String[]>() {}));
     }
 
     List<ChatComponentSnapshot> playerChatComponents(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerChatComponentsCommand(nextRequestId(), uuid));
-        final String componentsJson = response.data().getOrDefault("componentsJson", "[]");
-        try
-        {
-            final String[] components = objectMapper.readValue(componentsJson, String[].class);
-            return java.util.Arrays.stream(components)
-                .map(ChatComponentSnapshot::new)
-                .toList();
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse player chat components JSON.", exception);
-        }
+        return java.util.Arrays.stream(parseJsonField(response, "componentsJson", new TypeReference<String[]>() {}))
+            .map(ChatComponentSnapshot::new)
+            .toList();
     }
 
     long getServerTick()
@@ -328,17 +304,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, Object>> getPlayerInventory(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerInventoryCommand(nextRequestId(), uuid));
-        final String inventoryJson = response.data().getOrDefault("inventoryJson", "[]");
-        try
-        {
-            @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> items = objectMapper.readValue(inventoryJson, List.class);
-            return items;
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse player inventory JSON.", exception);
-        }
+        return parseJsonField(response, "inventoryJson", new TypeReference<List<Map<String, Object>>>() {});
     }
 
     boolean dropItem(UUID uuid)
@@ -355,17 +321,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, String>> getCapturedEvents(String eventClassName)
     {
         final AgentResponse response = send(new GetCapturedEventsCommand(nextRequestId(), eventClassName));
-        final String eventsJson = response.data().getOrDefault("eventsJson", "[]");
-        try
-        {
-            @SuppressWarnings("unchecked")
-            final List<Map<String, String>> events = objectMapper.readValue(eventsJson, List.class);
-            return events;
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse captured events JSON.", exception);
-        }
+        return parseJsonField(response, "eventsJson", new TypeReference<List<Map<String, String>>>() {});
     }
 
     void clearCapturedEvents(String eventClassName)
@@ -556,6 +512,35 @@ final class UdsAgentClient implements AutoCloseable
         if (value == null)
             throw new IllegalStateException("Missing response field '%s' from agent.".formatted(key));
         return value;
+    }
+
+    /**
+     * Reads a JSON string from a response data field and deserializes it using the supplied type reference.
+     *
+     * @param response
+     *     Agent response whose data map is searched.
+     * @param key
+     *     Data field key; defaults to {@code "[]"} when absent.
+     * @param typeRef
+     *     Jackson type reference for deserialization.
+     * @param <T>
+     *     Expected return type.
+     * @return
+     *     Deserialized value.
+     * @throws IllegalStateException
+     *     When deserialization fails.
+     */
+    private <T> T parseJsonField(AgentResponse response, String key, TypeReference<T> typeRef)
+    {
+        final String json = response.data().getOrDefault(key, "[]");
+        try
+        {
+            return objectMapper.readValue(json, typeRef);
+        }
+        catch (IOException exception)
+        {
+            throw new IllegalStateException("Failed to parse '%s' JSON from agent response.".formatted(key), exception);
+        }
     }
 
     private static void sleep(long millis)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -261,9 +261,10 @@ final class UdsAgentClient implements AutoCloseable
         return Long.parseLong(getRequiredData(response, "tick"));
     }
 
-    void teleportPlayer(UUID uuid, String worldName, double x, double y, double z)
+    boolean teleportPlayer(UUID uuid, String worldName, double x, double y, double z)
     {
-        send(new TeleportPlayerCommand(nextRequestId(), uuid, worldName, x, y, z));
+        final AgentResponse response = send(new TeleportPlayerCommand(nextRequestId(), uuid, worldName, x, y, z));
+        return Boolean.parseBoolean(getRequiredData(response, "teleported"));
     }
 
     boolean loadChunk(String worldName, int x, int z)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -86,6 +86,8 @@ final class UdsAgentClient implements AutoCloseable
         new TypeReference<>() {};
     private static final TypeReference<List<Map<String, String>>> TYPE_EVENT_DATA_LIST =
         new TypeReference<>() {};
+    private static final TypeReference<List<Map<String, Object>>> TYPE_INVENTORY_ITEM_LIST =
+        new TypeReference<>() {};
 
     /**
      * Maximum time to wait for a single agent response. Matches the agent-side WAIT_TICKS_TIMEOUT_MILLIS
@@ -314,7 +316,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, Object>> getPlayerInventory(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerInventoryCommand(nextRequestId(), uuid));
-        return parseJsonField(response, "inventoryJson", new TypeReference<List<Map<String, Object>>>() {});
+        return parseJsonField(response, "inventoryJson", TYPE_INVENTORY_ITEM_LIST);
     }
 
     boolean dropItem(UUID uuid)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.lightkeeper.framework.internal;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.CommandSource;
 import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuSnapshot;
@@ -255,6 +256,23 @@ final class UdsAgentClient implements AutoCloseable
         }
     }
 
+    List<ChatComponentSnapshot> playerChatComponents(UUID uuid)
+    {
+        final AgentResponse response = send(new GetPlayerChatComponentsCommand(nextRequestId(), uuid));
+        final String componentsJson = response.data().getOrDefault("componentsJson", "[]");
+        try
+        {
+            final String[] components = objectMapper.readValue(componentsJson, String[].class);
+            return java.util.Arrays.stream(components)
+                .map(ChatComponentSnapshot::new)
+                .toList();
+        }
+        catch (IOException exception)
+        {
+            throw new IllegalStateException("Failed to parse player chat components JSON.", exception);
+        }
+    }
+
     long getServerTick()
     {
         final AgentResponse response = send(new GetServerTickCommand(nextRequestId()));
@@ -334,21 +352,6 @@ final class UdsAgentClient implements AutoCloseable
     void unregisterEventListener(String eventClassName)
     {
         send(new UnregisterEventListenerCommand(nextRequestId(), eventClassName));
-    }
-
-    List<String> getPlayerChatComponents(UUID uuid)
-    {
-        final AgentResponse response = send(new GetPlayerChatComponentsCommand(nextRequestId(), uuid));
-        final String componentsJson = response.data().getOrDefault("componentsJson", "[]");
-        try
-        {
-            final String[] components = objectMapper.readValue(componentsJson, String[].class);
-            return List.of(components);
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse player chat components JSON.", exception);
-        }
     }
 
     String serverPlatform()

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -77,6 +77,16 @@ final class UdsAgentClient implements AutoCloseable
 {
     private static final System.Logger LOG = System.getLogger(UdsAgentClient.class.getName());
 
+    // Reusable TypeReference constants. Jackson captures the generic type at runtime via
+    // getGenericSuperclass(), which is preserved even when using the diamond operator on these
+    // explicit-target-type field declarations (Java 9+ behaviour).
+    private static final TypeReference<MenuItemSnapshot[]> TYPE_MENU_ITEM_ARRAY =
+        new TypeReference<>() {};
+    private static final TypeReference<String[]> TYPE_STRING_ARRAY =
+        new TypeReference<>() {};
+    private static final TypeReference<List<Map<String, String>>> TYPE_EVENT_DATA_LIST =
+        new TypeReference<>() {};
+
     /**
      * Maximum time to wait for a single agent response. Matches the agent-side WAIT_TICKS_TIMEOUT_MILLIS
      * so WAIT_TICKS is the longest action that can legitimately take close to this limit.
@@ -240,8 +250,7 @@ final class UdsAgentClient implements AutoCloseable
             return new MenuSnapshot(false, "", List.of());
 
         final String title = getRequiredData(response, "title");
-        final MenuItemSnapshot[] items =
-            parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
+        final MenuItemSnapshot[] items = parseJsonField(response, "itemsJson", TYPE_MENU_ITEM_ARRAY);
         return new MenuSnapshot(true, title, List.of(items));
     }
 
@@ -263,13 +272,13 @@ final class UdsAgentClient implements AutoCloseable
     List<String> playerMessages(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerMessagesCommand(nextRequestId(), uuid));
-        return List.of(parseJsonField(response, "messagesJson", new TypeReference<String[]>() {}));
+        return List.of(parseJsonField(response, "messagesJson", TYPE_STRING_ARRAY));
     }
 
     List<ChatComponentSnapshot> playerChatComponents(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerChatComponentsCommand(nextRequestId(), uuid));
-        return java.util.Arrays.stream(parseJsonField(response, "componentsJson", new TypeReference<String[]>() {}))
+        return java.util.Arrays.stream(parseJsonField(response, "componentsJson", TYPE_STRING_ARRAY))
             .map(ChatComponentSnapshot::new)
             .toList();
     }
@@ -322,7 +331,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, String>> getCapturedEvents(String eventClassName)
     {
         final AgentResponse response = send(new GetCapturedEventsCommand(nextRequestId(), eventClassName));
-        return parseJsonField(response, "eventsJson", new TypeReference<List<Map<String, String>>>() {});
+        return parseJsonField(response, "eventsJson", TYPE_EVENT_DATA_LIST);
     }
 
     void clearCapturedEvents(String eventClassName)

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandleTest.java
@@ -1,0 +1,65 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EventCaptureHandleTest
+{
+    private static final String EVENT_CLASS_NAME = "org.bukkit.event.player.PlayerDropItemEvent";
+
+    private IFrameworkGatewayView frameworkGateway;
+    private EventCaptureHandle eventCaptureHandle;
+
+    @BeforeEach
+    void setUp()
+    {
+        frameworkGateway = mock(IFrameworkGatewayView.class);
+        eventCaptureHandle = new EventCaptureHandle(frameworkGateway, EVENT_CLASS_NAME);
+    }
+
+    @Test
+    void getCapturedEvents_shouldDelegateToGateway()
+    {
+        // setup
+        final List<CapturedEventSnapshot> events = List.of(
+            new CapturedEventSnapshot(EVENT_CLASS_NAME, Map.of("isCancelled", "true"))
+        );
+        when(frameworkGateway.getCapturedEvents(EVENT_CLASS_NAME)).thenReturn(events);
+
+        // execute
+        final List<CapturedEventSnapshot> result = eventCaptureHandle.getCapturedEvents();
+
+        // verify
+        assertThat(result).isSameAs(events);
+        verify(frameworkGateway).getCapturedEvents(EVENT_CLASS_NAME);
+    }
+
+    @Test
+    void clear_shouldDelegateToGatewayAndReturnSelf()
+    {
+        // execute
+        final EventCaptureHandle result = eventCaptureHandle.clear();
+
+        // verify
+        assertThat(result).isSameAs(eventCaptureHandle);
+        verify(frameworkGateway).clearCapturedEvents(EVENT_CLASS_NAME);
+    }
+
+    @Test
+    void close_shouldDelegateToGateway()
+    {
+        // execute
+        eventCaptureHandle.close();
+
+        // verify
+        verify(frameworkGateway).unregisterEventListener(EVENT_CLASS_NAME);
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/InventorySnapshotTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/InventorySnapshotTest.java
@@ -1,0 +1,54 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InventorySnapshotTest
+{
+    @Test
+    void constructor_shouldDefensivelyCopyItems()
+    {
+        // setup
+        final List<MenuItemSnapshot> items = new ArrayList<>();
+        items.add(new MenuItemSnapshot(0, "minecraft:stone", "Stone", List.of()));
+
+        // execute
+        final InventorySnapshot snapshot = new InventorySnapshot(items);
+        items.clear();
+
+        // verify
+        assertThat(snapshot.items()).hasSize(1);
+    }
+
+    @Test
+    void findItem_shouldReturnMatchingItemIgnoringCase()
+    {
+        // setup
+        final MenuItemSnapshot item = new MenuItemSnapshot(0, "minecraft:stone", "Stone", List.of());
+        final InventorySnapshot snapshot = new InventorySnapshot(List.of(item));
+
+        // execute
+        final MenuItemSnapshot result = snapshot.findItem("MINECRAFT:STONE");
+
+        // verify
+        assertThat(result).isSameAs(item);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void findItem_shouldThrowExceptionWhenMaterialKeyIsNull()
+    {
+        // setup
+        final InventorySnapshot snapshot = new InventorySnapshot(List.of());
+
+        // execute + verify
+        assertThatThrownBy(() -> snapshot.findItem(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("materialKey");
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -63,17 +63,18 @@ class PlayerHandleTest
     }
 
     @Test
-    void teleport_shouldDelegateToGatewayAndReturnSelf()
+    void teleport_shouldDelegateToGatewayAndReturnResult()
     {
         // setup
         final WorldHandle world = mock(WorldHandle.class);
         when(world.name()).thenReturn("world_nether");
+        when(frameworkGateway.teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5)).thenReturn(true);
 
         // execute
-        final PlayerHandle result = playerHandle.teleport(world, 10.5, 64.0, 20.5);
+        final boolean result = playerHandle.teleport(world, 10.5, 64.0, 20.5);
 
         // verify
-        assertThat(result).isSameAs(playerHandle);
+        assertThat(result).isTrue();
         verify(frameworkGateway).teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5);
     }
 

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -78,6 +78,37 @@ class PlayerHandleTest
     }
 
     @Test
+    void inventory_shouldReturnInventorySnapshotFromGateway()
+    {
+        // setup
+        final InventorySnapshot snapshot = new InventorySnapshot(List.of(
+            new MenuItemSnapshot(0, "minecraft:stone", "Stone", List.of())
+        ));
+        when(frameworkGateway.playerInventory(PLAYER_UUID)).thenReturn(snapshot);
+
+        // execute
+        final InventorySnapshot result = playerHandle.inventory();
+
+        // verify
+        assertThat(result).isSameAs(snapshot);
+        verify(frameworkGateway).playerInventory(PLAYER_UUID);
+    }
+
+    @Test
+    void dropMainHandItem_shouldDelegateToGatewayAndReturnCancellationState()
+    {
+        // setup
+        when(frameworkGateway.dropItem(PLAYER_UUID)).thenReturn(true);
+
+        // execute
+        final boolean result = playerHandle.dropMainHandItem();
+
+        // verify
+        assertThat(result).isTrue();
+        verify(frameworkGateway).dropItem(PLAYER_UUID);
+    }
+
+    @Test
     void placeBlock_shouldDelegateToGatewayAndReturnSelf()
     {
         // execute

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -63,7 +64,7 @@ class PlayerHandleTest
     }
 
     @Test
-    void teleport_shouldDelegateToGatewayAndReturnResult()
+    void teleport_shouldDelegateToGatewayAndReturnSelf()
     {
         // setup
         final WorldHandle world = mock(WorldHandle.class);
@@ -71,11 +72,25 @@ class PlayerHandleTest
         when(frameworkGateway.teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5)).thenReturn(true);
 
         // execute
-        final boolean result = playerHandle.teleport(world, 10.5, 64.0, 20.5);
+        final PlayerHandle result = playerHandle.teleport(world, 10.5, 64.0, 20.5);
 
         // verify
-        assertThat(result).isTrue();
+        assertThat(result).isSameAs(playerHandle);
         verify(frameworkGateway).teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5);
+    }
+
+    @Test
+    void teleport_shouldThrowWhenTeleportIsRejected()
+    {
+        // setup
+        final WorldHandle world = mock(WorldHandle.class);
+        when(world.name()).thenReturn("world_nether");
+        when(frameworkGateway.teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5)).thenReturn(false);
+
+        // execute + verify
+        assertThatThrownBy(() -> playerHandle.teleport(world, 10.5, 64.0, 20.5))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("was rejected by the server");
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -95,9 +95,9 @@ class PlayerHandleTest
     }
 
     @Test
-    void dropMainHandItem_shouldDelegateToGatewayAndReturnCancellationState()
+    void dropMainHandItem_shouldDelegateToGatewayAndReturnDroppedState()
     {
-        // setup
+        // setup — gateway returns true when the drop was not cancelled by any plugin
         when(frameworkGateway.dropItem(PLAYER_UUID)).thenReturn(true);
 
         // execute
@@ -239,6 +239,21 @@ class PlayerHandleTest
     }
 
     @Test
+    void chatComponents_shouldReturnComponentsFromGateway()
+    {
+        // setup
+        final List<ChatComponentSnapshot> components = List.of(new ChatComponentSnapshot("{\"text\":\"Hello\"}"));
+        when(frameworkGateway.playerChatComponents(PLAYER_UUID)).thenReturn(components);
+
+        // execute
+        final List<ChatComponentSnapshot> result = playerHandle.chatComponents();
+
+        // verify
+        assertThat(result).isSameAs(components);
+        verify(frameworkGateway).playerChatComponents(PLAYER_UUID);
+    }
+
+    @Test
     void receivedMessagesText_shouldJoinMessagesWithLineSeparator()
     {
         // setup
@@ -259,5 +274,55 @@ class PlayerHandleTest
 
         // verify
         verify(frameworkGateway).removePlayer(playerHandle);
+    }
+
+    @Test
+    void leftClickBlock_shouldDelegateWithDefaultBlockFaceWhenOnlyPositionGiven()
+    {
+        // setup
+        final Vector3Di position = new Vector3Di(3, 70, 4);
+
+        // execute
+        final PlayerHandle result = playerHandle.leftClickBlock(position);
+
+        // verify
+        assertThat(result).isSameAs(playerHandle);
+        verify(frameworkGateway).leftClickBlock(PLAYER_UUID, position, "UP");
+    }
+
+    @Test
+    void leftClickBlock_shouldDelegateWithCoordinatesUsingDefaultBlockFace()
+    {
+        // execute
+        final PlayerHandle result = playerHandle.leftClickBlock(5, 64, 6);
+
+        // verify
+        assertThat(result).isSameAs(playerHandle);
+        verify(frameworkGateway).leftClickBlock(eq(PLAYER_UUID), any(Vector3Di.class), eq("UP"));
+    }
+
+    @Test
+    void rightClickBlock_shouldDelegateWithDefaultBlockFaceWhenOnlyPositionGiven()
+    {
+        // setup
+        final Vector3Di position = new Vector3Di(7, 70, 8);
+
+        // execute
+        final PlayerHandle result = playerHandle.rightClickBlock(position);
+
+        // verify
+        assertThat(result).isSameAs(playerHandle);
+        verify(frameworkGateway).rightClickBlock(PLAYER_UUID, position, "UP");
+    }
+
+    @Test
+    void rightClickBlock_shouldDelegateWithCoordinatesUsingDefaultBlockFace()
+    {
+        // execute
+        final PlayerHandle result = playerHandle.rightClickBlock(9, 64, 10);
+
+        // verify
+        assertThat(result).isSameAs(playerHandle);
+        verify(frameworkGateway).rightClickBlock(eq(PLAYER_UUID), any(Vector3Di.class), eq("UP"));
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -63,6 +63,21 @@ class PlayerHandleTest
     }
 
     @Test
+    void teleport_shouldDelegateToGatewayAndReturnSelf()
+    {
+        // setup
+        final WorldHandle world = mock(WorldHandle.class);
+        when(world.name()).thenReturn("world_nether");
+
+        // execute
+        final PlayerHandle result = playerHandle.teleport(world, 10.5, 64.0, 20.5);
+
+        // verify
+        assertThat(result).isSameAs(playerHandle);
+        verify(frameworkGateway).teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5);
+    }
+
+    @Test
     void placeBlock_shouldDelegateToGatewayAndReturnSelf()
     {
         // execute

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,31 +60,55 @@ class WorldHandleTest
     }
 
     @Test
-    void loadChunk_shouldDelegateToGateway()
+    void loadChunk_shouldDelegateToGatewayAndReturnSelf()
     {
         // setup
         when(frameworkGateway.loadChunk("world", 1, 2)).thenReturn(true);
 
         // execute
-        final boolean result = worldHandle.loadChunk(1, 2);
+        final WorldHandle result = worldHandle.loadChunk(1, 2);
 
         // verify
-        assertThat(result).isTrue();
+        assertThat(result).isSameAs(worldHandle);
         verify(frameworkGateway).loadChunk("world", 1, 2);
     }
 
     @Test
-    void unloadChunk_shouldDelegateToGateway()
+    void loadChunk_shouldThrowWhenLoadFails()
+    {
+        // setup
+        when(frameworkGateway.loadChunk("world", 1, 2)).thenReturn(false);
+
+        // execute + verify
+        assertThatThrownBy(() -> worldHandle.loadChunk(1, 2))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Failed to load chunk [1, 2] in world 'world'");
+    }
+
+    @Test
+    void unloadChunk_shouldDelegateToGatewayAndReturnSelf()
     {
         // setup
         when(frameworkGateway.unloadChunk("world", 1, 2)).thenReturn(true);
 
         // execute
-        final boolean result = worldHandle.unloadChunk(1, 2);
+        final WorldHandle result = worldHandle.unloadChunk(1, 2);
 
         // verify
-        assertThat(result).isTrue();
+        assertThat(result).isSameAs(worldHandle);
         verify(frameworkGateway).unloadChunk("world", 1, 2);
+    }
+
+    @Test
+    void unloadChunk_shouldThrowWhenUnloadFails()
+    {
+        // setup
+        when(frameworkGateway.unloadChunk("world", 1, 2)).thenReturn(false);
+
+        // execute + verify
+        assertThatThrownBy(() -> worldHandle.unloadChunk(1, 2))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Failed to unload chunk [1, 2] in world 'world'");
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
@@ -58,4 +58,43 @@ class WorldHandleTest
         verify(frameworkGateway).setBlock("world", position, "STONE");
     }
 
+    @Test
+    void loadChunk_shouldDelegateToGatewayAndReturnSelf()
+    {
+        // execute
+        final WorldHandle result = worldHandle.loadChunk(1, 2);
+
+        // verify
+        assertThat(result).isSameAs(worldHandle);
+        verify(frameworkGateway).loadChunk("world", 1, 2);
+    }
+
+    @Test
+    void unloadChunk_shouldDelegateToGateway()
+    {
+        // setup
+        when(frameworkGateway.unloadChunk("world", 1, 2)).thenReturn(true);
+
+        // execute
+        final boolean result = worldHandle.unloadChunk(1, 2);
+
+        // verify
+        assertThat(result).isTrue();
+        verify(frameworkGateway).unloadChunk("world", 1, 2);
+    }
+
+    @Test
+    void isChunkLoaded_shouldDelegateToGateway()
+    {
+        // setup
+        when(frameworkGateway.isChunkLoaded("world", 1, 2)).thenReturn(true);
+
+        // execute
+        final boolean result = worldHandle.isChunkLoaded(1, 2);
+
+        // verify
+        assertThat(result).isTrue();
+        verify(frameworkGateway).isChunkLoaded("world", 1, 2);
+    }
+
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
@@ -59,13 +59,16 @@ class WorldHandleTest
     }
 
     @Test
-    void loadChunk_shouldDelegateToGatewayAndReturnSelf()
+    void loadChunk_shouldDelegateToGateway()
     {
+        // setup
+        when(frameworkGateway.loadChunk("world", 1, 2)).thenReturn(true);
+
         // execute
-        final WorldHandle result = worldHandle.loadChunk(1, 2);
+        final boolean result = worldHandle.loadChunk(1, 2);
 
         // verify
-        assertThat(result).isSameAs(worldHandle);
+        assertThat(result).isTrue();
         verify(frameworkGateway).loadChunk("world", 1, 2);
     }
 

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
@@ -1,7 +1,10 @@
 package nl.pim16aap2.lightkeeper.framework.assertions;
 
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
+import nl.pim16aap2.lightkeeper.framework.InventorySnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
+import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
@@ -44,6 +47,57 @@ class HandleAssertionsTest
         assertThatThrownBy(() -> LightkeeperAssertions.assertThat(handle).hasName("other"))
             .isInstanceOf(AssertionError.class)
             .hasMessageContaining("Expected player name");
+    }
+
+    @Test
+    void playerHandleAssert_shouldValidateInventoryAndClickableChatText()
+    {
+        // setup
+        final PlayerHandle handle = mock(PlayerHandle.class);
+        when(handle.name()).thenReturn("bot");
+        when(handle.inventory()).thenReturn(new InventorySnapshot(List.of(
+            new MenuItemSnapshot(3, "minecraft:stone", "Stone", List.of())
+        )));
+        when(handle.chatComponents()).thenReturn(List.of(
+            new ChatComponentSnapshot("{\"text\":\"Open\",\"clickEvent\":{\"action\":\"run_command\"}}")
+        ));
+
+        // execute + verify
+        LightkeeperAssertions.assertThat(handle)
+            .hasItemInInventory("minecraft:stone")
+            .doesNotHaveItemInInventory("minecraft:diamond")
+            .hasClickableChatText("Open");
+    }
+
+    @Test
+    void playerHandleAssert_shouldFailWhenUnexpectedItemExists()
+    {
+        // setup
+        final PlayerHandle handle = mock(PlayerHandle.class);
+        when(handle.name()).thenReturn("bot");
+        when(handle.inventory()).thenReturn(new InventorySnapshot(List.of(
+            new MenuItemSnapshot(2, "minecraft:stone", "Stone", List.of())
+        )));
+
+        // execute + verify
+        assertThatThrownBy(() ->
+            LightkeeperAssertions.assertThat(handle).doesNotHaveItemInInventory("minecraft:stone"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("slot 2");
+    }
+
+    @Test
+    void playerHandleAssert_shouldFailWhenClickableChatTextMissing()
+    {
+        // setup
+        final PlayerHandle handle = mock(PlayerHandle.class);
+        when(handle.name()).thenReturn("bot");
+        when(handle.chatComponents()).thenReturn(List.of(new ChatComponentSnapshot("{\"text\":\"Open\"}")));
+
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.assertThat(handle).hasClickableChatText("Open"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("clickable chat text");
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -23,10 +23,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UdsAgentClientTest
 {
+    private static final ObjectMapper REQUEST_MAPPER = new ObjectMapper();
+    private static final java.util.UUID PLAYER_ID =
+        java.util.UUID.fromString("6efa93e0-6b5f-45b7-8af8-2453c9c7ef0c");
+
     @Test
     void send_shouldThrowExceptionWhenResponseIdDoesNotMatch(@TempDir Path tempDirectory)
         throws Exception
@@ -80,6 +85,368 @@ class UdsAgentClientTest
         }
     }
 
+    @Test
+    void serverPlatform_shouldSendPlatformRequestAndMapPaperResponse(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "PAPER"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.PAPER);
+            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+        }
+    }
+
+    @Test
+    void serverPlatform_shouldMapCraftBukkitResponseToSpigot(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform-craftbukkit.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "SPIGOT"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.SPIGOT);
+            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+        }
+    }
+
+    @Test
+    void loadChunk_shouldSendChunkCoordinates(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-load-chunk.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.loadChunk("world", 3, -4);
+
+            // verify
+            assertRequest(server, AgentAction.LOAD_CHUNK, Map.of("worldName", "world", "x", "3", "z", "-4"));
+        }
+    }
+
+    @Test
+    void playerInventory_shouldParseInventorySnapshot(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-inventory.sock");
+        final String inventoryJson = "[{\"slot\":1,\"materialKey\":\"minecraft:stone\",\"displayName\":\"Stone\","
+            + "\"lore\":[\"Line\"]}]";
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("inventoryJson", inventoryJson))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.InventorySnapshot result = client.playerInventory(PLAYER_ID);
+
+            // verify
+            assertThat(result.items()).hasSize(1);
+            assertThat(result.items().getFirst().materialKey()).isEqualTo("minecraft:stone");
+            assertRequest(server, AgentAction.GET_PLAYER_INVENTORY, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    @Test
+    void dropItem_shouldParseDroppedState(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-drop.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("dropped", "true"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.dropItem(PLAYER_ID);
+
+            // verify
+            assertThat(result).isTrue();
+            assertRequest(server, AgentAction.DROP_ITEM, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    @Test
+    void playerChatComponents_shouldParseComponentSnapshots(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-components.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("componentsJson", "[\"{\\\"text\\\":\\\"Hi\\\"}\"]"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final java.util.List<nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot> result =
+                client.playerChatComponents(PLAYER_ID);
+
+            // verify
+            assertThat(result).extracting(nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot::json)
+                .containsExactly("{\"text\":\"Hi\"}");
+            assertRequest(server, AgentAction.GET_PLAYER_CHAT_COMPONENTS, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    @Test
+    void getCapturedEvents_shouldSendEventClassNameAndParseEvents(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-events.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("eventsJson", "[{\"getValue\":\"value\"}]"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final java.util.List<nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot> result =
+                client.getCapturedEvents("org.bukkit.event.Event");
+
+            // verify
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().data()).containsEntry("getValue", "value");
+            assertRequest(
+                server,
+                AgentAction.GET_CAPTURED_EVENTS,
+                Map.of("eventClassName", "org.bukkit.event.Event")
+            );
+        }
+    }
+
+    @Test
+    void handshake_shouldSendHandshakeRequest(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-handshake.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("protocolVersion", "1", "bukkitVersion", "1.21.11")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.handshake("my-token", 1, "sha256");
+
+            // verify
+            assertRequest(server, AgentAction.HANDSHAKE, Map.of("token", "my-token", "protocolVersion", "1", "agentSha256", "sha256"));
+        }
+    }
+
+    @Test
+    void mainWorld_shouldSendRequestAndReturnWorldName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-mainworld.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("worldName", "world")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final String result = client.mainWorld();
+
+            // verify
+            assertThat(result).isEqualTo("world");
+            assertRequest(server, AgentAction.MAIN_WORLD, Map.of());
+        }
+    }
+
+    @Test
+    void unloadChunk_shouldSendCoordinatesAndReturnResult(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-unload-chunk.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("success", "false")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.unloadChunk("world", 5, -3);
+
+            // verify
+            assertThat(result).isFalse();
+            assertRequest(server, AgentAction.UNLOAD_CHUNK, Map.of("worldName", "world", "x", "5", "z", "-3"));
+        }
+    }
+
+    @Test
+    void isChunkLoaded_shouldSendCoordinatesAndReturnResult(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-is-loaded.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("loaded", "true")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.isChunkLoaded("world", 1, 2);
+
+            // verify
+            assertThat(result).isTrue();
+            assertRequest(server, AgentAction.IS_CHUNK_LOADED, Map.of("worldName", "world", "x", "1", "z", "2"));
+        }
+    }
+
+    @Test
+    void executeCommand_shouldSendCommandAndReturnResult(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-execute-cmd.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("success", "true")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.executeCommand(
+                nl.pim16aap2.lightkeeper.framework.CommandSource.CONSOLE, "time set day");
+
+            // verify
+            assertThat(result).isTrue();
+            assertRequest(server, AgentAction.EXECUTE_COMMAND, Map.of("source", "CONSOLE", "command", "time set day"));
+        }
+    }
+
+    @Test
+    void registerEventListener_shouldSendEventClassName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-register-event.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.registerEventListener("org.bukkit.event.player.PlayerJoinEvent");
+
+            // verify
+            assertRequest(server, AgentAction.REGISTER_EVENT_LISTENER,
+                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+        }
+    }
+
+    @Test
+    void clearCapturedEvents_shouldSendEventClassName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-clear-events.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.clearCapturedEvents("org.bukkit.event.player.PlayerJoinEvent");
+
+            // verify
+            assertRequest(server, AgentAction.CLEAR_CAPTURED_EVENTS,
+                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+        }
+    }
+
+    @Test
+    void unregisterEventListener_shouldSendEventClassName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-unregister-event.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.unregisterEventListener("org.bukkit.event.player.PlayerJoinEvent");
+
+            // verify
+            assertRequest(server, AgentAction.UNREGISTER_EVENT_LISTENER,
+                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+        }
+    }
+
+    @Test
+    void waitTicks_shouldSendTickCount(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-wait-ticks.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("startTick", "0", "endTick", "5")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.waitTicks(5);
+
+            // verify
+            assertRequest(server, AgentAction.WAIT_TICKS, Map.of("ticks", "5"));
+        }
+    }
+
+    @Test
+    void serverPlatform_shouldMapUnknownPlatformToUnknown(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform-unknown.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "Sponge"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.UNKNOWN);
+        }
+    }
+
+    @Test
+    void playerMessages_shouldParseMessageList(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-messages.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("messagesJson", "[\"hello\",\"world\"]"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final java.util.List<String> result = client.playerMessages(PLAYER_ID);
+
+            // verify
+            assertThat(result).containsExactly("hello", "world");
+            assertRequest(server, AgentAction.GET_PLAYER_MESSAGES, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    private static AgentResponse successResponse(Map<String, String> data)
+    {
+        return new AgentResponse("1", true, null, null, data);
+    }
+
+    private static void assertRequest(AgentSocketServer server, AgentAction action, Map<String, String> arguments)
+        throws IOException
+    {
+        final nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest request =
+            REQUEST_MAPPER.readValue(server.requestLine(), nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest.class);
+        assertThat(request.action()).isEqualTo(action);
+        assertThat(request.arguments()).isEqualTo(arguments);
+    }
+
     private static final class AgentSocketServer implements AutoCloseable
     {
         private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -88,6 +455,7 @@ class UdsAgentClientTest
         private final Thread workerThread;
         private final CountDownLatch started = new CountDownLatch(1);
         private final AtomicReference<Throwable> workerFailure = new AtomicReference<>();
+        private final AtomicReference<String> requestLine = new AtomicReference<>();
         private final Path socketPath;
 
         private AgentSocketServer(Path socketPath, AgentResponse response)
@@ -121,6 +489,7 @@ class UdsAgentClientTest
                 final String requestLine = reader.readLine();
                 if (requestLine == null)
                     return;
+                this.requestLine.set(requestLine);
                 writer.write(OBJECT_MAPPER.writeValueAsString(response));
                 writer.newLine();
                 writer.flush();
@@ -141,6 +510,11 @@ class UdsAgentClientTest
             if (failure != null)
                 throw new IllegalStateException("Socket server worker failed.", failure);
             Files.deleteIfExists(socketPath);
+        }
+
+        private String requestLine()
+        {
+            return java.util.Objects.requireNonNull(requestLine.get(), "No request was received.");
         }
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicksCommand;
@@ -18,7 +19,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -29,8 +32,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class UdsAgentClientTest
 {
     private static final ObjectMapper REQUEST_MAPPER = new ObjectMapper();
-    private static final java.util.UUID PLAYER_ID =
-        java.util.UUID.fromString("6efa93e0-6b5f-45b7-8af8-2453c9c7ef0c");
+    private static final UUID PLAYER_ID =
+        UUID.fromString("6efa93e0-6b5f-45b7-8af8-2453c9c7ef0c");
 
     @Test
     void send_shouldThrowExceptionWhenResponseIdDoesNotMatch(@TempDir Path tempDirectory)
@@ -93,7 +96,7 @@ class UdsAgentClientTest
         final Path socketPath = tempDirectory.resolve("agent-platform.sock");
         try (AgentSocketServer server = AgentSocketServer.start(
             socketPath,
-            successResponse(Map.of("platform", "PAPER"))
+            successResponse(Map.of("platform", "paper"))
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
@@ -101,19 +104,19 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.PAPER);
-            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+            assertRequestAction(server, "GET_SERVER_PLATFORM");
         }
     }
 
     @Test
-    void serverPlatform_shouldMapCraftBukkitResponseToSpigot(@TempDir Path tempDirectory)
+    void serverPlatform_shouldMapSpigotResponseToSpigot(@TempDir Path tempDirectory)
         throws Exception
     {
         // setup
-        final Path socketPath = tempDirectory.resolve("agent-platform-craftbukkit.sock");
+        final Path socketPath = tempDirectory.resolve("agent-platform-spigot.sock");
         try (AgentSocketServer server = AgentSocketServer.start(
             socketPath,
-            successResponse(Map.of("platform", "SPIGOT"))
+            successResponse(Map.of("platform", "spigot"))
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
@@ -121,7 +124,26 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.SPIGOT);
-            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+            assertRequestAction(server, "GET_SERVER_PLATFORM");
+        }
+    }
+
+    @Test
+    void serverPlatform_shouldMapUnknownPlatformToUnknown(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform-unknown.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "sponge"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.UNKNOWN);
         }
     }
 
@@ -138,30 +160,34 @@ class UdsAgentClientTest
             client.loadChunk("world", 3, -4);
 
             // verify
-            assertRequest(server, AgentAction.LOAD_CHUNK, Map.of("worldName", "world", "x", "3", "z", "-4"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("LOAD_CHUNK");
+            assertThat(request.get("worldName").asText()).isEqualTo("world");
+            assertThat(request.get("x").asInt()).isEqualTo(3);
+            assertThat(request.get("z").asInt()).isEqualTo(-4);
         }
     }
 
     @Test
-    void playerInventory_shouldParseInventorySnapshot(@TempDir Path tempDirectory)
+    void getPlayerInventory_shouldParseInventoryItemMaps(@TempDir Path tempDirectory)
         throws Exception
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-inventory.sock");
-        final String inventoryJson = "[{\"slot\":1,\"materialKey\":\"minecraft:stone\",\"displayName\":\"Stone\","
-            + "\"lore\":[\"Line\"]}]";
+        final String inventoryJson =
+            "[{\"slot\":1,\"materialKey\":\"minecraft:stone\",\"displayName\":\"Stone\",\"lore\":[\"Line\"]}]";
         try (AgentSocketServer server = AgentSocketServer.start(
             socketPath,
             successResponse(Map.of("inventoryJson", inventoryJson))
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final nl.pim16aap2.lightkeeper.framework.InventorySnapshot result = client.playerInventory(PLAYER_ID);
+            final List<Map<String, Object>> result = client.getPlayerInventory(PLAYER_ID);
 
             // verify
-            assertThat(result.items()).hasSize(1);
-            assertThat(result.items().getFirst().materialKey()).isEqualTo("minecraft:stone");
-            assertRequest(server, AgentAction.GET_PLAYER_INVENTORY, Map.of("uuid", PLAYER_ID.toString()));
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst()).containsEntry("materialKey", "minecraft:stone");
+            assertRequestAction(server, "GET_PLAYER_INVENTORY");
         }
     }
 
@@ -181,7 +207,7 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isTrue();
-            assertRequest(server, AgentAction.DROP_ITEM, Map.of("uuid", PLAYER_ID.toString()));
+            assertRequestAction(server, "DROP_ITEM");
         }
     }
 
@@ -197,13 +223,13 @@ class UdsAgentClientTest
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final java.util.List<nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot> result =
+            final List<nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot> result =
                 client.playerChatComponents(PLAYER_ID);
 
             // verify
             assertThat(result).extracting(nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot::json)
                 .containsExactly("{\"text\":\"Hi\"}");
-            assertRequest(server, AgentAction.GET_PLAYER_CHAT_COMPONENTS, Map.of("uuid", PLAYER_ID.toString()));
+            assertRequestAction(server, "GET_PLAYER_CHAT_COMPONENTS");
         }
     }
 
@@ -219,17 +245,14 @@ class UdsAgentClientTest
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final java.util.List<nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot> result =
-                client.getCapturedEvents("org.bukkit.event.Event");
+            final List<Map<String, String>> result = client.getCapturedEvents("org.bukkit.event.Event");
 
             // verify
             assertThat(result).hasSize(1);
-            assertThat(result.getFirst().data()).containsEntry("getValue", "value");
-            assertRequest(
-                server,
-                AgentAction.GET_CAPTURED_EVENTS,
-                Map.of("eventClassName", "org.bukkit.event.Event")
-            );
+            assertThat(result.getFirst()).containsEntry("getValue", "value");
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("GET_CAPTURED_EVENTS");
+            assertThat(request.get("eventClassName").asText()).isEqualTo("org.bukkit.event.Event");
         }
     }
 
@@ -239,14 +262,20 @@ class UdsAgentClientTest
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-handshake.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("protocolVersion", "1", "bukkitVersion", "1.21.11")));
-             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("protocolVersion", "1", "bukkitVersion", "1.21.11"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
             client.handshake("my-token", 1, "sha256");
 
             // verify
-            assertRequest(server, AgentAction.HANDSHAKE, Map.of("token", "my-token", "protocolVersion", "1", "agentSha256", "sha256"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("HANDSHAKE");
+            assertThat(request.get("token").asText()).isEqualTo("my-token");
+            assertThat(request.get("protocolVersion").asInt()).isEqualTo(1);
+            assertThat(request.get("agentSha256").asText()).isEqualTo("sha256");
         }
     }
 
@@ -264,7 +293,7 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isEqualTo("world");
-            assertRequest(server, AgentAction.MAIN_WORLD, Map.of());
+            assertRequestAction(server, "MAIN_WORLD");
         }
     }
 
@@ -274,7 +303,7 @@ class UdsAgentClientTest
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-unload-chunk.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("success", "false")));
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("unloaded", "false")));
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
@@ -282,7 +311,11 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isFalse();
-            assertRequest(server, AgentAction.UNLOAD_CHUNK, Map.of("worldName", "world", "x", "5", "z", "-3"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("UNLOAD_CHUNK");
+            assertThat(request.get("worldName").asText()).isEqualTo("world");
+            assertThat(request.get("x").asInt()).isEqualTo(5);
+            assertThat(request.get("z").asInt()).isEqualTo(-3);
         }
     }
 
@@ -300,7 +333,7 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isTrue();
-            assertRequest(server, AgentAction.IS_CHUNK_LOADED, Map.of("worldName", "world", "x", "1", "z", "2"));
+            assertRequestAction(server, "IS_CHUNK_LOADED");
         }
     }
 
@@ -319,7 +352,10 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isTrue();
-            assertRequest(server, AgentAction.EXECUTE_COMMAND, Map.of("source", "CONSOLE", "command", "time set day"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("EXECUTE_COMMAND");
+            assertThat(request.get("commandSource").asText()).isEqualTo("CONSOLE");
+            assertThat(request.get("command").asText()).isEqualTo("time set day");
         }
     }
 
@@ -336,8 +372,9 @@ class UdsAgentClientTest
             client.registerEventListener("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
-            assertRequest(server, AgentAction.REGISTER_EVENT_LISTENER,
-                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("REGISTER_EVENT_LISTENER");
+            assertThat(request.get("eventClassName").asText()).isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
         }
     }
 
@@ -354,8 +391,10 @@ class UdsAgentClientTest
             client.clearCapturedEvents("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
-            assertRequest(server, AgentAction.CLEAR_CAPTURED_EVENTS,
-                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("CLEAR_CAPTURED_EVENTS");
+            assertThat(request.get("eventClassName").asText())
+                .isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
         }
     }
 
@@ -372,8 +411,10 @@ class UdsAgentClientTest
             client.unregisterEventListener("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
-            assertRequest(server, AgentAction.UNREGISTER_EVENT_LISTENER,
-                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("UNREGISTER_EVENT_LISTENER");
+            assertThat(request.get("eventClassName").asText())
+                .isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
         }
     }
 
@@ -383,33 +424,18 @@ class UdsAgentClientTest
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-wait-ticks.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("startTick", "0", "endTick", "5")));
-             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("startTick", "0", "endTick", "5"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
             client.waitTicks(5);
 
             // verify
-            assertRequest(server, AgentAction.WAIT_TICKS, Map.of("ticks", "5"));
-        }
-    }
-
-    @Test
-    void serverPlatform_shouldMapUnknownPlatformToUnknown(@TempDir Path tempDirectory)
-        throws Exception
-    {
-        // setup
-        final Path socketPath = tempDirectory.resolve("agent-platform-unknown.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(
-            socketPath,
-            successResponse(Map.of("platform", "Sponge"))
-        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
-        {
-            // execute
-            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
-
-            // verify
-            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.UNKNOWN);
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("WAIT_TICKS");
+            assertThat(request.get("ticks").asInt()).isEqualTo(5);
         }
     }
 
@@ -425,11 +451,11 @@ class UdsAgentClientTest
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final java.util.List<String> result = client.playerMessages(PLAYER_ID);
+            final List<String> result = client.playerMessages(PLAYER_ID);
 
             // verify
             assertThat(result).containsExactly("hello", "world");
-            assertRequest(server, AgentAction.GET_PLAYER_MESSAGES, Map.of("uuid", PLAYER_ID.toString()));
+            assertRequestAction(server, "GET_PLAYER_MESSAGES");
         }
     }
 
@@ -438,13 +464,21 @@ class UdsAgentClientTest
         return new AgentResponse("1", true, null, null, data);
     }
 
-    private static void assertRequest(AgentSocketServer server, AgentAction action, Map<String, String> arguments)
+    /**
+     * Asserts that the received request JSON has the expected {@code "action"} field value.
+     *
+     * @param server
+     *     The test socket server holding the received request line.
+     * @param expectedAction
+     *     The expected action name (e.g. {@code "LOAD_CHUNK"}).
+     * @throws IOException
+     *     If JSON parsing fails.
+     */
+    private static void assertRequestAction(AgentSocketServer server, String expectedAction)
         throws IOException
     {
-        final nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest request =
-            REQUEST_MAPPER.readValue(server.requestLine(), nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest.class);
-        assertThat(request.action()).isEqualTo(action);
-        assertThat(request.arguments()).isEqualTo(arguments);
+        final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+        assertThat(request.get("action").asText()).isEqualTo(expectedAction);
     }
 
     private static final class AgentSocketServer implements AutoCloseable
@@ -486,10 +520,10 @@ class UdsAgentClientTest
                  BufferedWriter writer = new BufferedWriter(
                      Channels.newWriter(clientChannel, StandardCharsets.UTF_8)))
             {
-                final String requestLine = reader.readLine();
-                if (requestLine == null)
+                final String line = reader.readLine();
+                if (line == null)
                     return;
-                this.requestLine.set(requestLine);
+                this.requestLine.set(line);
                 writer.write(OBJECT_MAPPER.writeValueAsString(response));
                 writer.newLine();
                 writer.flush();

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
@@ -135,7 +135,7 @@ class LightkeeperBotIT
         final MenuHandle noLongerOpenMenu = builtPlayer.getMenu();
         explicitPlayer.placeBlock("STONE", 2, 100, 0);
         framework.waitUntil(
-            () -> "STONE".equals(buildWorldResult.blockTypeAt(new Vector3Di(2, 100, 0))),
+            () -> "minecraft:stone".equals(buildWorldResult.blockTypeAt(new Vector3Di(2, 100, 0))),
             Duration.ofSeconds(20)
         );
 

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperExtensionIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperExtensionIT.java
@@ -33,7 +33,7 @@ class LightkeeperExtensionIT
         // execute
         final var world = framework.newWorld();
         world.setBlockAt(position, "STONE");
-        framework.waitUntil(() -> "STONE".equals(world.blockTypeAt(position)), Duration.ofSeconds(20));
+        framework.waitUntil(() -> "minecraft:stone".equals(world.blockTypeAt(position)), Duration.ofSeconds(20));
 
         // verify
         assertThat(world.name())

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperFrameworkIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperFrameworkIT.java
@@ -62,7 +62,7 @@ class LightkeeperFrameworkIT
             final WorldHandle worldHandle = framework.newWorld(worldSpec);
             worldHandle.setBlockAt(position, "STONE");
             framework.waitUntil(
-                () -> "STONE".equals(worldHandle.blockTypeAt(position)),
+                () -> "minecraft:stone".equals(worldHandle.blockTypeAt(position)),
                 Duration.ofSeconds(20)
             );
 

--- a/lightkeeper-nms-parent/lightkeeper-nms-api/src/main/java/nl/pim16aap2/lightkeeper/nms/api/IBotPlayerNmsAdapter.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-api/src/main/java/nl/pim16aap2/lightkeeper/nms/api/IBotPlayerNmsAdapter.java
@@ -43,4 +43,13 @@ public interface IBotPlayerNmsAdapter
      * @return Newly captured messages since the previous drain.
      */
     List<String> drainReceivedMessages(UUID playerId);
+
+    /**
+     * Drains newly received chat components (JSON format) for a synthetic player.
+     *
+     * @param playerId
+     *     Synthetic player UUID.
+     * @return Newly captured chat components since the previous drain.
+     */
+    List<String> drainChatComponents(UUID playerId);
 }

--- a/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7.java
@@ -55,6 +55,8 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
     private final Field connectionChannelField;
     private final Field connectionAddressField;
     private final Method embeddedChannelReadOutboundMethod;
+    private final Method componentSerializerToJsonMethod;
+    private final Object registryAccess;
     private final Object serverboundPacketFlow;
 
     /**
@@ -71,6 +73,27 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             final Method craftServerGetServerMethod = craftServerClass.getMethod("getServer");
             minecraftServer = craftServerGetServerMethod.invoke(craftServer);
             playerList = resolvePlayerList(minecraftServer, serverClassLoader);
+
+            final Method registryAccessMethod = minecraftServer.getClass().getMethod("registryAccess");
+            registryAccess = registryAccessMethod.invoke(minecraftServer);
+
+            final Class<?> componentClass = resolveClass(
+                "net.minecraft.network.chat.Component",
+                serverClassLoader
+            );
+            final Class<?> registryAccessClass = resolveClass(
+                "net.minecraft.core.HolderLookup$Provider",
+                serverClassLoader
+            );
+            final Class<?> componentSerializerClass = resolveClass(
+                "net.minecraft.network.chat.Component$Serializer",
+                serverClassLoader
+            );
+            componentSerializerToJsonMethod = componentSerializerClass.getMethod(
+                "toJson",
+                componentClass,
+                registryAccessClass
+            );
 
             final Class<?> gameProfileClass = resolveClass(
                 "com.mojang.authlib.GameProfile",
@@ -669,6 +692,84 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             );
         }
         return List.copyOf(messages);
+    }
+
+    /**
+     * Drains newly received chat components (JSON format) for a synthetic player.
+     *
+     * @param playerId
+     *     Synthetic player UUID.
+     * @return Newly captured chat components since the previous drain.
+     */
+    @Override
+    public List<String> drainChatComponents(UUID playerId)
+    {
+        Objects.requireNonNull(playerId, "playerId may not be null.");
+        final Object embeddedChannel = playerChannels.get(playerId);
+        if (embeddedChannel == null)
+            return List.of();
+
+        final List<String> components = new ArrayList<>();
+        try
+        {
+            Object outboundPacket;
+            while ((outboundPacket = embeddedChannelReadOutboundMethod.invoke(embeddedChannel)) != null)
+            {
+                final String json =
+                    extractComponentJson(outboundPacket, TEXT_EXTRACTION_MAX_DEPTH, new IdentityHashMap<>());
+                if (json != null)
+                    components.add(json);
+            }
+        }
+        catch (Exception exception)
+        {
+            throw new IllegalStateException(
+                "Failed to drain chat components for synthetic player '%s'."
+                    .formatted(playerId),
+                exception
+            );
+        }
+        return List.copyOf(components);
+    }
+
+    private @Nullable String extractComponentJson(
+        @Nullable Object value,
+        int depth,
+        IdentityHashMap<Object, Boolean> seen)
+    {
+        if (value == null || depth < 0 || seen.put(value, Boolean.TRUE) != null)
+            return null;
+
+        if (value.getClass().getSimpleName().endsWith("Component") ||
+            value.getClass().getName().startsWith("net.minecraft.network.chat."))
+        {
+            try
+            {
+                return (String) componentSerializerToJsonMethod.invoke(null, value, registryAccess);
+            }
+            catch (Exception ignored)
+            {
+            }
+        }
+
+        // Recursively search for components in packets/objects
+        for (final Method method : value.getClass().getMethods())
+        {
+            if (method.getParameterCount() == 0 && !method.getDeclaringClass().equals(Object.class))
+            {
+                try
+                {
+                    final Object nestedValue = method.invoke(value);
+                    final String json = extractComponentJson(nestedValue, depth - 1, seen);
+                    if (json != null)
+                        return json;
+                }
+                catch (Exception ignored)
+                {
+                }
+            }
+        }
+        return null;
     }
 
     private static @Nullable String extractText(

--- a/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7.java
@@ -7,24 +7,25 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.Nullable;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Paper 1.21.11 (v1_21_R7) synthetic-player adapter.
@@ -33,12 +34,13 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
 {
     private static final System.Logger LOG = System.getLogger(BotPlayerNmsAdapterV1_21_R7.class.getName());
 
-    private static final int TEXT_EXTRACTION_MAX_DEPTH = 4;
-    private static final int TEXT_EXTRACTION_MAX_METHODS = 24;
+    private static final int TEXT_EXTRACTION_MAX_DEPTH = NmsValueExtractor.MAX_DEPTH;
 
     private final Object minecraftServer;
     private final Object playerList;
     private final Map<UUID, Object> playerChannels = new ConcurrentHashMap<>();
+    private final Map<UUID, Queue<String>> playerMessageQueues = new ConcurrentHashMap<>();
+    private final Map<UUID, Queue<String>> playerChatComponentQueues = new ConcurrentHashMap<>();
 
     private final Constructor<?> gameProfileConstructor;
     private final Constructor<?> connectionConstructor;
@@ -55,8 +57,10 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
     private final Field connectionChannelField;
     private final Field connectionAddressField;
     private final Method embeddedChannelReadOutboundMethod;
-    private final Method componentSerializerToJsonMethod;
-    private final Object registryAccess;
+    private final Object componentJsonCodec;
+    private final Object componentJsonOps;
+    private final Method componentCodecEncodeStartMethod;
+    private final Method dataResultResultMethod;
     private final Object serverboundPacketFlow;
 
     /**
@@ -74,65 +78,61 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             minecraftServer = craftServerGetServerMethod.invoke(craftServer);
             playerList = resolvePlayerList(minecraftServer, serverClassLoader);
 
-            final Method registryAccessMethod = minecraftServer.getClass().getMethod("registryAccess");
-            registryAccess = registryAccessMethod.invoke(minecraftServer);
+            final Class<?> componentSerializationClass = NmsReflectionUtils.resolveClass(
+                "net.minecraft.network.chat.ComponentSerialization",
+                serverClassLoader
+            );
+            final Class<?> codecClass =
+                NmsReflectionUtils.resolveClass("com.mojang.serialization.Codec", serverClassLoader);
+            final Class<?> dataResultClass =
+                NmsReflectionUtils.resolveClass("com.mojang.serialization.DataResult", serverClassLoader);
+            final Class<?> dynamicOpsClass =
+                NmsReflectionUtils.resolveClass("com.mojang.serialization.DynamicOps", serverClassLoader);
+            final Class<?> jsonOpsClass =
+                NmsReflectionUtils.resolveClass("com.mojang.serialization.JsonOps", serverClassLoader);
+            componentJsonCodec = resolveComponentJsonCodec(componentSerializationClass, codecClass);
+            componentJsonOps = jsonOpsClass.getField("INSTANCE").get(null);
+            componentCodecEncodeStartMethod = codecClass.getMethod("encodeStart", dynamicOpsClass, Object.class);
+            dataResultResultMethod = dataResultClass.getMethod("result");
 
-            final Class<?> componentClass = resolveClass(
-                "net.minecraft.network.chat.Component",
-                serverClassLoader
-            );
-            final Class<?> registryAccessClass = resolveClass(
-                "net.minecraft.core.HolderLookup$Provider",
-                serverClassLoader
-            );
-            final Class<?> componentSerializerClass = resolveClass(
-                "net.minecraft.network.chat.Component$Serializer",
-                serverClassLoader
-            );
-            componentSerializerToJsonMethod = componentSerializerClass.getMethod(
-                "toJson",
-                componentClass,
-                registryAccessClass
-            );
-
-            final Class<?> gameProfileClass = resolveClass(
+            final Class<?> gameProfileClass = NmsReflectionUtils.resolveClass(
                 "com.mojang.authlib.GameProfile",
                 serverClassLoader
             );
-            final Class<?> packetFlowClass = resolveFirstClass(
+            final Class<?> packetFlowClass = NmsReflectionUtils.resolveFirstClass(
                 serverClassLoader,
                 "net.minecraft.network.protocol.PacketFlow",
                 "net.minecraft.network.protocol.EnumProtocolDirection"
             );
-            final Class<?> connectionClass = resolveFirstClass(
+            final Class<?> connectionClass = NmsReflectionUtils.resolveFirstClass(
                 serverClassLoader,
                 "net.minecraft.network.Connection",
                 "net.minecraft.network.NetworkManager"
             );
-            final Class<?> serverPlayerClass = resolveFirstClass(
+            final Class<?> serverPlayerClass = NmsReflectionUtils.resolveFirstClass(
                 serverClassLoader,
                 "net.minecraft.server.level.ServerPlayer",
                 "net.minecraft.server.level.EntityPlayer"
             );
-            final Class<?> commonListenerCookieClass = resolveClass(
+            final Class<?> commonListenerCookieClass = NmsReflectionUtils.resolveClass(
                 "net.minecraft.server.network.CommonListenerCookie",
                 serverClassLoader
             );
 
-            final Class<?> minecraftServerClass = resolveClass(
+            final Class<?> minecraftServerClass = NmsReflectionUtils.resolveClass(
                 "net.minecraft.server.MinecraftServer",
                 serverClassLoader
             );
-            final Class<?> serverLevelClass = resolveFirstClass(
+            final Class<?> serverLevelClass = NmsReflectionUtils.resolveFirstClass(
                 serverClassLoader,
                 "net.minecraft.server.level.ServerLevel",
                 "net.minecraft.server.level.WorldServer"
             );
-            final Class<?> clientInformationClass = resolveClass(
+            final Class<?> clientInformationClass = NmsReflectionUtils.resolveClass(
                 "net.minecraft.server.level.ClientInformation",
                 serverClassLoader
             );
-            final Class<?> embeddedChannelClass = resolveClass(
+            final Class<?> embeddedChannelClass = NmsReflectionUtils.resolveClass(
                 "io.netty.channel.embedded.EmbeddedChannel",
                 serverClassLoader
             );
@@ -148,19 +148,19 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
                 clientInformationClass
             );
 
-            final Class<?> craftWorldClass = resolveClass(
+            final Class<?> craftWorldClass = NmsReflectionUtils.resolveClass(
                 craftBukkitPackage + ".CraftWorld",
                 serverClassLoader
             );
             craftWorldGetHandleMethod = craftWorldClass.getMethod("getHandle");
 
-            commonListenerCreateInitialMethod = resolveStaticFactoryMethod(
+            commonListenerCreateInitialMethod = NmsReflectionUtils.resolveStaticFactoryMethod(
                 commonListenerCookieClass,
                 commonListenerCookieClass,
                 gameProfileClass,
                 boolean.class
             );
-            clientInformationCreateDefaultMethod = resolveStaticNoArgFactoryMethod(
+            clientInformationCreateDefaultMethod = NmsReflectionUtils.resolveStaticNoArgFactoryMethod(
                 clientInformationClass,
                 clientInformationClass
             );
@@ -173,53 +173,48 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             playerListRemoveMethod = resolvePlayerListRemoveMethod(playerList.getClass(), serverPlayerClass);
             serverPlayerGetBukkitEntityMethod = serverPlayerClass.getMethod("getBukkitEntity");
 
-            final Class<?> craftPlayerClass = resolveClass(
+            final Class<?> craftPlayerClass = NmsReflectionUtils.resolveClass(
                 craftBukkitPackage + ".entity.CraftPlayer",
                 serverClassLoader
             );
             craftPlayerGetHandleMethod = craftPlayerClass.getMethod("getHandle");
-            connectionChannelField = resolveFieldByNameOrAcceptedType(connectionClass, "channel", embeddedChannelClass);
-            connectionAddressField = resolveFieldByNameOrType(connectionClass, "address", SocketAddress.class);
+            connectionChannelField = NmsReflectionUtils.resolveFieldByNameOrAcceptedType(
+                connectionClass, "channel", embeddedChannelClass);
+            connectionAddressField = NmsReflectionUtils.resolveFieldByNameOrType(
+                connectionClass, "address", SocketAddress.class);
             embeddedChannelReadOutboundMethod = embeddedChannelClass.getMethod("readOutbound");
         }
         catch (Exception exception)
         {
-            throw new IllegalStateException("Failed to initialize v1_21_R7 NMS adapter.", exception);
+            throw new IllegalStateException(
+                "Failed to initialize v1_21_R7 NMS adapter. Cause: %s: %s"
+                    .formatted(exception.getClass().getName(), exception.getMessage()),
+                exception
+            );
         }
     }
 
-    private static Class<?> resolveClass(String className, ClassLoader classLoader)
-        throws ClassNotFoundException
+    private static Object resolveComponentJsonCodec(Class<?> componentSerializationClass, Class<?> codecClass)
+        throws ReflectiveOperationException
     {
         try
         {
-            return Class.forName(className, false, classLoader);
+            return componentSerializationClass.getField("CODEC").get(null);
         }
-        catch (ClassNotFoundException ignored)
+        catch (NoSuchFieldException ignored)
         {
-            return Class.forName(className);
-        }
-    }
+            for (final Field field : componentSerializationClass.getFields())
+            {
+                if (!Modifier.isStatic(field.getModifiers()) || !codecClass.isAssignableFrom(field.getType()))
+                    continue;
 
-    private static Class<?> resolveFirstClass(ClassLoader classLoader, String... classNames)
-        throws ClassNotFoundException
-    {
-        ClassNotFoundException lastException = null;
-        for (final String className : classNames)
-        {
-            try
-            {
-                return resolveClass(className, classLoader);
+                field.setAccessible(true);
+                return field.get(null);
             }
-            catch (ClassNotFoundException exception)
-            {
-                lastException = exception;
-            }
+            throw new NoSuchFieldException(
+                "Failed to resolve component JSON codec field on " + componentSerializationClass.getName()
+            );
         }
-        throw Objects.requireNonNullElseGet(
-            lastException,
-            () -> new ClassNotFoundException("No candidate class names were provided.")
-        );
     }
 
     private static Object resolveServerboundPacketFlow(Class<?> packetFlowEnumClass)
@@ -238,7 +233,7 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             }
         }
 
-        final Method stringMethod = findNamedNoArgMethod(packetFlowEnumClass, "b");
+        final Method stringMethod = NmsReflectionUtils.findNamedNoArgMethod(packetFlowEnumClass, "b");
         if (stringMethod != null)
         {
             for (final Object enumConstant : enumConstants)
@@ -266,21 +261,24 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
     private static Object resolvePlayerList(Object minecraftServer, ClassLoader serverClassLoader)
         throws ReflectiveOperationException
     {
-        final Method namedMethod = findNamedNoArgMethod(minecraftServer.getClass(), "getPlayerList");
+        final Method namedMethod =
+            NmsReflectionUtils.findNamedNoArgMethod(minecraftServer.getClass(), "getPlayerList");
         if (namedMethod != null)
         {
             return namedMethod.invoke(minecraftServer);
         }
 
-        final Class<?> playerListClass = resolveClass("net.minecraft.server.players.PlayerList", serverClassLoader);
+        final Class<?> playerListClass =
+            NmsReflectionUtils.resolveClass("net.minecraft.server.players.PlayerList", serverClassLoader);
 
-        final Method typedMethod = findNoArgMethodByReturnType(minecraftServer.getClass(), playerListClass);
+        final Method typedMethod =
+            NmsReflectionUtils.findNoArgMethodByReturnType(minecraftServer.getClass(), playerListClass);
         if (typedMethod != null)
         {
             return typedMethod.invoke(minecraftServer);
         }
 
-        final Field typedField = findFieldByType(minecraftServer.getClass(), playerListClass);
+        final Field typedField = NmsReflectionUtils.findFieldByType(minecraftServer.getClass(), playerListClass);
         if (typedField != null)
         {
             return typedField.get(minecraftServer);
@@ -299,7 +297,7 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
     )
         throws NoSuchMethodException
     {
-        final Method namedMethod = findNamedMethod(
+        final Method namedMethod = NmsReflectionUtils.findNamedMethod(
             playerListClass,
             "placeNewPlayer",
             connectionClass,
@@ -310,239 +308,19 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
         {
             return namedMethod;
         }
-        return findCompatibleMethod(playerListClass, connectionClass, serverPlayerClass, commonListenerCookieClass);
+        return NmsReflectionUtils.findCompatibleMethod(
+            playerListClass, connectionClass, serverPlayerClass, commonListenerCookieClass);
     }
 
     private static Method resolvePlayerListRemoveMethod(Class<?> playerListClass, Class<?> serverPlayerClass)
         throws NoSuchMethodException
     {
-        final Method namedMethod = findNamedMethod(playerListClass, "remove", serverPlayerClass);
+        final Method namedMethod = NmsReflectionUtils.findNamedMethod(playerListClass, "remove", serverPlayerClass);
         if (namedMethod != null)
         {
             return namedMethod;
         }
-        return findCompatibleMethod(playerListClass, serverPlayerClass);
-    }
-
-    private static Method resolveStaticFactoryMethod(
-        Class<?> ownerClass,
-        Class<?> returnTypeClass,
-        Class<?>... parameterTypes
-    )
-        throws NoSuchMethodException
-    {
-        for (Class<?> cursor = ownerClass; cursor != null; cursor = cursor.getSuperclass())
-        {
-            for (final Method method : cursor.getDeclaredMethods())
-            {
-                if (!java.lang.reflect.Modifier.isStatic(method.getModifiers()))
-                {
-                    continue;
-                }
-                if (!returnTypeClass.isAssignableFrom(method.getReturnType()))
-                {
-                    continue;
-                }
-                final Class<?>[] methodParameterTypes = method.getParameterTypes();
-                if (methodParameterTypes.length != parameterTypes.length)
-                {
-                    continue;
-                }
-                boolean compatible = true;
-                for (int idx = 0; idx < methodParameterTypes.length; ++idx)
-                {
-                    if (!methodParameterTypes[idx].isAssignableFrom(parameterTypes[idx]))
-                    {
-                        compatible = false;
-                        break;
-                    }
-                }
-                if (!compatible)
-                {
-                    continue;
-                }
-                method.setAccessible(true);
-                return method;
-            }
-        }
-        throw new NoSuchMethodException(
-            "Failed to resolve static factory method on "
-                + ownerClass.getName()
-                + " for return type "
-                + returnTypeClass.getName()
-        );
-    }
-
-    private static Method resolveStaticNoArgFactoryMethod(Class<?> ownerClass, Class<?> returnTypeClass)
-        throws NoSuchMethodException
-    {
-        return resolveStaticFactoryMethod(ownerClass, returnTypeClass);
-    }
-
-    private static Field resolveFieldByNameOrType(Class<?> ownerClass, String preferredName, Class<?> fieldType)
-        throws NoSuchFieldException
-    {
-        try
-        {
-            final Field field = ownerClass.getField(preferredName);
-            field.setAccessible(true);
-            return field;
-        }
-        catch (NoSuchFieldException ignored)
-        {
-            final Field typedField = findFieldByType(ownerClass, fieldType);
-            if (typedField != null)
-            {
-                return typedField;
-            }
-            throw new NoSuchFieldException(
-                "Failed to resolve field '" + preferredName + "' on " + ownerClass.getName()
-            );
-        }
-    }
-
-    private static Field resolveFieldByNameOrAcceptedType(
-        Class<?> ownerClass,
-        String preferredName,
-        Class<?> acceptedType
-    )
-        throws NoSuchFieldException
-    {
-        try
-        {
-            final Field field = ownerClass.getField(preferredName);
-            field.setAccessible(true);
-            return field;
-        }
-        catch (NoSuchFieldException ignored)
-        {
-            for (Class<?> cursor = ownerClass; cursor != null; cursor = cursor.getSuperclass())
-            {
-                for (final Field field : cursor.getDeclaredFields())
-                {
-                    if (!field.getType().isAssignableFrom(acceptedType))
-                    {
-                        continue;
-                    }
-                    field.setAccessible(true);
-                    return field;
-                }
-            }
-            throw new NoSuchFieldException(
-                "Failed to resolve field '" + preferredName + "' on " + ownerClass.getName()
-            );
-        }
-    }
-
-    private static @Nullable Method findNamedNoArgMethod(Class<?> type, String methodName)
-    {
-        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
-        {
-            try
-            {
-                final Method method = cursor.getDeclaredMethod(methodName);
-                method.setAccessible(true);
-                return method;
-            }
-            catch (NoSuchMethodException ignored)
-            {
-                // Continue searching in super class.
-            }
-        }
-        return null;
-    }
-
-    private static @Nullable Method findNoArgMethodByReturnType(Class<?> type, Class<?> returnType)
-    {
-        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
-        {
-            for (final Method method : cursor.getDeclaredMethods())
-            {
-                if (method.getParameterCount() != 0 || !returnType.isAssignableFrom(method.getReturnType()))
-                {
-                    continue;
-                }
-                method.setAccessible(true);
-                return method;
-            }
-        }
-        return null;
-    }
-
-    private static @Nullable Field findFieldByType(Class<?> type, Class<?> fieldType)
-    {
-        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
-        {
-            for (final Field field : cursor.getDeclaredFields())
-            {
-                if (!fieldType.isAssignableFrom(field.getType()))
-                {
-                    continue;
-                }
-                field.setAccessible(true);
-                return field;
-            }
-        }
-        return null;
-    }
-
-    private static @Nullable Method findNamedMethod(Class<?> type, String methodName, Class<?>... parameterTypes)
-    {
-        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
-        {
-            try
-            {
-                final Method method = cursor.getDeclaredMethod(methodName, parameterTypes);
-                method.setAccessible(true);
-                return method;
-            }
-            catch (NoSuchMethodException ignored)
-            {
-                // Continue searching in super class.
-            }
-        }
-        return null;
-    }
-
-    private static Method findCompatibleMethod(Class<?> type, Class<?>... argumentTypes)
-        throws NoSuchMethodException
-    {
-        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
-        {
-            for (final Method method : cursor.getDeclaredMethods())
-            {
-                final Class<?>[] parameterTypes = method.getParameterTypes();
-                if (parameterTypes.length != argumentTypes.length)
-                {
-                    continue;
-                }
-
-                boolean compatible = true;
-                for (int idx = 0; idx < parameterTypes.length; ++idx)
-                {
-                    if (!parameterTypes[idx].isAssignableFrom(argumentTypes[idx]))
-                    {
-                        compatible = false;
-                        break;
-                    }
-                }
-
-                if (!compatible)
-                {
-                    continue;
-                }
-
-                method.setAccessible(true);
-                return method;
-            }
-        }
-
-        throw new NoSuchMethodException(
-            "Failed to locate compatible method on "
-                + type.getName()
-                + " with parameter types "
-                + List.of(argumentTypes)
-        );
+        return NmsReflectionUtils.findCompatibleMethod(playerListClass, serverPlayerClass);
     }
 
     /**
@@ -591,6 +369,8 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             final Player bukkitPlayer = (Player) serverPlayerGetBukkitEntityMethod.invoke(serverPlayer);
             bukkitPlayer.teleport(spawnLocation);
             playerChannels.put(uuid, embeddedChannel);
+            playerMessageQueues.put(uuid, new ConcurrentLinkedQueue<>());
+            playerChatComponentQueues.put(uuid, new ConcurrentLinkedQueue<>());
             return bukkitPlayer;
         }
         catch (InvocationTargetException exception)
@@ -626,7 +406,10 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
         {
             final Object serverPlayer = craftPlayerGetHandleMethod.invoke(player);
             playerListRemoveMethod.invoke(playerList, serverPlayer);
-            playerChannels.remove(player.getUniqueId());
+            final UUID playerId = player.getUniqueId();
+            playerChannels.remove(playerId);
+            playerMessageQueues.remove(playerId);
+            playerChatComponentQueues.remove(playerId);
         }
         catch (InvocationTargetException exception)
         {
@@ -672,26 +455,9 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
         if (embeddedChannel == null)
             return List.of();
 
-        final List<String> messages = new ArrayList<>();
-        try
-        {
-            Object outboundPacket;
-            while ((outboundPacket = embeddedChannelReadOutboundMethod.invoke(embeddedChannel)) != null)
-            {
-                final String message = extractText(outboundPacket, TEXT_EXTRACTION_MAX_DEPTH, new IdentityHashMap<>());
-                if (message != null && !message.isBlank())
-                    messages.add(message);
-            }
-        }
-        catch (Exception exception)
-        {
-            throw new IllegalStateException(
-                "Failed to drain received messages for synthetic player '%s'."
-                    .formatted(playerId),
-                exception
-            );
-        }
-        return List.copyOf(messages);
+        drainOutboundPackets(playerId, embeddedChannel);
+        return NmsReflectionUtils.drainQueue(
+            playerMessageQueues.computeIfAbsent(playerId, ignored -> new ConcurrentLinkedQueue<>()));
     }
 
     /**
@@ -709,27 +475,41 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
         if (embeddedChannel == null)
             return List.of();
 
-        final List<String> components = new ArrayList<>();
+        drainOutboundPackets(playerId, embeddedChannel);
+        final Queue<String> componentQueue =
+            playerChatComponentQueues.computeIfAbsent(playerId, ignored -> new ConcurrentLinkedQueue<>());
+        return NmsReflectionUtils.drainQueue(componentQueue);
+    }
+
+    private void drainOutboundPackets(UUID playerId, Object embeddedChannel)
+    {
+        final Queue<String> messageQueue =
+            playerMessageQueues.computeIfAbsent(playerId, ignored -> new ConcurrentLinkedQueue<>());
+        final Queue<String> componentQueue =
+            playerChatComponentQueues.computeIfAbsent(playerId, ignored -> new ConcurrentLinkedQueue<>());
         try
         {
             Object outboundPacket;
             while ((outboundPacket = embeddedChannelReadOutboundMethod.invoke(embeddedChannel)) != null)
             {
+                final String message = extractText(outboundPacket, TEXT_EXTRACTION_MAX_DEPTH, new IdentityHashMap<>());
+                if (message != null && !message.isBlank())
+                    messageQueue.add(message);
+
                 final String json =
                     extractComponentJson(outboundPacket, TEXT_EXTRACTION_MAX_DEPTH, new IdentityHashMap<>());
                 if (json != null)
-                    components.add(json);
+                    componentQueue.add(json);
             }
         }
         catch (Exception exception)
         {
             throw new IllegalStateException(
-                "Failed to drain chat components for synthetic player '%s'."
+                "Failed to drain outbound packets for synthetic player '%s'."
                     .formatted(playerId),
                 exception
             );
         }
-        return List.copyOf(components);
     }
 
     private @Nullable String extractComponentJson(
@@ -737,39 +517,81 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
         int depth,
         IdentityHashMap<Object, Boolean> seen)
     {
-        if (value == null || depth < 0 || seen.put(value, Boolean.TRUE) != null)
+        return NmsValueExtractor.extract(
+            value, depth, seen,
+            this::trySerializeComponentToJson,
+            BotPlayerNmsAdapterV1_21_R7::isSafeComponentAccessor,
+            false
+        );
+    }
+
+    /**
+     * Detects NMS chat component objects and serialises them to JSON.
+     * Returns {@code null} when {@code value} is not a component or serialisation fails.
+     */
+    private @Nullable String trySerializeComponentToJson(Object value)
+    {
+        if (!value.getClass().getSimpleName().endsWith("Component") &&
+            !value.getClass().getName().startsWith("net.minecraft.network.chat."))
+        {
             return null;
-
-        if (value.getClass().getSimpleName().endsWith("Component") ||
-            value.getClass().getName().startsWith("net.minecraft.network.chat."))
-        {
-            try
-            {
-                return (String) componentSerializerToJsonMethod.invoke(null, value, registryAccess);
-            }
-            catch (Exception ignored)
-            {
-            }
         }
-
-        // Recursively search for components in packets/objects
-        for (final Method method : value.getClass().getMethods())
+        try
         {
-            if (method.getParameterCount() == 0 && !method.getDeclaringClass().equals(Object.class))
-            {
-                try
-                {
-                    final Object nestedValue = method.invoke(value);
-                    final String json = extractComponentJson(nestedValue, depth - 1, seen);
-                    if (json != null)
-                        return json;
-                }
-                catch (Exception ignored)
-                {
-                }
-            }
+            final Object dataResult = componentCodecEncodeStartMethod.invoke(
+                componentJsonCodec,
+                componentJsonOps,
+                value
+            );
+            final Optional<?> serializedJson = (Optional<?>) dataResultResultMethod.invoke(dataResult);
+            return serializedJson.map(Object::toString).orElse(null);
         }
-        return null;
+        catch (Exception exception)
+        {
+            LOG.log(
+                System.Logger.Level.TRACE,
+                "Ignoring component serialization failure while extracting packet component.",
+                exception
+            );
+            return null;
+        }
+    }
+
+    private static boolean isSafeComponentAccessor(Method method)
+    {
+        if (method.getParameterCount() != 0)
+            return false;
+        if (method.getDeclaringClass() == Object.class)
+            return false;
+
+        final String methodName = method.getName();
+        if (methodName.equals("getClass") || methodName.equals("hashCode") || methodName.equals("toString"))
+            return false;
+
+        final Class<?> returnType = method.getReturnType();
+        if (returnType == Void.TYPE || returnType.isPrimitive())
+            return false;
+
+        final String lowerMethodName = methodName.toLowerCase(Locale.ROOT);
+        final boolean safeName = methodName.startsWith("get") ||
+            methodName.startsWith("is") ||
+            lowerMethodName.contains("component") ||
+            lowerMethodName.contains("message") ||
+            lowerMethodName.contains("content") ||
+            lowerMethodName.contains("title");
+        if (!safeName)
+            return false;
+
+        if (Optional.class.isAssignableFrom(returnType))
+            return true;
+        if (Collection.class.isAssignableFrom(returnType))
+            return true;
+        if (returnType.isArray())
+            return true;
+
+        final String returnTypeName = returnType.getName();
+        return returnTypeName.startsWith("net.minecraft.network.chat.") ||
+            returnTypeName.endsWith("Component");
     }
 
     private static @Nullable String extractText(
@@ -777,76 +599,20 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
         int depth,
         IdentityHashMap<Object, Boolean> seen)
     {
-        if (value == null || depth < 0 || seen.put(value, Boolean.TRUE) != null)
-            return null;
-
-        switch (value)
-        {
-            case String stringValue ->
+        // Try getString() directly first (net.minecraft.network.chat.Component has this method).
+        // NmsValueExtractor.extract handles containers first, so we pre-check for String leaves here.
+        return NmsValueExtractor.extract(
+            value, depth, seen,
+            v ->
             {
-                return stringValue;
-            }
-            case Optional<?> optional ->
-            {
-                return optional.map(inner -> extractText(inner, depth - 1, seen)).orElse(null);
-            }
-            case Collection<?> collection ->
-            {
-                for (final Object element : collection)
-                {
-                    final String extracted = extractText(element, depth - 1, seen);
-                    if (extracted != null && !extracted.isBlank())
-                        return extracted;
-                }
-                return null;
-            }
-            default ->
-            {
-            }
-        }
-        if (value.getClass().isArray())
-        {
-            final int arrayLength = Array.getLength(value);
-            for (int index = 0; index < arrayLength; ++index)
-            {
-                final String extracted = extractText(Array.get(value, index), depth - 1, seen);
-                if (extracted != null && !extracted.isBlank())
-                    return extracted;
-            }
-            return null;
-        }
-
-        // net.minecraft.network.chat.Component has getString().
-        final String directText = invokeStringMethod(value, "getString");
-        if (directText != null && !directText.isBlank())
-            return directText;
-
-        int inspectedMethodCount = 0;
-        for (final Method method : value.getClass().getMethods())
-        {
-            if (!isSafeTextAccessor(method))
-                continue;
-            if (inspectedMethodCount >= TEXT_EXTRACTION_MAX_METHODS)
-                break;
-            ++inspectedMethodCount;
-
-            try
-            {
-                final Object nestedValue = method.invoke(value);
-                final String extracted = extractText(nestedValue, depth - 1, seen);
-                if (extracted != null && !extracted.isBlank())
-                    return extracted;
-            }
-            catch (Exception exception)
-            {
-                LOG.log(
-                    System.Logger.Level.TRACE,
-                    "Ignoring reflective accessor failure while extracting packet text.",
-                    exception
-                );
-            }
-        }
-        return null;
+                if (v instanceof String s)
+                    return s.isBlank() ? null : s;
+                final String direct = NmsReflectionUtils.invokeStringMethod(v, "getString");
+                return (direct != null && !direct.isBlank()) ? direct : null;
+            },
+            BotPlayerNmsAdapterV1_21_R7::isSafeTextAccessor,
+            true
+        );
     }
 
     private static boolean isSafeTextAccessor(Method method)
@@ -886,18 +652,4 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             lowerMethodName.contains("title");
     }
 
-    private static @Nullable String invokeStringMethod(Object target, String methodName)
-    {
-        try
-        {
-            final Method method = target.getClass().getMethod(methodName);
-            if (method.getReturnType() != String.class)
-                return null;
-            return (String) method.invoke(target);
-        }
-        catch (Exception ignored)
-        {
-            return null;
-        }
-    }
 }

--- a/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/NmsReflectionUtils.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/NmsReflectionUtils.java
@@ -1,0 +1,433 @@
+package nl.pim16aap2.lightkeeper.nms.v121r7;
+
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+
+/**
+ * Generic reflection utilities shared by NMS adapter code.
+ *
+ * <p>All methods are pure reflection helpers with no dependency on any Minecraft, Bukkit, or Spigot
+ * internals. They are kept package-private so that only the v1_21_R7 adapter module can use them.
+ */
+final class NmsReflectionUtils
+{
+    private NmsReflectionUtils()
+    {
+    }
+
+    /**
+     * Loads a class by name, preferring the supplied class loader and falling back to the system class loader.
+     *
+     * @param className
+     *     Fully qualified class name.
+     * @param classLoader
+     *     Preferred class loader.
+     * @return
+     *     Resolved class.
+     * @throws ClassNotFoundException
+     *     When the class cannot be found in either loader.
+     */
+    static Class<?> resolveClass(String className, ClassLoader classLoader)
+        throws ClassNotFoundException
+    {
+        try
+        {
+            return Class.forName(className, false, classLoader);
+        }
+        catch (ClassNotFoundException ignored)
+        {
+            return Class.forName(className);
+        }
+    }
+
+    /**
+     * Tries to load each candidate class name in order and returns the first one found.
+     *
+     * @param classLoader
+     *     Preferred class loader passed to {@link #resolveClass}.
+     * @param classNames
+     *     Candidate fully qualified class names.
+     * @return
+     *     The first resolvable class.
+     * @throws ClassNotFoundException
+     *     When none of the candidates can be resolved.
+     */
+    static Class<?> resolveFirstClass(ClassLoader classLoader, String... classNames)
+        throws ClassNotFoundException
+    {
+        ClassNotFoundException lastException = null;
+        for (final String className : classNames)
+        {
+            try
+            {
+                return resolveClass(className, classLoader);
+            }
+            catch (ClassNotFoundException exception)
+            {
+                lastException = exception;
+            }
+        }
+        throw Objects.requireNonNullElseGet(
+            lastException,
+            () -> new ClassNotFoundException("No candidate class names were provided.")
+        );
+    }
+
+    /**
+     * Finds a static factory method on {@code ownerClass} (or any of its superclasses) whose return type is
+     * assignable to {@code returnTypeClass} and whose parameter types match {@code parameterTypes}.
+     *
+     * @param ownerClass
+     *     Class to search (including superclass chain).
+     * @param returnTypeClass
+     *     Expected return type (supertype match accepted).
+     * @param parameterTypes
+     *     Expected parameter types (supertype match accepted per parameter).
+     * @return
+     *     Found method with accessibility set.
+     * @throws NoSuchMethodException
+     *     When no matching static factory method exists.
+     */
+    static Method resolveStaticFactoryMethod(
+        Class<?> ownerClass,
+        Class<?> returnTypeClass,
+        Class<?>... parameterTypes
+    )
+        throws NoSuchMethodException
+    {
+        for (Class<?> cursor = ownerClass; cursor != null; cursor = cursor.getSuperclass())
+        {
+            for (final Method method : cursor.getDeclaredMethods())
+            {
+                if (!Modifier.isStatic(method.getModifiers()))
+                    continue;
+                if (!returnTypeClass.isAssignableFrom(method.getReturnType()))
+                    continue;
+                final Class<?>[] methodParameterTypes = method.getParameterTypes();
+                if (methodParameterTypes.length != parameterTypes.length)
+                    continue;
+
+                boolean compatible = true;
+                for (int idx = 0; idx < methodParameterTypes.length; ++idx)
+                {
+                    if (!methodParameterTypes[idx].isAssignableFrom(parameterTypes[idx]))
+                    {
+                        compatible = false;
+                        break;
+                    }
+                }
+                if (!compatible)
+                    continue;
+
+                method.setAccessible(true);
+                return method;
+            }
+        }
+        throw new NoSuchMethodException(
+            "Failed to resolve static factory method on "
+                + ownerClass.getName()
+                + " for return type "
+                + returnTypeClass.getName()
+        );
+    }
+
+    /**
+     * Finds a static no-argument factory method on {@code ownerClass} whose return type is
+     * assignable to {@code returnTypeClass}.
+     *
+     * @see #resolveStaticFactoryMethod(Class, Class, Class...)
+     */
+    static Method resolveStaticNoArgFactoryMethod(Class<?> ownerClass, Class<?> returnTypeClass)
+        throws NoSuchMethodException
+    {
+        return resolveStaticFactoryMethod(ownerClass, returnTypeClass);
+    }
+
+    /**
+     * Finds a field by name on {@code ownerClass}, falling back to type-based discovery if the name is not found.
+     *
+     * @param ownerClass
+     *     Class to search.
+     * @param preferredName
+     *     Field name to try first.
+     * @param fieldType
+     *     Type to search for when name lookup fails.
+     * @return
+     *     Found field with accessibility set.
+     * @throws NoSuchFieldException
+     *     When neither the name nor type lookup succeeds.
+     */
+    static Field resolveFieldByNameOrType(Class<?> ownerClass, String preferredName, Class<?> fieldType)
+        throws NoSuchFieldException
+    {
+        try
+        {
+            final Field field = ownerClass.getField(preferredName);
+            field.setAccessible(true);
+            return field;
+        }
+        catch (NoSuchFieldException ignored)
+        {
+            final Field typedField = findFieldByType(ownerClass, fieldType);
+            if (typedField != null)
+                return typedField;
+
+            throw new NoSuchFieldException(
+                "Failed to resolve field '" + preferredName + "' on " + ownerClass.getName()
+            );
+        }
+    }
+
+    /**
+     * Finds a field by name on {@code ownerClass}, falling back to assignability-based discovery when the name is
+     * not found. Unlike {@link #resolveFieldByNameOrType}, the fallback checks whether the field's type is
+     * assignable <em>from</em> {@code acceptedType} (i.e., the field is a supertype of the accepted type).
+     *
+     * @param ownerClass
+     *     Class to search (including superclass chain).
+     * @param preferredName
+     *     Field name to try first.
+     * @param acceptedType
+     *     Type whose supertype the field's declared type must be.
+     * @return
+     *     Found field with accessibility set.
+     * @throws NoSuchFieldException
+     *     When neither the name nor the type-assignability lookup succeeds.
+     */
+    static Field resolveFieldByNameOrAcceptedType(
+        Class<?> ownerClass,
+        String preferredName,
+        Class<?> acceptedType
+    )
+        throws NoSuchFieldException
+    {
+        try
+        {
+            final Field field = ownerClass.getField(preferredName);
+            field.setAccessible(true);
+            return field;
+        }
+        catch (NoSuchFieldException ignored)
+        {
+            for (Class<?> cursor = ownerClass; cursor != null; cursor = cursor.getSuperclass())
+            {
+                for (final Field field : cursor.getDeclaredFields())
+                {
+                    if (!field.getType().isAssignableFrom(acceptedType))
+                        continue;
+                    field.setAccessible(true);
+                    return field;
+                }
+            }
+            throw new NoSuchFieldException(
+                "Failed to resolve field '" + preferredName + "' on " + ownerClass.getName()
+            );
+        }
+    }
+
+    /**
+     * Searches the class hierarchy for a public or declared no-argument method with the given name.
+     *
+     * @param type
+     *     Root class to search.
+     * @param methodName
+     *     Method name.
+     * @return
+     *     Found method with accessibility set, or {@code null} when not found.
+     */
+    static @Nullable Method findNamedNoArgMethod(Class<?> type, String methodName)
+    {
+        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
+        {
+            try
+            {
+                final Method method = cursor.getDeclaredMethod(methodName);
+                method.setAccessible(true);
+                return method;
+            }
+            catch (NoSuchMethodException ignored)
+            {
+                // Continue searching in super class.
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Searches the class hierarchy for a public or declared no-argument method with the given return type.
+     *
+     * @param type
+     *     Root class to search.
+     * @param returnType
+     *     Expected return type (supertype match accepted).
+     * @return
+     *     Found method with accessibility set, or {@code null} when not found.
+     */
+    static @Nullable Method findNoArgMethodByReturnType(Class<?> type, Class<?> returnType)
+    {
+        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
+        {
+            for (final Method method : cursor.getDeclaredMethods())
+            {
+                if (method.getParameterCount() != 0 || !returnType.isAssignableFrom(method.getReturnType()))
+                    continue;
+                method.setAccessible(true);
+                return method;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Searches the class hierarchy for a field whose type is assignable to the given field type.
+     *
+     * @param type
+     *     Root class to search.
+     * @param fieldType
+     *     Expected field type (supertype match accepted).
+     * @return
+     *     Found field with accessibility set, or {@code null} when not found.
+     */
+    static @Nullable Field findFieldByType(Class<?> type, Class<?> fieldType)
+    {
+        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
+        {
+            for (final Field field : cursor.getDeclaredFields())
+            {
+                if (!fieldType.isAssignableFrom(field.getType()))
+                    continue;
+                field.setAccessible(true);
+                return field;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Searches the class hierarchy for a method with the exact name and parameter types.
+     *
+     * @param type
+     *     Root class to search.
+     * @param methodName
+     *     Method name.
+     * @param parameterTypes
+     *     Exact parameter types.
+     * @return
+     *     Found method with accessibility set, or {@code null} when not found.
+     */
+    static @Nullable Method findNamedMethod(Class<?> type, String methodName, Class<?>... parameterTypes)
+    {
+        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
+        {
+            try
+            {
+                final Method method = cursor.getDeclaredMethod(methodName, parameterTypes);
+                method.setAccessible(true);
+                return method;
+            }
+            catch (NoSuchMethodException ignored)
+            {
+                // Continue searching in super class.
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Searches the class hierarchy for a method whose parameter count matches and whose parameter types are
+     * assignable from the supplied argument types.
+     *
+     * @param type
+     *     Root class to search.
+     * @param argumentTypes
+     *     Argument types the parameters must be assignable from.
+     * @return
+     *     Found method with accessibility set.
+     * @throws NoSuchMethodException
+     *     When no compatible method exists.
+     */
+    static Method findCompatibleMethod(Class<?> type, Class<?>... argumentTypes)
+        throws NoSuchMethodException
+    {
+        for (Class<?> cursor = type; cursor != null; cursor = cursor.getSuperclass())
+        {
+            for (final Method method : cursor.getDeclaredMethods())
+            {
+                final Class<?>[] parameterTypes = method.getParameterTypes();
+                if (parameterTypes.length != argumentTypes.length)
+                    continue;
+
+                boolean compatible = true;
+                for (int idx = 0; idx < parameterTypes.length; ++idx)
+                {
+                    if (!parameterTypes[idx].isAssignableFrom(argumentTypes[idx]))
+                    {
+                        compatible = false;
+                        break;
+                    }
+                }
+                if (!compatible)
+                    continue;
+
+                method.setAccessible(true);
+                return method;
+            }
+        }
+        throw new NoSuchMethodException(
+            "Failed to locate compatible method on "
+                + type.getName()
+                + " with parameter types "
+                + List.of(argumentTypes)
+        );
+    }
+
+    /**
+     * Drains all elements from a queue into an immutable list.
+     *
+     * @param queue
+     *     Queue to drain.
+     * @return
+     *     Immutable snapshot of the drained elements, in poll order.
+     */
+    static List<String> drainQueue(Queue<String> queue)
+    {
+        final List<String> drained = new ArrayList<>();
+        String value;
+        while ((value = queue.poll()) != null)
+            drained.add(value);
+        return List.copyOf(drained);
+    }
+
+    /**
+     * Invokes a named no-argument method on {@code target} and returns its value if it returns a
+     * {@link String}; returns {@code null} on any failure.
+     *
+     * @param target
+     *     Instance to invoke on.
+     * @param methodName
+     *     Method name to look up via {@link Class#getMethod}.
+     * @return
+     *     String return value, or {@code null} when the method is absent, throws, or returns a non-String type.
+     */
+    static @Nullable String invokeStringMethod(Object target, String methodName)
+    {
+        try
+        {
+            final Method method = target.getClass().getMethod(methodName);
+            if (method.getReturnType() != String.class)
+                return null;
+            return (String) method.invoke(target);
+        }
+        catch (Exception ignored)
+        {
+            return null;
+        }
+    }
+}

--- a/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/NmsValueExtractor.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/NmsValueExtractor.java
@@ -1,0 +1,143 @@
+package nl.pim16aap2.lightkeeper.nms.v121r7;
+
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Generic reflective value extractor shared by both text and chat-component extraction paths.
+ *
+ * <p>Both {@code extractText} and {@code extractComponentJson} in
+ * {@link BotPlayerNmsAdapterV1_21_R7} follow the same recursive structure:
+ * <ol>
+ *   <li>Guard against null / exceeded depth / cycles.</li>
+ *   <li>Detect leaf values and extract them with a caller-supplied function.</li>
+ *   <li>Recurse into {@link Optional}, {@link Collection}, and array containers.</li>
+ *   <li>Reflect over safe zero-arg accessors (capped at {@link #MAX_METHODS}) and recurse.</li>
+ * </ol>
+ *
+ * <p>Callers supply the two points of variance:
+ * <ul>
+ *   <li>{@code leafExtractor} — detects leaf objects and converts them to a string; returns
+ *       {@code null} if the value is not a leaf or extraction fails.</li>
+ *   <li>{@code isSafeAccessor} — determines which zero-arg methods are safe to invoke reflectively.</li>
+ * </ul>
+ *
+ * <p>The {@code skipBlank} flag controls whether blank-but-non-null results from recursive calls
+ * are treated as absent (text extraction) or valid (component JSON extraction).
+ *
+ * <p><b>Design note on heuristic semantics:</b> both paths find the <em>first</em> matching leaf,
+ * not the definitive chat content. Non-chat packets that expose title- or message-like getters may
+ * produce false matches. This is a known trade-off of the reflection-based approach.
+ */
+final class NmsValueExtractor
+{
+    private static final System.Logger LOG = System.getLogger(NmsValueExtractor.class.getName());
+
+    /**
+     * Maximum number of accessor methods inspected per object instance to bound reflection overhead.
+     */
+    static final int MAX_METHODS = 24;
+
+    /**
+     * Maximum recursion depth; limits how deep the extractor follows object graphs.
+     */
+    static final int MAX_DEPTH = 4;
+
+    private NmsValueExtractor()
+    {
+    }
+
+    /**
+     * Recursively extracts a string value from {@code value} using the supplied strategy.
+     *
+     * @param value
+     *     Root object to inspect.
+     * @param depth
+     *     Remaining recursion budget.
+     * @param seen
+     *     Cycle-detection set keyed by object identity.
+     * @param leafExtractor
+     *     Returns a non-null string when {@code value} is a leaf; {@code null} otherwise.
+     * @param isSafeAccessor
+     *     Determines which zero-arg methods are safe to invoke reflectively.
+     * @param skipBlank
+     *     When {@code true}, blank (but non-null) results from recursive calls are skipped;
+     *     use {@code false} for JSON where an empty string is a valid result.
+     * @return
+     *     Extracted string, or {@code null} when nothing was found.
+     */
+    static @Nullable String extract(
+        @Nullable Object value,
+        int depth,
+        IdentityHashMap<Object, Boolean> seen,
+        Function<Object, @Nullable String> leafExtractor,
+        Predicate<Method> isSafeAccessor,
+        boolean skipBlank)
+    {
+        if (value == null || depth < 0 || seen.put(value, Boolean.TRUE) != null)
+            return null;
+
+        final String leaf = leafExtractor.apply(value);
+        if (leaf != null)
+            return (!skipBlank || !leaf.isBlank()) ? leaf : null;
+
+        if (value instanceof Optional<?> optional)
+        {
+            return optional.map(inner -> extract(inner, depth - 1, seen, leafExtractor, isSafeAccessor, skipBlank))
+                .orElse(null);
+        }
+        if (value instanceof Collection<?> collection)
+        {
+            for (final Object element : collection)
+            {
+                final String result = extract(element, depth - 1, seen, leafExtractor, isSafeAccessor, skipBlank);
+                if (result != null && (!skipBlank || !result.isBlank()))
+                    return result;
+            }
+            return null;
+        }
+        if (value.getClass().isArray())
+        {
+            final int length = Array.getLength(value);
+            for (int index = 0; index < length; ++index)
+            {
+                final String result =
+                    extract(Array.get(value, index), depth - 1, seen, leafExtractor, isSafeAccessor, skipBlank);
+                if (result != null && (!skipBlank || !result.isBlank()))
+                    return result;
+            }
+            return null;
+        }
+
+        int inspectedMethodCount = 0;
+        for (final Method method : value.getClass().getMethods())
+        {
+            if (!isSafeAccessor.test(method))
+                continue;
+            if (inspectedMethodCount >= MAX_METHODS)
+                break;
+            ++inspectedMethodCount;
+
+            try
+            {
+                final Object nested = method.invoke(value);
+                final String result = extract(nested, depth - 1, seen, leafExtractor, isSafeAccessor, skipBlank);
+                if (result != null && (!skipBlank || !result.isBlank()))
+                    return result;
+            }
+            catch (Exception exception)
+            {
+                LOG.log(System.Logger.Level.TRACE, "Ignoring reflective accessor failure during extraction.",
+                    exception);
+            }
+        }
+        return null;
+    }
+}

--- a/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/test/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7Test.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/test/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7Test.java
@@ -11,8 +11,10 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,7 +29,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
         throws Exception
     {
         // execute
-        final Class<?> resolvedClass = (Class<?>) invokeStatic(
+        final Class<?> resolvedClass = (Class<?>) invokeStaticOnUtils(
             "resolveClass",
             new Class<?>[]{String.class, ClassLoader.class},
             "java.lang.String",
@@ -43,7 +45,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
         throws Exception
     {
         // execute
-        final Class<?> resolvedClass = (Class<?>) invokeStatic(
+        final Class<?> resolvedClass = (Class<?>) invokeStaticOnUtils(
             "resolveFirstClass",
             new Class<?>[]{ClassLoader.class, String[].class},
             getClass().getClassLoader(),
@@ -58,7 +60,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
     void resolveFirstClass_shouldThrowExceptionWhenNoCandidateExists()
     {
         // execute + verify
-        assertThatThrownBy(() -> invokeStatic(
+        assertThatThrownBy(() -> invokeStaticOnUtils(
             "resolveFirstClass",
             new Class<?>[]{ClassLoader.class, String[].class},
             getClass().getClassLoader(),
@@ -131,26 +133,26 @@ class BotPlayerNmsAdapterV1_21_R7Test
         throws Exception
     {
         // execute
-        final Method namedNoArg = (Method) invokeStatic(
+        final Method namedNoArg = (Method) invokeStaticOnUtils(
             "findNamedNoArgMethod",
             new Class<?>[]{Class.class, String.class},
             MethodFixture.class,
             "getValue"
         );
-        final Method byReturnType = (Method) invokeStatic(
+        final Method byReturnType = (Method) invokeStaticOnUtils(
             "findNoArgMethodByReturnType",
             new Class<?>[]{Class.class, Class.class},
             MethodFixture.class,
             CharSequence.class
         );
-        final Method namedMethod = (Method) invokeStatic(
+        final Method namedMethod = (Method) invokeStaticOnUtils(
             "findNamedMethod",
             new Class<?>[]{Class.class, String.class, Class[].class},
             MethodFixture.class,
             "setValue",
             new Class<?>[]{String.class}
         );
-        final Method compatibleMethod = (Method) invokeStatic(
+        final Method compatibleMethod = (Method) invokeStaticOnUtils(
             "findCompatibleMethod",
             new Class<?>[]{Class.class, Class[].class},
             MethodFixture.class,
@@ -169,20 +171,20 @@ class BotPlayerNmsAdapterV1_21_R7Test
         throws Exception
     {
         // execute
-        final Field byType = (Field) invokeStatic(
+        final Field byType = (Field) invokeStaticOnUtils(
             "findFieldByType",
             new Class<?>[]{Class.class, Class.class},
             FieldFixture.class,
             CharSequence.class
         );
-        final Field byNameOrType = (Field) invokeStatic(
+        final Field byNameOrType = (Field) invokeStaticOnUtils(
             "resolveFieldByNameOrType",
             new Class<?>[]{Class.class, String.class, Class.class},
             FieldFixture.class,
             "missing",
             CharSequence.class
         );
-        final Field byAcceptedType = (Field) invokeStatic(
+        final Field byAcceptedType = (Field) invokeStaticOnUtils(
             "resolveFieldByNameOrAcceptedType",
             new Class<?>[]{Class.class, String.class, Class.class},
             FieldFixture.class,
@@ -213,7 +215,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
             4,
             new IdentityHashMap<>()
         );
-        final String stringFromMissingMethod = (String) invokeStatic(
+        final String stringFromMissingMethod = (String) invokeStaticOnUtils(
             "invokeStringMethod",
             new Class<?>[]{Object.class, String.class},
             new Object(),
@@ -242,7 +244,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
     void helperMethods_shouldThrowExceptionWhenLookupCannotResolveMember()
     {
         // execute + verify
-        assertThatThrownBy(() -> invokeStatic(
+        assertThatThrownBy(() -> invokeStaticOnUtils(
             "findCompatibleMethod",
             new Class<?>[]{Class.class, Class[].class},
             NoCompatibleMethodFixture.class,
@@ -250,7 +252,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
         ))
             .isInstanceOf(NoSuchMethodException.class);
 
-        assertThatThrownBy(() -> invokeStatic(
+        assertThatThrownBy(() -> invokeStaticOnUtils(
             "resolveFieldByNameOrType",
             new Class<?>[]{Class.class, String.class, Class.class},
             NoMatchingFieldFixture.class,
@@ -269,6 +271,8 @@ class BotPlayerNmsAdapterV1_21_R7Test
         final TestChannel channel = new TestChannel("first", " ", "second");
         final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
         setField(adapter, "playerChannels", new ConcurrentHashMap<>(Map.of(playerId, channel)));
+        setField(adapter, "playerMessageQueues", new ConcurrentHashMap<UUID, Queue<String>>());
+        setField(adapter, "playerChatComponentQueues", new ConcurrentHashMap<UUID, Queue<String>>());
         setField(adapter, "embeddedChannelReadOutboundMethod", TestChannel.class.getMethod("readOutbound"));
 
         // execute
@@ -276,6 +280,159 @@ class BotPlayerNmsAdapterV1_21_R7Test
 
         // verify
         assertThat(messages).containsExactly("first", "second");
+    }
+
+    @Test
+    void drains_shouldReturnEmptyListsWhenPlayerHasNoChannel()
+        throws Exception
+    {
+        // setup
+        final UUID playerId = UUID.randomUUID();
+        final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
+        setField(adapter, "playerChannels", new ConcurrentHashMap<UUID, Object>());
+
+        // execute
+        final List<String> messages = adapter.drainReceivedMessages(playerId);
+        final List<String> components = adapter.drainChatComponents(playerId);
+
+        // verify
+        assertThat(messages).isEmpty();
+        assertThat(components).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void drains_shouldRejectNullPlayerId()
+        throws Exception
+    {
+        // setup
+        final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
+
+        // execute + verify
+        assertThatThrownBy(() -> adapter.drainReceivedMessages(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("playerId");
+        assertThatThrownBy(() -> adapter.drainChatComponents(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("playerId");
+    }
+
+    @Test
+    void drainReceivedMessages_shouldWrapChannelReadFailures()
+        throws Exception
+    {
+        // setup
+        final UUID playerId = UUID.randomUUID();
+        final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
+        setField(adapter, "playerChannels", new ConcurrentHashMap<>(Map.of(playerId, new FailingChannel())));
+        setField(adapter, "playerMessageQueues", new ConcurrentHashMap<UUID, Queue<String>>());
+        setField(adapter, "playerChatComponentQueues", new ConcurrentHashMap<UUID, Queue<String>>());
+        setField(adapter, "embeddedChannelReadOutboundMethod", FailingChannel.class.getMethod("readOutbound"));
+
+        // execute + verify
+        assertThatThrownBy(() -> adapter.drainReceivedMessages(playerId))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Failed to drain outbound packets");
+    }
+
+    @Test
+    void drains_shouldKeepMessageAndComponentQueuesIndependent()
+        throws Exception
+    {
+        // setup
+        final UUID playerId = UUID.randomUUID();
+        final TestChannel channel = new TestChannel(new ComponentPacket(new FakeComponent("hello")));
+        final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
+        setField(adapter, "playerChannels", new ConcurrentHashMap<>(Map.of(playerId, channel)));
+        setField(adapter, "playerMessageQueues", new ConcurrentHashMap<UUID, Queue<String>>());
+        setField(adapter, "playerChatComponentQueues", new ConcurrentHashMap<UUID, Queue<String>>());
+        setField(adapter, "embeddedChannelReadOutboundMethod", TestChannel.class.getMethod("readOutbound"));
+        setField(adapter, "componentJsonCodec", new FakeCodec());
+        setField(adapter, "componentJsonOps", new Object());
+        setField(adapter, "componentCodecEncodeStartMethod", FakeCodec.class.getMethod(
+            "encodeStart",
+            Object.class,
+            Object.class
+        ));
+        setField(adapter, "dataResultResultMethod", FakeDataResult.class.getMethod("result"));
+
+        // execute
+        final List<String> messages = adapter.drainReceivedMessages(playerId);
+        final List<String> components = adapter.drainChatComponents(playerId);
+
+        // verify
+        assertThat(messages).containsExactly("hello");
+        assertThat(components).containsExactly("{\"text\":\"hello\"}");
+    }
+
+    @Test
+    void extractComponentJson_shouldInspectOnlySafeAccessors()
+        throws Exception
+    {
+        // setup
+        final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
+        setField(adapter, "componentJsonCodec", new FakeCodec());
+        setField(adapter, "componentJsonOps", new Object());
+        setField(adapter, "componentCodecEncodeStartMethod", FakeCodec.class.getMethod(
+            "encodeStart",
+            Object.class,
+            Object.class
+        ));
+        setField(adapter, "dataResultResultMethod", FakeDataResult.class.getMethod("result"));
+        final boolean safeComponentAccessor = (boolean) invokeStatic(
+            "isSafeComponentAccessor",
+            new Class<?>[]{Method.class},
+            ComponentPacket.class.getMethod("getComponent")
+        );
+        final boolean unsafeComponentAccessor = (boolean) invokeStatic(
+            "isSafeComponentAccessor",
+            new Class<?>[]{Method.class},
+            UnsafeComponentPacket.class.getMethod("value")
+        );
+
+        // execute
+        final String extracted = (String) invokeInstance(
+            adapter,
+            "extractComponentJson",
+            new Class<?>[]{Object.class, int.class, IdentityHashMap.class},
+            new ComponentPacket(new FakeComponent("hello")),
+            4,
+            new IdentityHashMap<>()
+        );
+
+        // verify
+        assertThat(extracted).isEqualTo("{\"text\":\"hello\"}");
+        assertThat(safeComponentAccessor).isTrue();
+        assertThat(unsafeComponentAccessor).isFalse();
+    }
+
+    @Test
+    void extractComponentJson_shouldReturnNullWhenComponentSerializationFails()
+        throws Exception
+    {
+        // setup
+        final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
+        setField(adapter, "componentJsonCodec", new ThrowingCodec());
+        setField(adapter, "componentJsonOps", new Object());
+        setField(adapter, "componentCodecEncodeStartMethod", ThrowingCodec.class.getMethod(
+            "encodeStart",
+            Object.class,
+            Object.class
+        ));
+        setField(adapter, "dataResultResultMethod", FakeDataResult.class.getMethod("result"));
+
+        // execute
+        final String extracted = (String) invokeInstance(
+            adapter,
+            "extractComponentJson",
+            new Class<?>[]{Object.class, int.class, IdentityHashMap.class},
+            new FakeComponent("hello"),
+            4,
+            new IdentityHashMap<>()
+        );
+
+        // verify
+        assertThat(extracted).isNull();
     }
 
     @Test
@@ -295,6 +452,12 @@ class BotPlayerNmsAdapterV1_21_R7Test
         when(craftPlayer.getName()).thenReturn("bot");
         final FakePlayerList playerList = new FakePlayerList();
         final Map<UUID, Object> channels = new ConcurrentHashMap<>(Map.of(playerId, new Object()));
+        final Map<UUID, Queue<String>> messageQueues = new ConcurrentHashMap<>(
+            Map.of(playerId, new ConcurrentLinkedQueue<>(List.of("message")))
+        );
+        final Map<UUID, Queue<String>> componentQueues = new ConcurrentHashMap<>(
+            Map.of(playerId, new ConcurrentLinkedQueue<>(List.of("{}")))
+        );
 
         final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
         StaticAccessors.serverPlayerHandle = serverPlayer;
@@ -302,12 +465,16 @@ class BotPlayerNmsAdapterV1_21_R7Test
         setField(adapter, "playerListRemoveMethod", FakePlayerList.class.getMethod("remove", FakeServerPlayer.class));
         setField(adapter, "playerList", playerList);
         setField(adapter, "playerChannels", channels);
+        setField(adapter, "playerMessageQueues", messageQueues);
+        setField(adapter, "playerChatComponentQueues", componentQueues);
 
         // execute
         adapter.removePlayer(craftPlayer);
 
         // verify
         assertThat(channels).isEmpty();
+        assertThat(messageQueues).isEmpty();
+        assertThat(componentQueues).isEmpty();
         assertThat(playerList.removedPlayer).isSameAs(serverPlayer);
     }
 
@@ -328,6 +495,8 @@ class BotPlayerNmsAdapterV1_21_R7Test
         setField(adapter, "minecraftServer", server);
         setField(adapter, "playerList", playerList);
         setField(adapter, "playerChannels", new ConcurrentHashMap<>());
+        setField(adapter, "playerMessageQueues", new ConcurrentHashMap<UUID, Queue<String>>());
+        setField(adapter, "playerChatComponentQueues", new ConcurrentHashMap<UUID, Queue<String>>());
 
         setField(adapter, "gameProfileConstructor", FakeGameProfile.class.getConstructor(UUID.class, String.class));
         setField(adapter, "connectionConstructor", FakeConnection.class.getConstructor(FakePacketFlow.class));
@@ -392,11 +561,51 @@ class BotPlayerNmsAdapterV1_21_R7Test
     private static Object invokeStatic(String methodName, Class<?>[] parameterTypes, Object... arguments)
         throws Exception
     {
-        final Method method = BotPlayerNmsAdapterV1_21_R7.class.getDeclaredMethod(methodName, parameterTypes);
+        return invokeStaticOn(BotPlayerNmsAdapterV1_21_R7.class, methodName, parameterTypes, arguments);
+    }
+
+    private static Object invokeStaticOnUtils(String methodName, Class<?>[] parameterTypes, Object... arguments)
+        throws Exception
+    {
+        return invokeStaticOn(NmsReflectionUtils.class, methodName, parameterTypes, arguments);
+    }
+
+    private static Object invokeStaticOn(
+        Class<?> targetClass,
+        String methodName,
+        Class<?>[] parameterTypes,
+        Object... arguments)
+        throws Exception
+    {
+        final Method method = targetClass.getDeclaredMethod(methodName, parameterTypes);
         method.setAccessible(true);
         try
         {
             return method.invoke(null, arguments);
+        }
+        catch (InvocationTargetException exception)
+        {
+            final Throwable cause = exception.getCause();
+            if (cause instanceof Exception wrappedException)
+                throw wrappedException;
+            if (cause instanceof Error wrappedError)
+                throw wrappedError;
+            throw exception;
+        }
+    }
+
+    private static Object invokeInstance(
+        Object target,
+        String methodName,
+        Class<?>[] parameterTypes,
+        Object... arguments)
+        throws Exception
+    {
+        final Method method = BotPlayerNmsAdapterV1_21_R7.class.getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        try
+        {
+            return method.invoke(target, arguments);
         }
         catch (InvocationTargetException exception)
         {
@@ -503,6 +712,68 @@ class BotPlayerNmsAdapterV1_21_R7Test
         public @Nullable Object readOutbound()
         {
             return index < values.length ? values[index++] : null;
+        }
+    }
+
+    public static final class FailingChannel
+    {
+        @SuppressWarnings("unused")
+        public @Nullable Object readOutbound()
+        {
+            if (System.nanoTime() >= 0L)
+                throw new IllegalStateException("boom");
+            return null;
+        }
+    }
+
+    public record ComponentPacket(FakeComponent component)
+    {
+        @SuppressWarnings("unused")
+        public FakeComponent getComponent()
+        {
+            return component;
+        }
+    }
+
+    public record UnsafeComponentPacket(FakeComponent value)
+    {
+    }
+
+    public record FakeComponent(String text)
+    {
+        @SuppressWarnings("unused")
+        public String getString()
+        {
+            return text;
+        }
+    }
+
+    public static final class FakeCodec
+    {
+        @SuppressWarnings("unused")
+        public FakeDataResult encodeStart(Object ops, Object component)
+        {
+            return new FakeDataResult(((FakeComponent) component).text());
+        }
+    }
+
+    public static final class ThrowingCodec
+    {
+        @SuppressWarnings("unused")
+        public FakeDataResult encodeStart(Object ops, Object component)
+        {
+            if (System.nanoTime() >= 0L)
+                throw new IllegalStateException("boom");
+            return new FakeDataResult("unreachable");
+        }
+    }
+
+    public record FakeDataResult(String text)
+    {
+        @SuppressWarnings("unused")
+        public Optional<String> result()
+        {
+            return Optional.of("{\"text\":\"%s\"}".formatted(text));
         }
     }
 


### PR DESCRIPTION
## Why
Integration tests need to move synthetic players between worlds and
control which chunks are loaded — e.g. to test chunk-load-dependent
plugin logic without relying on default world generation.

## How
- `AgentAction`: add `TELEPORT_PLAYER`, `LOAD_CHUNK`, `UNLOAD_CHUNK`,
  `IS_CHUNK_LOADED`
- `AgentPlayerActions.handleTeleportPlayer`: return actual
  `Player#teleport()` result (was hardcoded `true`)
- `AgentWorldActions.handleLoadChunk`: return actual `Chunk#load()`
  result (was hardcoded `true`)
- `WorldHandle`: add `loadChunk`, `unloadChunk`, `isChunkLoaded`
- `WorldHandleAssert`: add `hasLoadedChunkAt`, `doesNotHaveLoadedChunkAt`
- `PlayerHandle`: add `teleport(world, x, y, z)`

## Tests
- `WorldHandleTest` — chunk load/unload/isLoaded, set/get block
- `AgentWorldActionsTest` — 3 chunk tests with `chunk.load()` stub
- `PlayerHandleTest` — teleport delegation

_Part 2 of 6. Targets #74 (split/01-lifecycle)._

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added player teleportation support via framework and fluent `PlayerHandle.teleport(...)`.
  * Added chunk lifecycle APIs on `WorldHandle`: `loadChunk`, `unloadChunk`, and `isChunkLoaded`, with fluent chaining and clear success/failure behavior.
* **Bug Fixes**
  * Corrected chunk load handling so the reported “loaded” status reflects the server’s actual result.
* **Tests**
  * Expanded coverage for teleportation and chunk operations, including success/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->