### PR TITLE
🤖refactor: correctness fixes and SRP cleanup

### DIFF
--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
@@ -1,0 +1,141 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
+import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
+import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.RegisterEventListenerCommand;
+import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Protocol action handler for dynamic Bukkit event capture.
+ *
+ * <p>Handles {@code REGISTER_EVENT_LISTENER}, {@code GET_CAPTURED_EVENTS},
+ * {@code CLEAR_CAPTURED_EVENTS}, and {@code UNREGISTER_EVENT_LISTENER} actions by delegating to
+ * {@link AgentEventCapture}.
+ */
+final class AgentEventActions
+{
+    /**
+     * Dynamic event listener and payload store.
+     */
+    private final AgentEventCapture eventCapture;
+    /**
+     * JSON serializer for the captured event payload list.
+     */
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param eventCapture
+     *     Dynamic event capture facade.
+     * @param objectMapper
+     *     JSON serializer for event data.
+     */
+    AgentEventActions(AgentEventCapture eventCapture, ObjectMapper objectMapper)
+    {
+        this.eventCapture = Objects.requireNonNull(eventCapture, "eventCapture");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    /**
+     * Handles {@code REGISTER_EVENT_LISTENER} by resolving and registering a monitor-priority Bukkit listener.
+     *
+     * @param command
+     *     Typed register-event-listener command.
+     * @return
+     *     Success response, or {@code INVALID_ARGUMENT} when the class is blank, unknown, or not a Bukkit Event.
+     */
+    AgentResponse handleRegisterEventListener(RegisterEventListenerCommand command)
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName == null || eventClassName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(), AgentErrorCode.INVALID_ARGUMENT, "eventClassName may not be blank."
+            );
+        }
+        try
+        {
+            eventCapture.registerListener(eventClassName);
+        }
+        catch (ClassNotFoundException | IllegalArgumentException exception)
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.INVALID_ARGUMENT,
+                Objects.requireNonNullElse(exception.getMessage(), exception.getClass().getName())
+            );
+        }
+        catch (Exception exception)
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(),
+                AgentErrorCode.REQUEST_FAILED,
+                Objects.requireNonNullElse(exception.getMessage(), exception.getClass().getName())
+            );
+        }
+        return AgentResponses.successResponse(command.requestId(), Map.of());
+    }
+
+    /**
+     * Handles {@code GET_CAPTURED_EVENTS} by returning all events captured since the listener was registered or
+     * last cleared.
+     *
+     * @param command
+     *     Typed get-captured-events command.
+     * @return
+     *     Success response with {@code eventsJson}, or {@code INVALID_ARGUMENT} when the class name is blank.
+     * @throws Exception
+     *     Propagates JSON serialization failures.
+     */
+    AgentResponse handleGetCapturedEvents(GetCapturedEventsCommand command) throws Exception
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName == null || eventClassName.isBlank())
+        {
+            return AgentResponses.errorResponse(
+                command.requestId(), AgentErrorCode.INVALID_ARGUMENT, "eventClassName may not be blank."
+            );
+        }
+        final List<Map<String, String>> events = eventCapture.getCapturedEvents(eventClassName);
+        final String eventsJson = objectMapper.writeValueAsString(events);
+        return AgentResponses.successResponse(command.requestId(), Map.of("eventsJson", eventsJson));
+    }
+
+    /**
+     * Handles {@code CLEAR_CAPTURED_EVENTS} by discarding accumulated payloads for the event class.
+     *
+     * @param command
+     *     Typed clear-captured-events command.
+     * @return
+     *     Success response.
+     */
+    AgentResponse handleClearCapturedEvents(ClearCapturedEventsCommand command)
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName != null && !eventClassName.isBlank())
+            eventCapture.clearCapturedEvents(eventClassName);
+        return AgentResponses.successResponse(command.requestId(), Map.of());
+    }
+
+    /**
+     * Handles {@code UNREGISTER_EVENT_LISTENER} by removing the listener and discarding its accumulated events.
+     *
+     * @param command
+     *     Typed unregister-event-listener command.
+     * @return
+     *     Success response.
+     */
+    AgentResponse handleUnregisterEventListener(UnregisterEventListenerCommand command)
+    {
+        final String eventClassName = command.eventClassName();
+        if (eventClassName != null && !eventClassName.isBlank())
+            eventCapture.unregisterListener(eventClassName);
+        return AgentResponses.successResponse(command.requestId(), Map.of());
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -516,29 +516,4 @@ final class AgentPlayerActions
 
         return AgentResponses.successResponse(requestId, Map.of("cancelled", cancelled.toString()));
     }
-
-    private static List<Map<String, Object>> buildInventoryItems(ItemStack... contents)
-    {
-        final List<Map<String, Object>> items = new ArrayList<>();
-        for (int i = 0; i < contents.length; i++)
-        {
-            final ItemStack item = contents[i];
-            if (item == null || AgentMaterials.isAir(item.getType()))
-                continue;
-
-            final Map<String, Object> itemData = new HashMap<>();
-            itemData.put("slot", i);
-            itemData.put("materialKey", item.getType().getKey().toString());
-            final String displayName = item.getItemMeta() == null ? null : item.getItemMeta().getDisplayName();
-            itemData.put("displayName", displayName);
-            itemData.put(
-                "lore",
-                item.getItemMeta() == null
-                    ? List.of()
-                    : Objects.requireNonNullElse(item.getItemMeta().getLore(), List.of())
-            );
-            items.add(itemData);
-        }
-        return items;
-    }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -345,6 +345,31 @@ final class AgentPlayerActions
         return AgentResponses.successResponse(command.requestId(), Map.of("inventoryJson", inventoryJson));
     }
 
+    private static List<Map<String, Object>> buildInventoryItems(ItemStack... contents)
+    {
+        final List<Map<String, Object>> items = new ArrayList<>();
+        for (int i = 0; i < contents.length; i++)
+        {
+            final ItemStack item = contents[i];
+            if (item == null || AgentMaterials.isAir(item.getType()))
+                continue;
+
+            final Map<String, Object> itemData = new HashMap<>();
+            itemData.put("slot", i);
+            itemData.put("materialKey", item.getType().getKey().toString());
+            final String displayName = item.getItemMeta() == null ? null : item.getItemMeta().getDisplayName();
+            itemData.put("displayName", displayName);
+            itemData.put(
+                "lore",
+                item.getItemMeta() == null
+                    ? List.of()
+                    : Objects.requireNonNullElse(item.getItemMeta().getLore(), List.of())
+            );
+            items.add(itemData);
+        }
+        return items;
+    }
+
     /**
      * Handles {@code DROP_ITEM} by simulating the player dropping their main hand item.
      *
@@ -366,6 +391,9 @@ final class AgentPlayerActions
             if (item == null || AgentMaterials.isAir(item.getType()))
                 return Boolean.FALSE;
 
+            // Bukkit's PlayerDropItemEvent requires a pre-existing Item entity, so the entity is created
+            // unconditionally and removed afterwards. The response reflects whether a plugin *would* have
+            // allowed the drop (i.e., the event was not cancelled).
             final org.bukkit.entity.Item droppedItem =
                 player.getWorld().dropItemNaturally(player.getLocation(), item.clone());
             final org.bukkit.event.player.PlayerDropItemEvent event =

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -67,7 +67,7 @@ final class AgentRequestDispatcher
     /**
      * Handler for dynamic Bukkit event capture.
      */
-    private final AgentEventCapture eventCapture;
+    private final AgentEventActions eventActions;
     /**
      * Plugin logger used for operational diagnostics.
      */
@@ -95,8 +95,8 @@ final class AgentRequestDispatcher
      *     Player action handler.
      * @param menuActions
      *     Menu action handler.
-     * @param eventCapture
-     *     Event capture handler.
+     * @param eventActions
+     *     Event capture action handler.
      * @param logger
      *     Logger for request and error diagnostics.
      * @param authToken
@@ -111,7 +111,7 @@ final class AgentRequestDispatcher
         AgentWorldActions worldActions,
         AgentPlayerActions playerActions,
         AgentMenuActions menuActions,
-        AgentEventCapture eventCapture,
+        AgentEventActions eventActions,
         java.util.logging.Logger logger,
         String authToken,
         int protocolVersion,
@@ -121,7 +121,7 @@ final class AgentRequestDispatcher
         this.worldActions = Objects.requireNonNull(worldActions, "worldActions");
         this.playerActions = Objects.requireNonNull(playerActions, "playerActions");
         this.menuActions = Objects.requireNonNull(menuActions, "menuActions");
-        this.eventCapture = Objects.requireNonNull(eventCapture, "eventCapture");
+        this.eventActions = Objects.requireNonNull(eventActions, "eventActions");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.authToken = Objects.requireNonNull(authToken, "authToken");
         this.protocolVersion = protocolVersion;
@@ -226,10 +226,10 @@ final class AgentRequestDispatcher
                 case IsChunkLoadedCommand c -> worldActions.handleIsChunkLoaded(c);
                 case GetPlayerInventoryCommand c -> playerActions.handleGetPlayerInventory(c);
                 case DropItemCommand c -> playerActions.handleDropItem(c);
-                case RegisterEventListenerCommand c -> handleRegisterEventListener(c);
-                case GetCapturedEventsCommand c -> handleGetCapturedEvents(c);
-                case ClearCapturedEventsCommand c -> handleClearCapturedEvents(c);
-                case UnregisterEventListenerCommand c -> handleUnregisterEventListener(c);
+                case RegisterEventListenerCommand c -> eventActions.handleRegisterEventListener(c);
+                case GetCapturedEventsCommand c -> eventActions.handleGetCapturedEvents(c);
+                case ClearCapturedEventsCommand c -> eventActions.handleClearCapturedEvents(c);
+                case UnregisterEventListenerCommand c -> eventActions.handleUnregisterEventListener(c);
                 case GetPlayerChatComponentsCommand c -> playerActions.handleGetPlayerChatComponents(c);
                 case GetServerPlatformCommand c -> worldActions.handleGetServerPlatform(c);
                 case HandshakeCommand ignored ->
@@ -269,71 +269,6 @@ final class AgentRequestDispatcher
                 handshakeCompleted
             );
         }
-    }
-
-    private AgentResponse handleRegisterEventListener(RegisterEventListenerCommand command)
-        throws Exception
-    {
-        final String eventClassName = command.eventClassName();
-        if (eventClassName == null || eventClassName.isBlank())
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                "eventClassName may not be blank."
-            );
-        }
-        try
-        {
-            eventCapture.registerListener(eventClassName);
-            return AgentResponses.successResponse(command.requestId(), Map.of());
-        }
-        catch (ClassNotFoundException exception)
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                "Event class not found: " + eventClassName
-            );
-        }
-        catch (IllegalArgumentException exception)
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                exception.getMessage() == null ? "Invalid event class." : exception.getMessage()
-            );
-        }
-    }
-
-    private AgentResponse handleGetCapturedEvents(GetCapturedEventsCommand command)
-        throws Exception
-    {
-        final String eventClassName = command.eventClassName();
-        if (eventClassName == null || eventClassName.isBlank())
-        {
-            return AgentResponses.errorResponse(
-                command.requestId(),
-                AgentErrorCode.INVALID_ARGUMENT,
-                "eventClassName may not be blank."
-            );
-        }
-        final java.util.List<java.util.Map<String, String>> events = eventCapture.getCapturedEvents(eventClassName);
-        final String eventsJson = objectMapper.writeValueAsString(events);
-        return AgentResponses.successResponse(command.requestId(), Map.of("eventsJson", eventsJson));
-    }
-
-    private AgentResponse handleClearCapturedEvents(ClearCapturedEventsCommand command)
-    {
-        eventCapture.clearCapturedEvents(command.eventClassName());
-        return AgentResponses.successResponse(command.requestId(), Map.of());
-    }
-
-    private AgentResponse handleUnregisterEventListener(UnregisterEventListenerCommand command)
-        throws Exception
-    {
-        eventCapture.unregisterListener(command.eventClassName());
-        return AgentResponses.successResponse(command.requestId(), Map.of());
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -69,6 +69,28 @@ final class AgentRequestDispatcher
      */
     private final AgentEventActions eventActions;
     /**
+     * Immutable configuration block for the dispatcher.
+     *
+     * @param authToken
+     *     Expected handshake token.
+     * @param protocolVersion
+     *     Expected runtime protocol version.
+     * @param expectedAgentSha256
+     *     Optional expected agent artifact SHA-256 hash; blank disables the check.
+     * @param logger
+     *     Logger for request and error diagnostics.
+     */
+    record Config(String authToken, int protocolVersion, String expectedAgentSha256, java.util.logging.Logger logger)
+    {
+        Config
+        {
+            Objects.requireNonNull(authToken, "authToken");
+            Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
+            Objects.requireNonNull(logger, "logger");
+        }
+    }
+
+    /**
      * Plugin logger used for operational diagnostics.
      */
     private final java.util.logging.Logger logger;
@@ -97,14 +119,8 @@ final class AgentRequestDispatcher
      *     Menu action handler.
      * @param eventActions
      *     Event capture action handler.
-     * @param logger
-     *     Logger for request and error diagnostics.
-     * @param authToken
-     *     Expected handshake token.
-     * @param protocolVersion
-     *     Expected protocol version.
-     * @param expectedAgentSha256
-     *     Optional expected agent artifact hash.
+     * @param config
+     *     Immutable dispatcher configuration (auth, protocol, SHA, logger).
      */
     AgentRequestDispatcher(
         ObjectMapper objectMapper,
@@ -112,20 +128,18 @@ final class AgentRequestDispatcher
         AgentPlayerActions playerActions,
         AgentMenuActions menuActions,
         AgentEventActions eventActions,
-        java.util.logging.Logger logger,
-        String authToken,
-        int protocolVersion,
-        String expectedAgentSha256)
+        Config config)
     {
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
         this.worldActions = Objects.requireNonNull(worldActions, "worldActions");
         this.playerActions = Objects.requireNonNull(playerActions, "playerActions");
         this.menuActions = Objects.requireNonNull(menuActions, "menuActions");
         this.eventActions = Objects.requireNonNull(eventActions, "eventActions");
-        this.logger = Objects.requireNonNull(logger, "logger");
-        this.authToken = Objects.requireNonNull(authToken, "authToken");
-        this.protocolVersion = protocolVersion;
-        this.expectedAgentSha256 = Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
+        Objects.requireNonNull(config, "config");
+        this.logger = config.logger();
+        this.authToken = config.authToken();
+        this.protocolVersion = config.protocolVersion();
+        this.expectedAgentSha256 = config.expectedAgentSha256();
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -68,27 +68,6 @@ final class AgentRequestDispatcher
      * Handler for dynamic Bukkit event capture.
      */
     private final AgentEventActions eventActions;
-    /**
-     * Immutable configuration block for the dispatcher.
-     *
-     * @param authToken
-     *     Expected handshake token.
-     * @param protocolVersion
-     *     Expected runtime protocol version.
-     * @param expectedAgentSha256
-     *     Optional expected agent artifact SHA-256 hash; blank disables the check.
-     * @param logger
-     *     Logger for request and error diagnostics.
-     */
-    record Config(String authToken, int protocolVersion, String expectedAgentSha256, java.util.logging.Logger logger)
-    {
-        Config
-        {
-            Objects.requireNonNull(authToken, "authToken");
-            Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
-            Objects.requireNonNull(logger, "logger");
-        }
-    }
 
     /**
      * Plugin logger used for operational diagnostics.
@@ -340,5 +319,27 @@ final class AgentRequestDispatcher
      */
     record RequestDispatchResult(AgentResponse response, boolean handshakeCompleted)
     {
+    }
+
+    /**
+     * Immutable configuration block for the dispatcher.
+     *
+     * @param authToken
+     *     Expected handshake token.
+     * @param protocolVersion
+     *     Expected runtime protocol version.
+     * @param expectedAgentSha256
+     *     Optional expected agent artifact SHA-256 hash; blank disables the check.
+     * @param logger
+     *     Logger for request and error diagnostics.
+     */
+    record Config(String authToken, int protocolVersion, String expectedAgentSha256, java.util.logging.Logger logger)
+    {
+        Config
+        {
+            Objects.requireNonNull(authToken, "authToken");
+            Objects.requireNonNull(expectedAgentSha256, "expectedAgentSha256");
+            Objects.requireNonNull(logger, "logger");
+        }
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
@@ -218,19 +218,19 @@ final class AgentSyntheticPlayerStore
         /**
          * Live Bukkit player instance.
          */
-        final Player player;
+        private final Player player;
         /**
          * Permission attachment, or {@code null} when no permissions have been assigned.
          */
-        @Nullable PermissionAttachment permissionAttachment;
+        @Nullable private PermissionAttachment permissionAttachment;
         /**
          * Accumulated plain-text message history (direct sends + NMS adapter drains).
          */
-        final List<String> messageHistory = new CopyOnWriteArrayList<>();
+        private final List<String> messageHistory = new CopyOnWriteArrayList<>();
         /**
          * Accumulated chat-component JSON history.
          */
-        final List<String> componentHistory = new CopyOnWriteArrayList<>();
+        private final List<String> componentHistory = new CopyOnWriteArrayList<>();
 
         private SyntheticPlayerState(Player player)
         {

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
@@ -4,6 +4,7 @@ import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,31 +16,17 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * Thread-safe registry for synthetic players and related per-player state.
  *
- * <p>The store tracks:
- * <ul>
- *   <li>Registered synthetic player instances by UUID.</li>
- *   <li>Permission attachments created for those players.</li>
- *   <li>Message history merged from direct sends and NMS adapter drains.</li>
- * </ul>
+ * <p>All per-player state (player instance, permission attachment, message history, chat component
+ * history) is colocated in a single {@link SyntheticPlayerState} entry so lifecycle operations always
+ * touch a consistent, atomic view. There is no risk of one of several parallel maps being updated
+ * while another is not.
  */
 final class AgentSyntheticPlayerStore
 {
     /**
-     * Synthetic players registered by protocol UUID.
+     * All per-player state keyed by protocol UUID.
      */
-    private final ConcurrentHashMap<UUID, Player> syntheticPlayers = new ConcurrentHashMap<>();
-    /**
-     * Permission attachments associated with synthetic players.
-     */
-    private final ConcurrentHashMap<UUID, PermissionAttachment> permissionAttachments = new ConcurrentHashMap<>();
-    /**
-     * Aggregated player message history by synthetic player UUID.
-     */
-    private final ConcurrentHashMap<UUID, List<String>> playerMessageHistory = new ConcurrentHashMap<>();
-    /**
-     * Aggregated player chat component history by synthetic player UUID.
-     */
-    private final ConcurrentHashMap<UUID, List<String>> playerChatComponentHistory = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, SyntheticPlayerState> players = new ConcurrentHashMap<>();
 
     /**
      * Resolves a registered synthetic player.
@@ -53,10 +40,10 @@ final class AgentSyntheticPlayerStore
      */
     Player getRequiredPlayer(UUID uuid)
     {
-        final Player player = syntheticPlayers.get(uuid);
-        if (player == null)
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state == null)
             throw new IllegalArgumentException("Synthetic player '%s' is not registered.".formatted(uuid));
-        return player;
+        return state.player;
     }
 
     /**
@@ -69,9 +56,7 @@ final class AgentSyntheticPlayerStore
      */
     void registerSyntheticPlayer(UUID uuid, Player player)
     {
-        syntheticPlayers.put(uuid, player);
-        playerMessageHistory.put(uuid, new CopyOnWriteArrayList<>());
-        playerChatComponentHistory.put(uuid, new CopyOnWriteArrayList<>());
+        players.put(uuid, new SyntheticPlayerState(player));
     }
 
     /**
@@ -93,7 +78,10 @@ final class AgentSyntheticPlayerStore
             .map(String::trim)
             .filter(permission -> !permission.isEmpty())
             .forEach(permission -> attachment.setPermission(permission, true));
-        permissionAttachments.put(uuid, attachment);
+
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.permissionAttachment = attachment;
     }
 
     /**
@@ -106,22 +94,26 @@ final class AgentSyntheticPlayerStore
      */
     void removePermissionAttachment(UUID uuid, Player player)
     {
-        final PermissionAttachment attachment = permissionAttachments.remove(uuid);
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state == null)
+            return;
+        final PermissionAttachment attachment = state.permissionAttachment;
         if (attachment != null)
+        {
             player.removeAttachment(attachment);
+            state.permissionAttachment = null;
+        }
     }
 
     /**
-     * Removes a synthetic player and all associated message tracking state.
+     * Removes a synthetic player and all associated state.
      *
      * @param uuid
      *     Synthetic player UUID.
      */
     void removeSyntheticPlayer(UUID uuid)
     {
-        playerMessageHistory.remove(uuid);
-        playerChatComponentHistory.remove(uuid);
-        syntheticPlayers.remove(uuid);
+        players.remove(uuid);
     }
 
     /**
@@ -132,7 +124,7 @@ final class AgentSyntheticPlayerStore
      */
     Set<UUID> syntheticPlayerIds()
     {
-        return Set.copyOf(syntheticPlayers.keySet());
+        return Set.copyOf(players.keySet());
     }
 
     /**
@@ -146,9 +138,9 @@ final class AgentSyntheticPlayerStore
     void sendTrackedMessage(Player player, String message)
     {
         player.sendMessage(message);
-        playerMessageHistory
-            .computeIfAbsent(player.getUniqueId(), ignored -> new CopyOnWriteArrayList<>())
-            .add(message);
+        final SyntheticPlayerState state = players.get(player.getUniqueId());
+        if (state != null)
+            state.messageHistory.add(message);
     }
 
     /**
@@ -165,9 +157,9 @@ final class AgentSyntheticPlayerStore
         if (drainedMessages.isEmpty())
             return;
 
-        playerMessageHistory
-            .computeIfAbsent(uuid, ignored -> new CopyOnWriteArrayList<>())
-            .addAll(drainedMessages);
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.messageHistory.addAll(drainedMessages);
     }
 
     /**
@@ -184,9 +176,9 @@ final class AgentSyntheticPlayerStore
         if (drainedComponents.isEmpty())
             return;
 
-        playerChatComponentHistory
-            .computeIfAbsent(uuid, ignored -> new CopyOnWriteArrayList<>())
-            .addAll(drainedComponents);
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.componentHistory.addAll(drainedComponents);
     }
 
     /**
@@ -195,11 +187,12 @@ final class AgentSyntheticPlayerStore
      * @param uuid
      *     Synthetic player UUID.
      * @return
-     *     Immutable empty list when unknown; otherwise tracked history list.
+     *     Immutable empty list when unknown; otherwise the tracked history list.
      */
     List<String> getPlayerMessages(UUID uuid)
     {
-        return playerMessageHistory.getOrDefault(uuid, List.of());
+        final SyntheticPlayerState state = players.get(uuid);
+        return state != null ? state.messageHistory : List.of();
     }
 
     /**
@@ -208,10 +201,40 @@ final class AgentSyntheticPlayerStore
      * @param uuid
      *     Synthetic player UUID.
      * @return
-     *     Immutable empty list when unknown; otherwise tracked history list.
+     *     Immutable empty list when unknown; otherwise the tracked history list.
      */
     List<String> getPlayerChatComponents(UUID uuid)
     {
-        return playerChatComponentHistory.getOrDefault(uuid, List.of());
+        final SyntheticPlayerState state = players.get(uuid);
+        return state != null ? state.componentHistory : List.of();
+    }
+
+    /**
+     * Per-player state colocating all mutable fields so lifecycle operations always touch a consistent
+     * view.
+     */
+    private static final class SyntheticPlayerState
+    {
+        /**
+         * Live Bukkit player instance.
+         */
+        final Player player;
+        /**
+         * Permission attachment, or {@code null} when no permissions have been assigned.
+         */
+        @Nullable PermissionAttachment permissionAttachment;
+        /**
+         * Accumulated plain-text message history (direct sends + NMS adapter drains).
+         */
+        final List<String> messageHistory = new CopyOnWriteArrayList<>();
+        /**
+         * Accumulated chat-component JSON history.
+         */
+        final List<String> componentHistory = new CopyOnWriteArrayList<>();
+
+        private SyntheticPlayerState(Player player)
+        {
+            this.player = player;
+        }
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -136,10 +136,12 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 playerActions,
                 menuActions,
                 eventActions,
-                getLogger(),
-                configuration.authToken(),
-                configuration.protocolVersion(),
-                configuration.expectedAgentSha256()
+                new AgentRequestDispatcher.Config(
+                    configuration.authToken(),
+                    configuration.protocolVersion(),
+                    configuration.expectedAgentSha256(),
+                    getLogger()
+                )
             );
 
             startTickLoop(worldActions);

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -128,13 +128,14 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 botPlayerNmsAdapter
             );
             final AgentEventCapture eventCapture = new AgentEventCapture(this, mainThreadExecutor);
+            final AgentEventActions eventActions = new AgentEventActions(eventCapture, objectMapper);
 
             requestDispatcher = new AgentRequestDispatcher(
                 objectMapper,
                 worldActions,
                 playerActions,
                 menuActions,
-                eventCapture,
+                eventActions,
                 getLogger(),
                 configuration.authToken(),
                 configuration.protocolVersion(),

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
@@ -1,0 +1,199 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
+import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEventsCommand;
+import nl.pim16aap2.lightkeeper.protocol.RegisterEventListenerCommand;
+import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AgentEventActionsTest
+{
+    private static AgentEventActions createEventActions(AgentEventCapture eventCapture)
+    {
+        return new AgentEventActions(eventCapture, new ObjectMapper());
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldReturnInvalidArgumentWhenClassIsBlank()
+    {
+        // setup
+        final AgentEventActions actions = createEventActions(mock());
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-1", ""));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("eventClassName");
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldReturnInvalidArgumentWhenClassIsNotBukkitEvent()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("Class 'java.lang.String' is not a Bukkit Event."))
+            .when(eventCapture).registerListener("java.lang.String");
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-2", "java.lang.String"));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("not a Bukkit Event");
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldReturnInvalidArgumentWhenClassIsNotFound()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+        org.mockito.Mockito.doThrow(new ClassNotFoundException("com.example.NonExistent"))
+            .when(eventCapture).registerListener("com.example.NonExistent");
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-cnf", "com.example.NonExistent"));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+    }
+
+    @Test
+    void handleRegisterEventListener_shouldSucceedWhenClassIsRegistered()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleRegisterEventListener(new RegisterEventListenerCommand("req-3", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        verify(eventCapture).registerListener("org.bukkit.event.Event");
+    }
+
+    @Test
+    void handleGetCapturedEvents_shouldReturnInvalidArgumentWhenClassIsBlank()
+        throws Exception
+    {
+        // setup
+        final AgentEventActions actions = createEventActions(mock());
+
+        // execute
+        final AgentResponse response =
+            actions.handleGetCapturedEvents(new GetCapturedEventsCommand("req-4", ""));
+
+        // verify
+        assertThat(response.success()).isFalse();
+        assertThat(response.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        assertThat(response.errorMessage()).contains("eventClassName");
+    }
+
+    @Test
+    void handleGetCapturedEvents_shouldReturnSerializedEventsJson()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+        when(eventCapture.getCapturedEvents("org.bukkit.event.Event"))
+            .thenReturn(List.of(Map.of("isCancelled", "true")));
+
+        // execute
+        final AgentResponse response =
+            actions.handleGetCapturedEvents(new GetCapturedEventsCommand("req-5", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        assertThat(response.data().get("eventsJson")).contains("isCancelled");
+    }
+
+    @Test
+    void handleClearCapturedEvents_shouldSucceedAndClearWhenClassIsNotBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleClearCapturedEvents(new ClearCapturedEventsCommand("req-6", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        verify(eventCapture).clearCapturedEvents("org.bukkit.event.Event");
+    }
+
+    @Test
+    void handleClearCapturedEvents_shouldSucceedAndNoopWhenClassIsBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleClearCapturedEvents(new ClearCapturedEventsCommand("req-7", ""));
+
+        // verify - blank is silently ignored
+        assertThat(response.success()).isTrue();
+        verifyNoInteractions(eventCapture);
+    }
+
+    @Test
+    void handleUnregisterEventListener_shouldSucceedAndUnregisterWhenClassIsNotBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleUnregisterEventListener(
+                new UnregisterEventListenerCommand("req-8", "org.bukkit.event.Event"));
+
+        // verify
+        assertThat(response.success()).isTrue();
+        verify(eventCapture).unregisterListener("org.bukkit.event.Event");
+    }
+
+    @Test
+    void handleUnregisterEventListener_shouldSucceedAndNoopWhenClassIsBlank()
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final AgentResponse response =
+            actions.handleUnregisterEventListener(new UnregisterEventListenerCommand("req-9", ""));
+
+        // verify - blank is silently ignored
+        assertThat(response.success()).isTrue();
+        verifyNoInteractions(eventCapture);
+    }
+}

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -40,7 +40,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -213,8 +212,14 @@ class AgentRequestDispatcherTest
             .thenReturn(AgentResponses.successResponse("request-21", Map.of("inventoryJson", "[]")));
         when(fixture.playerActions().handleDropItem(any(DropItemCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-22", Map.of("dropped", "false")));
-        when(fixture.eventCapture().getCapturedEvents(eq(eventClass)))
-            .thenReturn(List.of(Map.of("getEventName", "Event")));
+        when(fixture.eventActions().handleRegisterEventListener(any(RegisterEventListenerCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-23", Map.of()));
+        when(fixture.eventActions().handleGetCapturedEvents(any(GetCapturedEventsCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-24", Map.of("eventsJson", "[{\"getEventName\":\"Event\"}]")));
+        when(fixture.eventActions().handleClearCapturedEvents(any(ClearCapturedEventsCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-25", Map.of()));
+        when(fixture.eventActions().handleUnregisterEventListener(any(UnregisterEventListenerCommand.class)))
+            .thenReturn(AgentResponses.successResponse("request-26", Map.of()));
         when(fixture.playerActions().handleGetPlayerChatComponents(
             any(GetPlayerChatComponentsCommand.class)))
             .thenReturn(AgentResponses.successResponse("request-27", Map.of()));
@@ -284,10 +289,10 @@ class AgentRequestDispatcherTest
         verify(fixture.worldActions()).handleIsChunkLoaded(any(IsChunkLoadedCommand.class));
         verify(fixture.playerActions()).handleGetPlayerInventory(any(GetPlayerInventoryCommand.class));
         verify(fixture.playerActions()).handleDropItem(any(DropItemCommand.class));
-        verify(fixture.eventCapture()).registerListener(eventClass);
-        verify(fixture.eventCapture()).getCapturedEvents(eventClass);
-        verify(fixture.eventCapture()).clearCapturedEvents(eventClass);
-        verify(fixture.eventCapture()).unregisterListener(eventClass);
+        verify(fixture.eventActions()).handleRegisterEventListener(any(RegisterEventListenerCommand.class));
+        verify(fixture.eventActions()).handleGetCapturedEvents(any(GetCapturedEventsCommand.class));
+        verify(fixture.eventActions()).handleClearCapturedEvents(any(ClearCapturedEventsCommand.class));
+        verify(fixture.eventActions()).handleUnregisterEventListener(any(UnregisterEventListenerCommand.class));
         verify(fixture.playerActions()).handleGetPlayerChatComponents(any(GetPlayerChatComponentsCommand.class));
         verify(fixture.worldActions()).handleGetServerPlatform(any(GetServerPlatformCommand.class));
     }
@@ -298,8 +303,12 @@ class AgentRequestDispatcherTest
     {
         // setup
         final DispatcherFixture fixture = createDispatcherFixture();
-        doThrow(new IllegalArgumentException("Class 'java.lang.String' is not a Bukkit Event."))
-            .when(fixture.eventCapture()).registerListener("java.lang.String");
+        when(fixture.eventActions().handleRegisterEventListener(any(RegisterEventListenerCommand.class)))
+            .thenReturn(AgentResponses.errorResponse(
+                "request-event",
+                nl.pim16aap2.lightkeeper.protocol.AgentErrorCode.INVALID_ARGUMENT,
+                "Class 'java.lang.String' is not a Bukkit Event."
+            ));
         final String requestLine = toJson(new RegisterEventListenerCommand("request-event", "java.lang.String"));
 
         // execute
@@ -418,74 +427,6 @@ class AgentRequestDispatcherTest
         assertThat(result.response().errorCode()).isEqualTo("AGENT_SHA_MISMATCH");
     }
 
-    @Test
-    void handleRequestLine_shouldReturnInvalidArgumentWhenRegisterEventListenerClassIsBlank()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new RegisterEventListenerCommand("request-blank-class", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify
-        assertThat(result.response().success()).isFalse();
-        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
-        assertThat(result.response().errorMessage()).contains("eventClassName");
-    }
-
-    @Test
-    void handleRequestLine_shouldReturnInvalidArgumentWhenGetCapturedEventsClassIsBlank()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new GetCapturedEventsCommand("request-blank-events", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify
-        assertThat(result.response().success()).isFalse();
-        assertThat(result.response().errorCode()).isEqualTo("INVALID_ARGUMENT");
-        assertThat(result.response().errorMessage()).contains("eventClassName");
-    }
-
-    @Test
-    void handleRequestLine_shouldSucceedClearCapturedEventsWithBlankClassName()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new ClearCapturedEventsCommand("request-clear-blank", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify - blank is silently ignored, operation succeeds
-        assertThat(result.response().success()).isTrue();
-    }
-
-    @Test
-    void handleRequestLine_shouldSucceedUnregisterEventListenerWithBlankClassName()
-        throws Exception
-    {
-        // setup
-        final DispatcherFixture fixture = createDispatcherFixture();
-        final String requestLine = toJson(new UnregisterEventListenerCommand("request-unregister-blank", ""));
-
-        // execute
-        final AgentRequestDispatcher.RequestDispatchResult result =
-            fixture.dispatcher().handleRequestLine(requestLine, true);
-
-        // verify - blank is silently ignored, operation succeeds
-        assertThat(result.response().success()).isTrue();
-    }
-
     private static AgentRequestDispatcher createDispatcher(String authToken, int protocolVersion, String expectedSha)
     {
         final ObjectMapper objectMapper = new ObjectMapper()
@@ -512,13 +453,14 @@ class AgentRequestDispatcherTest
             nmsAdapter
         );
         final AgentEventCapture eventCapture = mock();
+        final AgentEventActions eventActions = new AgentEventActions(eventCapture, objectMapper);
 
         return new AgentRequestDispatcher(
             objectMapper,
             worldActions,
             playerActions,
             menuActions,
-            eventCapture,
+            eventActions,
             Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
             authToken,
             protocolVersion,
@@ -533,19 +475,19 @@ class AgentRequestDispatcherTest
         final AgentWorldActions worldActions = mock();
         final AgentPlayerActions playerActions = mock();
         final AgentMenuActions menuActions = mock();
-        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions eventActions = mock();
         final AgentRequestDispatcher dispatcher = new AgentRequestDispatcher(
             objectMapper,
             worldActions,
             playerActions,
             menuActions,
-            eventCapture,
+            eventActions,
             Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
             "token",
             1,
             ""
         );
-        return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions, eventCapture);
+        return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions, eventActions);
     }
 
     private record DispatcherFixture(
@@ -553,7 +495,7 @@ class AgentRequestDispatcherTest
         AgentWorldActions worldActions,
         AgentPlayerActions playerActions,
         AgentMenuActions menuActions,
-        AgentEventCapture eventCapture)
+        AgentEventActions eventActions)
     {
     }
 

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -461,10 +461,12 @@ class AgentRequestDispatcherTest
             playerActions,
             menuActions,
             eventActions,
-            Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
-            authToken,
-            protocolVersion,
-            expectedSha
+            new AgentRequestDispatcher.Config(
+                authToken,
+                protocolVersion,
+                expectedSha,
+                Logger.getLogger(AgentRequestDispatcherTest.class.getName())
+            )
         );
     }
 
@@ -482,10 +484,12 @@ class AgentRequestDispatcherTest
             playerActions,
             menuActions,
             eventActions,
-            Logger.getLogger(AgentRequestDispatcherTest.class.getName()),
-            "token",
-            1,
-            ""
+            new AgentRequestDispatcher.Config(
+                "token",
+                1,
+                "",
+                Logger.getLogger(AgentRequestDispatcherTest.class.getName())
+            )
         );
         return new DispatcherFixture(dispatcher, worldActions, playerActions, menuActions, eventActions);
     }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
@@ -54,6 +54,7 @@ class AgentSyntheticPlayerStoreTest
         final PermissionAttachment attachment = mock();
         final UUID uuid = UUID.randomUUID();
         when(player.addAttachment(plugin)).thenReturn(attachment);
+        store.registerSyntheticPlayer(uuid, player);
 
         // execute
         store.setPermissions(plugin, uuid, player, "perm.one, perm.two, ,perm.three");
@@ -75,6 +76,7 @@ class AgentSyntheticPlayerStoreTest
         final PermissionAttachment attachment = mock();
         final UUID uuid = UUID.randomUUID();
         when(player.addAttachment(plugin)).thenReturn(attachment);
+        store.registerSyntheticPlayer(uuid, player);
         store.setPermissions(plugin, uuid, player, "perm.one");
 
         // execute
@@ -92,6 +94,7 @@ class AgentSyntheticPlayerStoreTest
         final Player player = mock();
         final UUID uuid = UUID.randomUUID();
         when(player.getUniqueId()).thenReturn(uuid);
+        store.registerSyntheticPlayer(uuid, player);
 
         // execute
         store.sendTrackedMessage(player, "hello");
@@ -111,6 +114,7 @@ class AgentSyntheticPlayerStoreTest
         when(adapter.drainReceivedMessages(uuid)).thenReturn(List.of("first", "second"));
         final Player player = mock();
         when(player.getUniqueId()).thenReturn(uuid);
+        store.registerSyntheticPlayer(uuid, player);
         store.sendTrackedMessage(player, "existing");
 
         // execute
@@ -118,6 +122,45 @@ class AgentSyntheticPlayerStoreTest
 
         // verify
         assertThat(store.getPlayerMessages(uuid)).containsExactly("existing", "first", "second");
+    }
+
+    @Test
+    void capturePlayerChatComponents_shouldAppendDrainedComponents()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final IBotPlayerNmsAdapter adapter = mock();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(adapter.drainChatComponents(uuid)).thenReturn(List.of("{\"text\":\"hello\"}"));
+        store.registerSyntheticPlayer(uuid, player);
+
+        // execute
+        store.capturePlayerChatComponents(adapter, uuid);
+
+        // verify
+        assertThat(store.getPlayerChatComponents(uuid)).containsExactly("{\"text\":\"hello\"}");
+    }
+
+    @Test
+    void capturePlayerChatComponents_shouldKeepHistoryWhenNoComponentsWereDrained()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final IBotPlayerNmsAdapter adapter = mock();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(adapter.drainChatComponents(uuid))
+            .thenReturn(List.of("{\"text\":\"hello\"}"))
+            .thenReturn(List.of());
+        store.registerSyntheticPlayer(uuid, player);
+        store.capturePlayerChatComponents(adapter, uuid);
+
+        // execute
+        store.capturePlayerChatComponents(adapter, uuid);
+
+        // verify
+        assertThat(store.getPlayerChatComponents(uuid)).containsExactly("{\"text\":\"hello\"}");
     }
 
     @Test
@@ -137,5 +180,51 @@ class AgentSyntheticPlayerStoreTest
         assertThat(store.getPlayerMessages(uuid)).isEmpty();
         assertThatThrownBy(() -> store.getRequiredPlayer(uuid))
             .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void capturePlayerMessages_shouldNotAppendWhenDrainReturnsEmpty()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final IBotPlayerNmsAdapter adapter = mock();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(adapter.drainReceivedMessages(uuid)).thenReturn(List.of());
+        store.registerSyntheticPlayer(uuid, player);
+        store.sendTrackedMessage(player, "existing");
+
+        // execute
+        store.capturePlayerMessages(adapter, uuid);
+
+        // verify - history unchanged when drain is empty
+        assertThat(store.getPlayerMessages(uuid)).containsExactly("existing");
+    }
+
+    @Test
+    void removePermissionAttachment_shouldBeNoOpWhenNoAttachmentWasSet()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+
+        // execute + verify - should not throw
+        store.removePermissionAttachment(uuid, player);
+        verifyNoInteractions(player);
+    }
+
+    @Test
+    void getPlayerChatComponents_shouldReturnEmptyListForUnknownPlayer()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+
+        // execute
+        final List<String> components = store.getPlayerChatComponents(UUID.randomUUID());
+
+        // verify
+        assertThat(components).isEmpty();
     }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/PlayerHandleAssert.java
@@ -1,11 +1,14 @@
 package nl.pim16aap2.lightkeeper.framework.assertions;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -97,13 +100,28 @@ public final class PlayerHandleAssert extends AbstractAssert<PlayerHandleAssert,
     public PlayerHandleAssert hasClickableChatText(String expectedText)
     {
         final var actual = nonNullActual();
-        final boolean found = actual.chatComponents().stream()
-            .anyMatch(component -> component.json().contains(expectedText) &&
-                component.json().contains("clickEvent"));
+        final ObjectMapper mapper = new ObjectMapper();
+        final boolean found = actual.chatComponents().stream().anyMatch(component ->
+        {
+            if (!component.json().contains(expectedText))
+                return false;
+            try
+            {
+                final JsonNode root = mapper.readTree(component.json());
+                return root.has("clickEvent");
+            }
+            catch (IOException ignored)
+            {
+                return false;
+            }
+        });
         if (!found)
         {
-            failWithMessage("Expected player '%s' to receive clickable chat text matching '%s', but none was found.",
-                actual.name(), expectedText);
+            failWithMessage(
+                "Expected player '%s' to have a clickable chat text matching '%s', "
+                    + "but no component with a top-level clickEvent field and that text was found.",
+                actual.name(), expectedText
+            );
         }
         return this;
     }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -240,7 +240,8 @@ final class UdsAgentClient implements AutoCloseable
             return new MenuSnapshot(false, "", List.of());
 
         final String title = getRequiredData(response, "title");
-        final MenuItemSnapshot[] items = parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
+        final MenuItemSnapshot[] items =
+            parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
         return new MenuSnapshot(true, title, List.of(items));
     }
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -51,6 +51,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
+import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
@@ -61,6 +62,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -70,8 +75,26 @@ final class UdsAgentClient implements AutoCloseable
 {
     private static final System.Logger LOG = System.getLogger(UdsAgentClient.class.getName());
 
+    /**
+     * Maximum time to wait for a single agent response. Matches the agent-side WAIT_TICKS_TIMEOUT_MILLIS
+     * so WAIT_TICKS is the longest action that can legitimately take close to this limit.
+     *
+     * <p>Unix Domain Sockets do not support SO_TIMEOUT, so the timeout is enforced by a watchdog that
+     * closes the channel directly; this causes {@link AsynchronousCloseException} on the blocked read.
+     */
+    private static final int SEND_TIMEOUT_MS = 120_000;
+
     private final ObjectMapper objectMapper = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    /**
+     * Single-thread watchdog executor that closes the socket channel when a read takes longer than
+     * {@link #SEND_TIMEOUT_MS}. Closing the channel directly (not via {@link #close()}) avoids deadlock
+     * with the {@code synchronized} monitor held by {@link #send}.
+     */
+    private final ScheduledExecutorService readTimeoutWatchdog = Executors.newSingleThreadScheduledExecutor(
+        Thread.ofPlatform().name("lk-read-timeout-watchdog").daemon(true).factory()
+    );
 
     private final Path socketPath;
     private final AtomicLong requestCounter = new AtomicLong(0L);
@@ -370,6 +393,25 @@ final class UdsAgentClient implements AutoCloseable
     {
         final BufferedWriter out = Objects.requireNonNull(writer, "Client is not connected.");
         final BufferedReader in = Objects.requireNonNull(reader, "Client is not connected.");
+
+        // Capture the channel reference before the read; the watchdog closes it directly to avoid
+        // deadlocking on this synchronized method's monitor.
+        final SocketChannel channelSnapshot = this.socketChannel;
+        final ScheduledFuture<?> watchdog = readTimeoutWatchdog.schedule(() ->
+        {
+            if (channelSnapshot != null)
+            {
+                try
+                {
+                    channelSnapshot.close();
+                }
+                catch (IOException ignored)
+                {
+                    // Best-effort: the channel may already be closed.
+                }
+            }
+        }, SEND_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
         try
         {
             out.write(objectMapper.writeValueAsString(command));
@@ -408,12 +450,24 @@ final class UdsAgentClient implements AutoCloseable
 
             return response;
         }
+        catch (AsynchronousCloseException exception)
+        {
+            throw new IllegalStateException(
+                "Agent did not respond within %d ms for action '%s' via socket '%s'."
+                    .formatted(SEND_TIMEOUT_MS, command.getClass().getSimpleName(), socketPath),
+                exception
+            );
+        }
         catch (IOException exception)
         {
             throw new IllegalStateException(
                 "Failed to communicate with agent via socket '%s'.".formatted(socketPath),
                 exception
             );
+        }
+        finally
+        {
+            watchdog.cancel(false);
         }
     }
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -44,6 +44,8 @@ import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListenerCommand;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicksCommand;
 import org.jspecify.annotations.Nullable;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -238,16 +240,8 @@ final class UdsAgentClient implements AutoCloseable
             return new MenuSnapshot(false, "", List.of());
 
         final String title = getRequiredData(response, "title");
-        final String itemsJson = response.data().getOrDefault("itemsJson", "[]");
-        try
-        {
-            final MenuItemSnapshot[] items = objectMapper.readValue(itemsJson, MenuItemSnapshot[].class);
-            return new MenuSnapshot(true, title, List.of(items));
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse menu snapshot JSON.", exception);
-        }
+        final MenuItemSnapshot[] items = parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
+        return new MenuSnapshot(true, title, List.of(items));
     }
 
     void clickMenuSlot(UUID uuid, int slot)
@@ -268,33 +262,15 @@ final class UdsAgentClient implements AutoCloseable
     List<String> playerMessages(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerMessagesCommand(nextRequestId(), uuid));
-        final String messagesJson = response.data().getOrDefault("messagesJson", "[]");
-        try
-        {
-            final String[] messages = objectMapper.readValue(messagesJson, String[].class);
-            return List.of(messages);
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse player messages JSON.", exception);
-        }
+        return List.of(parseJsonField(response, "messagesJson", new TypeReference<String[]>() {}));
     }
 
     List<ChatComponentSnapshot> playerChatComponents(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerChatComponentsCommand(nextRequestId(), uuid));
-        final String componentsJson = response.data().getOrDefault("componentsJson", "[]");
-        try
-        {
-            final String[] components = objectMapper.readValue(componentsJson, String[].class);
-            return java.util.Arrays.stream(components)
-                .map(ChatComponentSnapshot::new)
-                .toList();
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse player chat components JSON.", exception);
-        }
+        return java.util.Arrays.stream(parseJsonField(response, "componentsJson", new TypeReference<String[]>() {}))
+            .map(ChatComponentSnapshot::new)
+            .toList();
     }
 
     long getServerTick()
@@ -328,17 +304,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, Object>> getPlayerInventory(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerInventoryCommand(nextRequestId(), uuid));
-        final String inventoryJson = response.data().getOrDefault("inventoryJson", "[]");
-        try
-        {
-            @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> items = objectMapper.readValue(inventoryJson, List.class);
-            return items;
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse player inventory JSON.", exception);
-        }
+        return parseJsonField(response, "inventoryJson", new TypeReference<List<Map<String, Object>>>() {});
     }
 
     boolean dropItem(UUID uuid)
@@ -355,17 +321,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, String>> getCapturedEvents(String eventClassName)
     {
         final AgentResponse response = send(new GetCapturedEventsCommand(nextRequestId(), eventClassName));
-        final String eventsJson = response.data().getOrDefault("eventsJson", "[]");
-        try
-        {
-            @SuppressWarnings("unchecked")
-            final List<Map<String, String>> events = objectMapper.readValue(eventsJson, List.class);
-            return events;
-        }
-        catch (IOException exception)
-        {
-            throw new IllegalStateException("Failed to parse captured events JSON.", exception);
-        }
+        return parseJsonField(response, "eventsJson", new TypeReference<List<Map<String, String>>>() {});
     }
 
     void clearCapturedEvents(String eventClassName)
@@ -556,6 +512,35 @@ final class UdsAgentClient implements AutoCloseable
         if (value == null)
             throw new IllegalStateException("Missing response field '%s' from agent.".formatted(key));
         return value;
+    }
+
+    /**
+     * Reads a JSON string from a response data field and deserializes it using the supplied type reference.
+     *
+     * @param response
+     *     Agent response whose data map is searched.
+     * @param key
+     *     Data field key; defaults to {@code "[]"} when absent.
+     * @param typeRef
+     *     Jackson type reference for deserialization.
+     * @param <T>
+     *     Expected return type.
+     * @return
+     *     Deserialized value.
+     * @throws IllegalStateException
+     *     When deserialization fails.
+     */
+    private <T> T parseJsonField(AgentResponse response, String key, TypeReference<T> typeRef)
+    {
+        final String json = response.data().getOrDefault(key, "[]");
+        try
+        {
+            return objectMapper.readValue(json, typeRef);
+        }
+        catch (IOException exception)
+        {
+            throw new IllegalStateException("Failed to parse '%s' JSON from agent response.".formatted(key), exception);
+        }
     }
 
     private static void sleep(long millis)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -86,6 +86,8 @@ final class UdsAgentClient implements AutoCloseable
         new TypeReference<>() {};
     private static final TypeReference<List<Map<String, String>>> TYPE_EVENT_DATA_LIST =
         new TypeReference<>() {};
+    private static final TypeReference<List<Map<String, Object>>> TYPE_INVENTORY_ITEM_LIST =
+        new TypeReference<>() {};
 
     /**
      * Maximum time to wait for a single agent response. Matches the agent-side WAIT_TICKS_TIMEOUT_MILLIS
@@ -314,7 +316,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, Object>> getPlayerInventory(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerInventoryCommand(nextRequestId(), uuid));
-        return parseJsonField(response, "inventoryJson", new TypeReference<List<Map<String, Object>>>() {});
+        return parseJsonField(response, "inventoryJson", TYPE_INVENTORY_ITEM_LIST);
     }
 
     boolean dropItem(UUID uuid)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -77,6 +77,16 @@ final class UdsAgentClient implements AutoCloseable
 {
     private static final System.Logger LOG = System.getLogger(UdsAgentClient.class.getName());
 
+    // Reusable TypeReference constants. Jackson captures the generic type at runtime via
+    // getGenericSuperclass(), which is preserved even when using the diamond operator on these
+    // explicit-target-type field declarations (Java 9+ behaviour).
+    private static final TypeReference<MenuItemSnapshot[]> TYPE_MENU_ITEM_ARRAY =
+        new TypeReference<>() {};
+    private static final TypeReference<String[]> TYPE_STRING_ARRAY =
+        new TypeReference<>() {};
+    private static final TypeReference<List<Map<String, String>>> TYPE_EVENT_DATA_LIST =
+        new TypeReference<>() {};
+
     /**
      * Maximum time to wait for a single agent response. Matches the agent-side WAIT_TICKS_TIMEOUT_MILLIS
      * so WAIT_TICKS is the longest action that can legitimately take close to this limit.
@@ -240,8 +250,7 @@ final class UdsAgentClient implements AutoCloseable
             return new MenuSnapshot(false, "", List.of());
 
         final String title = getRequiredData(response, "title");
-        final MenuItemSnapshot[] items =
-            parseJsonField(response, "itemsJson", new TypeReference<MenuItemSnapshot[]>() {});
+        final MenuItemSnapshot[] items = parseJsonField(response, "itemsJson", TYPE_MENU_ITEM_ARRAY);
         return new MenuSnapshot(true, title, List.of(items));
     }
 
@@ -263,13 +272,13 @@ final class UdsAgentClient implements AutoCloseable
     List<String> playerMessages(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerMessagesCommand(nextRequestId(), uuid));
-        return List.of(parseJsonField(response, "messagesJson", new TypeReference<String[]>() {}));
+        return List.of(parseJsonField(response, "messagesJson", TYPE_STRING_ARRAY));
     }
 
     List<ChatComponentSnapshot> playerChatComponents(UUID uuid)
     {
         final AgentResponse response = send(new GetPlayerChatComponentsCommand(nextRequestId(), uuid));
-        return java.util.Arrays.stream(parseJsonField(response, "componentsJson", new TypeReference<String[]>() {}))
+        return java.util.Arrays.stream(parseJsonField(response, "componentsJson", TYPE_STRING_ARRAY))
             .map(ChatComponentSnapshot::new)
             .toList();
     }
@@ -322,7 +331,7 @@ final class UdsAgentClient implements AutoCloseable
     List<Map<String, String>> getCapturedEvents(String eventClassName)
     {
         final AgentResponse response = send(new GetCapturedEventsCommand(nextRequestId(), eventClassName));
-        return parseJsonField(response, "eventsJson", new TypeReference<List<Map<String, String>>>() {});
+        return parseJsonField(response, "eventsJson", TYPE_EVENT_DATA_LIST);
     }
 
     void clearCapturedEvents(String eventClassName)

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -23,10 +23,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UdsAgentClientTest
 {
+    private static final ObjectMapper REQUEST_MAPPER = new ObjectMapper();
+    private static final java.util.UUID PLAYER_ID =
+        java.util.UUID.fromString("6efa93e0-6b5f-45b7-8af8-2453c9c7ef0c");
+
     @Test
     void send_shouldThrowExceptionWhenResponseIdDoesNotMatch(@TempDir Path tempDirectory)
         throws Exception
@@ -80,6 +85,368 @@ class UdsAgentClientTest
         }
     }
 
+    @Test
+    void serverPlatform_shouldSendPlatformRequestAndMapPaperResponse(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "PAPER"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.PAPER);
+            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+        }
+    }
+
+    @Test
+    void serverPlatform_shouldMapCraftBukkitResponseToSpigot(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform-craftbukkit.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "SPIGOT"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.SPIGOT);
+            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+        }
+    }
+
+    @Test
+    void loadChunk_shouldSendChunkCoordinates(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-load-chunk.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.loadChunk("world", 3, -4);
+
+            // verify
+            assertRequest(server, AgentAction.LOAD_CHUNK, Map.of("worldName", "world", "x", "3", "z", "-4"));
+        }
+    }
+
+    @Test
+    void playerInventory_shouldParseInventorySnapshot(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-inventory.sock");
+        final String inventoryJson = "[{\"slot\":1,\"materialKey\":\"minecraft:stone\",\"displayName\":\"Stone\","
+            + "\"lore\":[\"Line\"]}]";
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("inventoryJson", inventoryJson))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.InventorySnapshot result = client.playerInventory(PLAYER_ID);
+
+            // verify
+            assertThat(result.items()).hasSize(1);
+            assertThat(result.items().getFirst().materialKey()).isEqualTo("minecraft:stone");
+            assertRequest(server, AgentAction.GET_PLAYER_INVENTORY, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    @Test
+    void dropItem_shouldParseDroppedState(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-drop.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("dropped", "true"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.dropItem(PLAYER_ID);
+
+            // verify
+            assertThat(result).isTrue();
+            assertRequest(server, AgentAction.DROP_ITEM, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    @Test
+    void playerChatComponents_shouldParseComponentSnapshots(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-components.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("componentsJson", "[\"{\\\"text\\\":\\\"Hi\\\"}\"]"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final java.util.List<nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot> result =
+                client.playerChatComponents(PLAYER_ID);
+
+            // verify
+            assertThat(result).extracting(nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot::json)
+                .containsExactly("{\"text\":\"Hi\"}");
+            assertRequest(server, AgentAction.GET_PLAYER_CHAT_COMPONENTS, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    @Test
+    void getCapturedEvents_shouldSendEventClassNameAndParseEvents(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-events.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("eventsJson", "[{\"getValue\":\"value\"}]"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final java.util.List<nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot> result =
+                client.getCapturedEvents("org.bukkit.event.Event");
+
+            // verify
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().data()).containsEntry("getValue", "value");
+            assertRequest(
+                server,
+                AgentAction.GET_CAPTURED_EVENTS,
+                Map.of("eventClassName", "org.bukkit.event.Event")
+            );
+        }
+    }
+
+    @Test
+    void handshake_shouldSendHandshakeRequest(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-handshake.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("protocolVersion", "1", "bukkitVersion", "1.21.11")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.handshake("my-token", 1, "sha256");
+
+            // verify
+            assertRequest(server, AgentAction.HANDSHAKE, Map.of("token", "my-token", "protocolVersion", "1", "agentSha256", "sha256"));
+        }
+    }
+
+    @Test
+    void mainWorld_shouldSendRequestAndReturnWorldName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-mainworld.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("worldName", "world")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final String result = client.mainWorld();
+
+            // verify
+            assertThat(result).isEqualTo("world");
+            assertRequest(server, AgentAction.MAIN_WORLD, Map.of());
+        }
+    }
+
+    @Test
+    void unloadChunk_shouldSendCoordinatesAndReturnResult(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-unload-chunk.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("success", "false")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.unloadChunk("world", 5, -3);
+
+            // verify
+            assertThat(result).isFalse();
+            assertRequest(server, AgentAction.UNLOAD_CHUNK, Map.of("worldName", "world", "x", "5", "z", "-3"));
+        }
+    }
+
+    @Test
+    void isChunkLoaded_shouldSendCoordinatesAndReturnResult(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-is-loaded.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("loaded", "true")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.isChunkLoaded("world", 1, 2);
+
+            // verify
+            assertThat(result).isTrue();
+            assertRequest(server, AgentAction.IS_CHUNK_LOADED, Map.of("worldName", "world", "x", "1", "z", "2"));
+        }
+    }
+
+    @Test
+    void executeCommand_shouldSendCommandAndReturnResult(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-execute-cmd.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("success", "true")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean result = client.executeCommand(
+                nl.pim16aap2.lightkeeper.framework.CommandSource.CONSOLE, "time set day");
+
+            // verify
+            assertThat(result).isTrue();
+            assertRequest(server, AgentAction.EXECUTE_COMMAND, Map.of("source", "CONSOLE", "command", "time set day"));
+        }
+    }
+
+    @Test
+    void registerEventListener_shouldSendEventClassName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-register-event.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.registerEventListener("org.bukkit.event.player.PlayerJoinEvent");
+
+            // verify
+            assertRequest(server, AgentAction.REGISTER_EVENT_LISTENER,
+                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+        }
+    }
+
+    @Test
+    void clearCapturedEvents_shouldSendEventClassName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-clear-events.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.clearCapturedEvents("org.bukkit.event.player.PlayerJoinEvent");
+
+            // verify
+            assertRequest(server, AgentAction.CLEAR_CAPTURED_EVENTS,
+                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+        }
+    }
+
+    @Test
+    void unregisterEventListener_shouldSendEventClassName(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-unregister-event.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of()));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.unregisterEventListener("org.bukkit.event.player.PlayerJoinEvent");
+
+            // verify
+            assertRequest(server, AgentAction.UNREGISTER_EVENT_LISTENER,
+                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+        }
+    }
+
+    @Test
+    void waitTicks_shouldSendTickCount(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-wait-ticks.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("startTick", "0", "endTick", "5")));
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.waitTicks(5);
+
+            // verify
+            assertRequest(server, AgentAction.WAIT_TICKS, Map.of("ticks", "5"));
+        }
+    }
+
+    @Test
+    void serverPlatform_shouldMapUnknownPlatformToUnknown(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform-unknown.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "Sponge"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.UNKNOWN);
+        }
+    }
+
+    @Test
+    void playerMessages_shouldParseMessageList(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-messages.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("messagesJson", "[\"hello\",\"world\"]"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final java.util.List<String> result = client.playerMessages(PLAYER_ID);
+
+            // verify
+            assertThat(result).containsExactly("hello", "world");
+            assertRequest(server, AgentAction.GET_PLAYER_MESSAGES, Map.of("uuid", PLAYER_ID.toString()));
+        }
+    }
+
+    private static AgentResponse successResponse(Map<String, String> data)
+    {
+        return new AgentResponse("1", true, null, null, data);
+    }
+
+    private static void assertRequest(AgentSocketServer server, AgentAction action, Map<String, String> arguments)
+        throws IOException
+    {
+        final nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest request =
+            REQUEST_MAPPER.readValue(server.requestLine(), nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest.class);
+        assertThat(request.action()).isEqualTo(action);
+        assertThat(request.arguments()).isEqualTo(arguments);
+    }
+
     private static final class AgentSocketServer implements AutoCloseable
     {
         private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -88,6 +455,7 @@ class UdsAgentClientTest
         private final Thread workerThread;
         private final CountDownLatch started = new CountDownLatch(1);
         private final AtomicReference<Throwable> workerFailure = new AtomicReference<>();
+        private final AtomicReference<String> requestLine = new AtomicReference<>();
         private final Path socketPath;
 
         private AgentSocketServer(Path socketPath, AgentResponse response)
@@ -121,6 +489,7 @@ class UdsAgentClientTest
                 final String requestLine = reader.readLine();
                 if (requestLine == null)
                     return;
+                this.requestLine.set(requestLine);
                 writer.write(OBJECT_MAPPER.writeValueAsString(response));
                 writer.newLine();
                 writer.flush();
@@ -141,6 +510,11 @@ class UdsAgentClientTest
             if (failure != null)
                 throw new IllegalStateException("Socket server worker failed.", failure);
             Files.deleteIfExists(socketPath);
+        }
+
+        private String requestLine()
+        {
+            return java.util.Objects.requireNonNull(requestLine.get(), "No request was received.");
         }
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.protocol.AgentResponse;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicksCommand;
@@ -18,7 +19,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -29,8 +32,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class UdsAgentClientTest
 {
     private static final ObjectMapper REQUEST_MAPPER = new ObjectMapper();
-    private static final java.util.UUID PLAYER_ID =
-        java.util.UUID.fromString("6efa93e0-6b5f-45b7-8af8-2453c9c7ef0c");
+    private static final UUID PLAYER_ID =
+        UUID.fromString("6efa93e0-6b5f-45b7-8af8-2453c9c7ef0c");
 
     @Test
     void send_shouldThrowExceptionWhenResponseIdDoesNotMatch(@TempDir Path tempDirectory)
@@ -93,7 +96,7 @@ class UdsAgentClientTest
         final Path socketPath = tempDirectory.resolve("agent-platform.sock");
         try (AgentSocketServer server = AgentSocketServer.start(
             socketPath,
-            successResponse(Map.of("platform", "PAPER"))
+            successResponse(Map.of("platform", "paper"))
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
@@ -101,19 +104,19 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.PAPER);
-            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+            assertRequestAction(server, "GET_SERVER_PLATFORM");
         }
     }
 
     @Test
-    void serverPlatform_shouldMapCraftBukkitResponseToSpigot(@TempDir Path tempDirectory)
+    void serverPlatform_shouldMapSpigotResponseToSpigot(@TempDir Path tempDirectory)
         throws Exception
     {
         // setup
-        final Path socketPath = tempDirectory.resolve("agent-platform-craftbukkit.sock");
+        final Path socketPath = tempDirectory.resolve("agent-platform-spigot.sock");
         try (AgentSocketServer server = AgentSocketServer.start(
             socketPath,
-            successResponse(Map.of("platform", "SPIGOT"))
+            successResponse(Map.of("platform", "spigot"))
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
@@ -121,7 +124,26 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.SPIGOT);
-            assertRequest(server, AgentAction.GET_SERVER_PLATFORM, Map.of());
+            assertRequestAction(server, "GET_SERVER_PLATFORM");
+        }
+    }
+
+    @Test
+    void serverPlatform_shouldMapUnknownPlatformToUnknown(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-platform-unknown.sock");
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("platform", "sponge"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
+
+            // verify
+            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.UNKNOWN);
         }
     }
 
@@ -138,30 +160,34 @@ class UdsAgentClientTest
             client.loadChunk("world", 3, -4);
 
             // verify
-            assertRequest(server, AgentAction.LOAD_CHUNK, Map.of("worldName", "world", "x", "3", "z", "-4"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("LOAD_CHUNK");
+            assertThat(request.get("worldName").asText()).isEqualTo("world");
+            assertThat(request.get("x").asInt()).isEqualTo(3);
+            assertThat(request.get("z").asInt()).isEqualTo(-4);
         }
     }
 
     @Test
-    void playerInventory_shouldParseInventorySnapshot(@TempDir Path tempDirectory)
+    void getPlayerInventory_shouldParseInventoryItemMaps(@TempDir Path tempDirectory)
         throws Exception
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-inventory.sock");
-        final String inventoryJson = "[{\"slot\":1,\"materialKey\":\"minecraft:stone\",\"displayName\":\"Stone\","
-            + "\"lore\":[\"Line\"]}]";
+        final String inventoryJson =
+            "[{\"slot\":1,\"materialKey\":\"minecraft:stone\",\"displayName\":\"Stone\",\"lore\":[\"Line\"]}]";
         try (AgentSocketServer server = AgentSocketServer.start(
             socketPath,
             successResponse(Map.of("inventoryJson", inventoryJson))
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final nl.pim16aap2.lightkeeper.framework.InventorySnapshot result = client.playerInventory(PLAYER_ID);
+            final List<Map<String, Object>> result = client.getPlayerInventory(PLAYER_ID);
 
             // verify
-            assertThat(result.items()).hasSize(1);
-            assertThat(result.items().getFirst().materialKey()).isEqualTo("minecraft:stone");
-            assertRequest(server, AgentAction.GET_PLAYER_INVENTORY, Map.of("uuid", PLAYER_ID.toString()));
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst()).containsEntry("materialKey", "minecraft:stone");
+            assertRequestAction(server, "GET_PLAYER_INVENTORY");
         }
     }
 
@@ -181,7 +207,7 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isTrue();
-            assertRequest(server, AgentAction.DROP_ITEM, Map.of("uuid", PLAYER_ID.toString()));
+            assertRequestAction(server, "DROP_ITEM");
         }
     }
 
@@ -197,13 +223,13 @@ class UdsAgentClientTest
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final java.util.List<nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot> result =
+            final List<nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot> result =
                 client.playerChatComponents(PLAYER_ID);
 
             // verify
             assertThat(result).extracting(nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot::json)
                 .containsExactly("{\"text\":\"Hi\"}");
-            assertRequest(server, AgentAction.GET_PLAYER_CHAT_COMPONENTS, Map.of("uuid", PLAYER_ID.toString()));
+            assertRequestAction(server, "GET_PLAYER_CHAT_COMPONENTS");
         }
     }
 
@@ -219,17 +245,14 @@ class UdsAgentClientTest
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final java.util.List<nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot> result =
-                client.getCapturedEvents("org.bukkit.event.Event");
+            final List<Map<String, String>> result = client.getCapturedEvents("org.bukkit.event.Event");
 
             // verify
             assertThat(result).hasSize(1);
-            assertThat(result.getFirst().data()).containsEntry("getValue", "value");
-            assertRequest(
-                server,
-                AgentAction.GET_CAPTURED_EVENTS,
-                Map.of("eventClassName", "org.bukkit.event.Event")
-            );
+            assertThat(result.getFirst()).containsEntry("getValue", "value");
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("GET_CAPTURED_EVENTS");
+            assertThat(request.get("eventClassName").asText()).isEqualTo("org.bukkit.event.Event");
         }
     }
 
@@ -239,14 +262,20 @@ class UdsAgentClientTest
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-handshake.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("protocolVersion", "1", "bukkitVersion", "1.21.11")));
-             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("protocolVersion", "1", "bukkitVersion", "1.21.11"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
             client.handshake("my-token", 1, "sha256");
 
             // verify
-            assertRequest(server, AgentAction.HANDSHAKE, Map.of("token", "my-token", "protocolVersion", "1", "agentSha256", "sha256"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("HANDSHAKE");
+            assertThat(request.get("token").asText()).isEqualTo("my-token");
+            assertThat(request.get("protocolVersion").asInt()).isEqualTo(1);
+            assertThat(request.get("agentSha256").asText()).isEqualTo("sha256");
         }
     }
 
@@ -264,7 +293,7 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isEqualTo("world");
-            assertRequest(server, AgentAction.MAIN_WORLD, Map.of());
+            assertRequestAction(server, "MAIN_WORLD");
         }
     }
 
@@ -274,7 +303,7 @@ class UdsAgentClientTest
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-unload-chunk.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("success", "false")));
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("unloaded", "false")));
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
@@ -282,7 +311,11 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isFalse();
-            assertRequest(server, AgentAction.UNLOAD_CHUNK, Map.of("worldName", "world", "x", "5", "z", "-3"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("UNLOAD_CHUNK");
+            assertThat(request.get("worldName").asText()).isEqualTo("world");
+            assertThat(request.get("x").asInt()).isEqualTo(5);
+            assertThat(request.get("z").asInt()).isEqualTo(-3);
         }
     }
 
@@ -300,7 +333,7 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isTrue();
-            assertRequest(server, AgentAction.IS_CHUNK_LOADED, Map.of("worldName", "world", "x", "1", "z", "2"));
+            assertRequestAction(server, "IS_CHUNK_LOADED");
         }
     }
 
@@ -319,7 +352,10 @@ class UdsAgentClientTest
 
             // verify
             assertThat(result).isTrue();
-            assertRequest(server, AgentAction.EXECUTE_COMMAND, Map.of("source", "CONSOLE", "command", "time set day"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("EXECUTE_COMMAND");
+            assertThat(request.get("commandSource").asText()).isEqualTo("CONSOLE");
+            assertThat(request.get("command").asText()).isEqualTo("time set day");
         }
     }
 
@@ -336,8 +372,9 @@ class UdsAgentClientTest
             client.registerEventListener("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
-            assertRequest(server, AgentAction.REGISTER_EVENT_LISTENER,
-                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("REGISTER_EVENT_LISTENER");
+            assertThat(request.get("eventClassName").asText()).isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
         }
     }
 
@@ -354,8 +391,10 @@ class UdsAgentClientTest
             client.clearCapturedEvents("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
-            assertRequest(server, AgentAction.CLEAR_CAPTURED_EVENTS,
-                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("CLEAR_CAPTURED_EVENTS");
+            assertThat(request.get("eventClassName").asText())
+                .isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
         }
     }
 
@@ -372,8 +411,10 @@ class UdsAgentClientTest
             client.unregisterEventListener("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
-            assertRequest(server, AgentAction.UNREGISTER_EVENT_LISTENER,
-                Map.of("eventClassName", "org.bukkit.event.player.PlayerJoinEvent"));
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("UNREGISTER_EVENT_LISTENER");
+            assertThat(request.get("eventClassName").asText())
+                .isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
         }
     }
 
@@ -383,33 +424,18 @@ class UdsAgentClientTest
     {
         // setup
         final Path socketPath = tempDirectory.resolve("agent-wait-ticks.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(socketPath, successResponse(Map.of("startTick", "0", "endTick", "5")));
-             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        try (AgentSocketServer server = AgentSocketServer.start(
+            socketPath,
+            successResponse(Map.of("startTick", "0", "endTick", "5"))
+        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
             client.waitTicks(5);
 
             // verify
-            assertRequest(server, AgentAction.WAIT_TICKS, Map.of("ticks", "5"));
-        }
-    }
-
-    @Test
-    void serverPlatform_shouldMapUnknownPlatformToUnknown(@TempDir Path tempDirectory)
-        throws Exception
-    {
-        // setup
-        final Path socketPath = tempDirectory.resolve("agent-platform-unknown.sock");
-        try (AgentSocketServer server = AgentSocketServer.start(
-            socketPath,
-            successResponse(Map.of("platform", "Sponge"))
-        ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
-        {
-            // execute
-            final nl.pim16aap2.lightkeeper.framework.Platform result = client.serverPlatform();
-
-            // verify
-            assertThat(result).isEqualTo(nl.pim16aap2.lightkeeper.framework.Platform.UNKNOWN);
+            final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+            assertThat(request.get("action").asText()).isEqualTo("WAIT_TICKS");
+            assertThat(request.get("ticks").asInt()).isEqualTo(5);
         }
     }
 
@@ -425,11 +451,11 @@ class UdsAgentClientTest
         ); UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final java.util.List<String> result = client.playerMessages(PLAYER_ID);
+            final List<String> result = client.playerMessages(PLAYER_ID);
 
             // verify
             assertThat(result).containsExactly("hello", "world");
-            assertRequest(server, AgentAction.GET_PLAYER_MESSAGES, Map.of("uuid", PLAYER_ID.toString()));
+            assertRequestAction(server, "GET_PLAYER_MESSAGES");
         }
     }
 
@@ -438,13 +464,21 @@ class UdsAgentClientTest
         return new AgentResponse("1", true, null, null, data);
     }
 
-    private static void assertRequest(AgentSocketServer server, AgentAction action, Map<String, String> arguments)
+    /**
+     * Asserts that the received request JSON has the expected {@code "action"} field value.
+     *
+     * @param server
+     *     The test socket server holding the received request line.
+     * @param expectedAction
+     *     The expected action name (e.g. {@code "LOAD_CHUNK"}).
+     * @throws IOException
+     *     If JSON parsing fails.
+     */
+    private static void assertRequestAction(AgentSocketServer server, String expectedAction)
         throws IOException
     {
-        final nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest request =
-            REQUEST_MAPPER.readValue(server.requestLine(), nl.pim16aap2.lightkeeper.runtime.agent.AgentRequest.class);
-        assertThat(request.action()).isEqualTo(action);
-        assertThat(request.arguments()).isEqualTo(arguments);
+        final JsonNode request = REQUEST_MAPPER.readTree(server.requestLine());
+        assertThat(request.get("action").asText()).isEqualTo(expectedAction);
     }
 
     private static final class AgentSocketServer implements AutoCloseable
@@ -486,10 +520,10 @@ class UdsAgentClientTest
                  BufferedWriter writer = new BufferedWriter(
                      Channels.newWriter(clientChannel, StandardCharsets.UTF_8)))
             {
-                final String requestLine = reader.readLine();
-                if (requestLine == null)
+                final String line = reader.readLine();
+                if (line == null)
                     return;
-                this.requestLine.set(requestLine);
+                this.requestLine.set(line);
                 writer.write(OBJECT_MAPPER.writeValueAsString(response));
                 writer.newLine();
                 writer.flush();


### PR DESCRIPTION
## Why
After the feature PRs a round of correctness and structure review
identified four correctness bugs and three SRP violations. This PR fixes
all of them with no public API changes.

## How
**Correctness:**
- `UdsAgentClient.send()`: read timeout watchdog (120 s) closes the
  channel so hanging agent calls don't deadlock the framework forever
- `AgentEventCapture.registerListener()`: `putIfAbsent` + rollback
  prevents duplicate Bukkit listeners under concurrent invocations
- `UdsAgentClient.serverPlatform()`, `dragMenuSlots()`: type-safe
  `TypeReference` constants (eliminates unchecked cast); `IntStream +
  Collectors.joining` replaces O(n²) string concatenation
- `PlayerHandleAssert.hasClickableChatText()`: already fixed in PR #77;
  this PR wires `parseJsonField<T>` helper that eliminates 5 identical
  try/catch deserialization blocks

**SRP:**
- `AgentEventActions` (new): extracts the 4 event-capture handlers that
  were inline in `AgentRequestDispatcher`
- `AgentRequestDispatcher.Config` record: groups auth/protocol/SHA/logger
  into a named value object (9-param constructor → 6-param)
- `AgentSyntheticPlayerStore`: 4 parallel `ConcurrentHashMap` fields
  consolidated into a single `SyntheticPlayerState` inner class — no
  more risk of forgetting to update one of the four maps

**Polish:**
- `MinecraftServerProcess`: comment for `-DIReallyKnowWhatIAmDoingISwear`
  (Spigot stale-build suppressor); shell-safe quoted-arg tokenizer for
  `extraJvmArgs`
- `AgentPlayerActions.buildInventoryItems`: extracted as private static
  helper

## Tests
- All existing tests pass; `AgentEventActionsTest` (10 tests) and
  `UdsAgentClientTest` additions cover the new structure

_Part 6 of 6. Targets #78 (split/05-platform). Original PR: #73._

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register, manage and capture Bukkit event listeners; retrieve and clear captured events via a dedicated handler.

* **Improvements**
  * Dispatcher and plugin initialization refactored to use a consolidated event handler and bundled config.
  * Consolidated synthetic-player state storage; richer per-slot inventory serialization.
  * Improved clickable-chat detection in assertions.

* **Bug Fixes**
  * Added socket send timeout watchdog to prevent stalled communications.

* **Tests**
  * Expanded coverage for event lifecycle, request/response parsing, inventory and messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PimvanderLoos/LightKeeper/pull/79)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->