### PR TITLE
feat: structured server-error capture via Log4j appender

### DIFF
--- a/lightkeeper-agent-spigot/pom.xml
+++ b/lightkeeper-agent-spigot/pom.xml
@@ -59,6 +59,20 @@
             <version>${version.spigot-api}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Provided by the Minecraft server runtime; used to attach the structured error-capture appender. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${version.log4j}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${version.log4j}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.exc.ValueInstantiationException;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
+import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.ClickMenuSlot;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayer;
 import nl.pim16aap2.lightkeeper.protocol.DragMenuSlots;
@@ -17,6 +18,7 @@ import nl.pim16aap2.lightkeeper.protocol.GetOpenMenu;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponents;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessages;
+import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.GetServerPlatform;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.Handshake;
@@ -75,6 +77,10 @@ final class AgentRequestDispatcher
      * Handler for dynamic Bukkit event capture.
      */
     private final AgentEventActions eventActions;
+    /**
+     * Handler for structured server-error capture.
+     */
+    private final AgentServerErrorActions serverErrorActions;
 
     /**
      * Immutable authentication, protocol, and diagnostics configuration.
@@ -94,6 +100,8 @@ final class AgentRequestDispatcher
      *     Menu action handler.
      * @param eventActions
      *     Event capture action handler.
+     * @param serverErrorActions
+     *     Structured server-error capture action handler.
      * @param config
      *     Immutable dispatcher configuration (auth, protocol, SHA, logger).
      */
@@ -104,6 +112,7 @@ final class AgentRequestDispatcher
         AgentPlayerStateActions playerStateActions,
         AgentMenuActions menuActions,
         AgentEventActions eventActions,
+        AgentServerErrorActions serverErrorActions,
         Config config)
     {
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
@@ -112,6 +121,7 @@ final class AgentRequestDispatcher
         this.playerStateActions = Objects.requireNonNull(playerStateActions, "playerStateActions");
         this.menuActions = Objects.requireNonNull(menuActions, "menuActions");
         this.eventActions = Objects.requireNonNull(eventActions, "eventActions");
+        this.serverErrorActions = Objects.requireNonNull(serverErrorActions, "serverErrorActions");
         this.config = Objects.requireNonNull(config, "config");
     }
 
@@ -259,6 +269,8 @@ final class AgentRequestDispatcher
                 case UnregisterEventListener.Command c -> handle(c, eventActions::handleUnregisterEventListener);
                 case GetPlayerChatComponents.Command c -> handle(c, playerStateActions::handleGetPlayerChatComponents);
                 case GetServerPlatform.Command c -> handle(c, worldActions::handleGetServerPlatform);
+                case GetServerErrors.Command c -> handle(c, serverErrorActions::handleGetServerErrors);
+                case ClearServerErrors.Command c -> handle(c, serverErrorActions::handleClearServerErrors);
                 case Handshake.Command ignored ->
                     throw new IllegalStateException("Unreachable HANDSHAKE dispatch branch.");
             };

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorActions.java
@@ -1,0 +1,60 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
+import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
+
+import java.util.Objects;
+
+/**
+ * Protocol action handler for structured server-error capture.
+ *
+ * <p>Handles {@code GET_SERVER_ERRORS} and {@code CLEAR_SERVER_ERRORS} actions by delegating to
+ * {@link AgentServerErrorCapture}.
+ */
+final class AgentServerErrorActions
+{
+    /**
+     * Structured server-error store.
+     */
+    private final AgentServerErrorCapture serverErrorCapture;
+
+    /**
+     * @param serverErrorCapture
+     *     Structured server-error capture facade.
+     */
+    AgentServerErrorActions(AgentServerErrorCapture serverErrorCapture)
+    {
+        this.serverErrorCapture = Objects.requireNonNull(serverErrorCapture, "serverErrorCapture");
+    }
+
+    /**
+     * Handles {@code GET_SERVER_ERRORS} by returning all entries captured since agent load or the last clear.
+     *
+     * @param command
+     *     Typed get-server-errors command.
+     * @return
+     *     Success response with the captured entries, dropped-entry count, and capture-active flag.
+     */
+    GetServerErrors.Response handleGetServerErrors(GetServerErrors.Command command)
+    {
+        return new GetServerErrors.Response(
+            serverErrorCapture.snapshot(),
+            serverErrorCapture.droppedCount(),
+            serverErrorCapture.active()
+        );
+    }
+
+    /**
+     * Handles {@code CLEAR_SERVER_ERRORS} by discarding captured entries and resetting the dropped counter.
+     *
+     * @param command
+     *     Typed clear-server-errors command.
+     * @return
+     *     Success response.
+     */
+    ClearServerErrors.Response handleClearServerErrors(ClearServerErrors.Command command)
+    {
+        serverErrorCapture.clear();
+        return new ClearServerErrors.Response();
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCapture.java
@@ -127,7 +127,16 @@ final class AgentServerErrorCapture
 
             final CaptureAppender captureAppender = new CaptureAppender();
             captureAppender.start();
-            coreLogger.addAppender(captureAppender);
+            try
+            {
+                coreLogger.addAppender(captureAppender);
+            }
+            catch (RuntimeException | LinkageError exception)
+            {
+                // Never leak a started appender that was not attached.
+                captureAppender.stop();
+                throw exception;
+            }
 
             final CaptureStatusListener capturedStatusListener;
             try

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCapture.java
@@ -129,8 +129,20 @@ final class AgentServerErrorCapture
             captureAppender.start();
             coreLogger.addAppender(captureAppender);
 
-            final CaptureStatusListener capturedStatusListener = new CaptureStatusListener();
-            StatusLogger.getLogger().registerListener(capturedStatusListener);
+            final CaptureStatusListener capturedStatusListener;
+            try
+            {
+                capturedStatusListener = new CaptureStatusListener();
+                StatusLogger.getLogger().registerListener(capturedStatusListener);
+            }
+            catch (RuntimeException | LinkageError exception)
+            {
+                // Roll back the already-attached appender: without the field set, uninstall() could
+                // never remove it, leaving a half-installed capture on the root logger.
+                coreLogger.removeAppender(captureAppender);
+                captureAppender.stop();
+                throw exception;
+            }
 
             appender = captureAppender;
             statusListener = capturedStatusListener;

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCapture.java
@@ -1,0 +1,377 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.status.StatusListener;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.jspecify.annotations.Nullable;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Captures WARN-or-worse server log events as structured snapshots by attaching an appender to the Log4j root
+ * logger.
+ *
+ * <p>Unlike console scraping, capture happens at the {@link LogEvent} layer where the original {@link Throwable}
+ * is still attached, so entries carry the real exception class, message, and rendered cause chain. Because the
+ * server redirects {@code System.out}/{@code System.err} into Log4j during startup, raw
+ * {@code printStackTrace()} calls from plugins are captured as well. A {@link StatusListener} is registered
+ * alongside the appender so failures inside the logging system itself (which Log4j reports only through its
+ * status logger, bypassing all appenders) are captured too.
+ *
+ * <p>The buffer is bounded: once full, new entries are dropped and counted while the oldest entries are kept,
+ * so an error storm cannot exhaust server memory and the first (root-cause) errors always survive.
+ *
+ * <p>Install from {@code onLoad} — before any plugin's {@code onEnable} runs — so enable-time errors of the
+ * plugins under test are captured.
+ */
+final class AgentServerErrorCapture
+{
+    /**
+     * Maximum number of error entries retained. Prevents unbounded memory growth during error storms.
+     */
+    static final int MAX_CAPTURED_ERRORS = 1_000;
+    /**
+     * Maximum number of rendered stack trace lines (including the cause chain) retained per entry.
+     */
+    static final int MAX_STACK_TRACE_LINES = 100;
+    /**
+     * Severity bucket for error-or-worse events.
+     */
+    static final String SEVERITY_ERROR = "ERROR";
+    /**
+     * Severity bucket for warning events.
+     */
+    static final String SEVERITY_WARNING = "WARNING";
+    /**
+     * Name under which the capture appender is registered on the root logger.
+     */
+    private static final String APPENDER_NAME = "LightKeeperServerErrorCapture";
+    /**
+     * Synthetic logger name used for entries captured from Log4j's internal status logger.
+     */
+    private static final String STATUS_LOGGER_NAME = "log4j.StatusLogger";
+
+    /**
+     * Plugin logger used for install/uninstall diagnostics only; never used from the capture path, which must
+     * not log (logging from inside the appender would recurse straight back into it).
+     */
+    private final java.util.logging.Logger pluginLogger;
+    /**
+     * Guards {@link #buffer} and {@link #droppedCount}.
+     */
+    private final Object bufferLock = new Object();
+    /**
+     * Captured entries ordered oldest-to-newest; guarded by {@link #bufferLock}.
+     */
+    private final ArrayDeque<ServerErrorEntry> buffer = new ArrayDeque<>();
+    /**
+     * Number of entries discarded because the buffer was full; guarded by {@link #bufferLock}.
+     */
+    private long droppedCount;
+
+    /**
+     * The capture appender while installed.
+     */
+    private @Nullable CaptureAppender appender;
+    /**
+     * The status listener while installed.
+     */
+    private @Nullable CaptureStatusListener statusListener;
+    /**
+     * Whether the appender is currently attached to the root logger.
+     */
+    private volatile boolean captureActive;
+
+    /**
+     * @param pluginLogger
+     *     Logger used to report install/uninstall problems.
+     */
+    AgentServerErrorCapture(java.util.logging.Logger pluginLogger)
+    {
+        this.pluginLogger = Objects.requireNonNull(pluginLogger, "pluginLogger");
+    }
+
+    /**
+     * Attaches the capture appender to the Log4j root logger and registers the status listener.
+     *
+     * <p>Failures are reported through the plugin logger and leave capture inactive rather than breaking agent
+     * startup; {@link #active()} reflects the outcome.
+     *
+     * @return
+     *     {@code true} when capture is active after this call.
+     */
+    boolean install()
+    {
+        if (captureActive)
+            return true;
+
+        try
+        {
+            if (!(LogManager.getRootLogger() instanceof org.apache.logging.log4j.core.Logger coreLogger))
+            {
+                pluginLogger.warning(
+                    "Log4j root logger is not a log4j-core logger; structured server-error capture is disabled.");
+                return false;
+            }
+
+            final CaptureAppender captureAppender = new CaptureAppender();
+            captureAppender.start();
+            coreLogger.addAppender(captureAppender);
+
+            final CaptureStatusListener capturedStatusListener = new CaptureStatusListener();
+            StatusLogger.getLogger().registerListener(capturedStatusListener);
+
+            appender = captureAppender;
+            statusListener = capturedStatusListener;
+            captureActive = true;
+            return true;
+        }
+        catch (RuntimeException | LinkageError exception)
+        {
+            pluginLogger.warning(
+                "Failed to attach the structured server-error capture appender: " + exception);
+            return false;
+        }
+    }
+
+    /**
+     * Detaches the capture appender and status listener; safe to call when capture never became active.
+     *
+     * <p>The root logger is a singleton, so re-resolving it here detaches from the same logger the appender was
+     * added to during {@link #install()}.
+     */
+    void uninstall()
+    {
+        final CaptureAppender captureAppender = appender;
+        final CaptureStatusListener capturedStatusListener = statusListener;
+        appender = null;
+        statusListener = null;
+        captureActive = false;
+
+        try
+        {
+            if (captureAppender != null
+                && LogManager.getRootLogger() instanceof org.apache.logging.log4j.core.Logger coreLogger)
+            {
+                coreLogger.removeAppender(captureAppender);
+                captureAppender.stop();
+            }
+            if (capturedStatusListener != null)
+                StatusLogger.getLogger().removeListener(capturedStatusListener);
+        }
+        catch (RuntimeException | LinkageError exception)
+        {
+            pluginLogger.warning("Failed to detach the structured server-error capture appender: " + exception);
+        }
+    }
+
+    /**
+     * Reports whether the capture appender is currently attached.
+     *
+     * @return
+     *     {@code true} while capture is active.
+     */
+    boolean active()
+    {
+        return captureActive;
+    }
+
+    /**
+     * Returns a snapshot of captured entries ordered oldest-to-newest.
+     *
+     * @return
+     *     Snapshot list of captured entries.
+     */
+    List<ServerErrorEntry> snapshot()
+    {
+        synchronized (bufferLock)
+        {
+            return new ArrayList<>(buffer);
+        }
+    }
+
+    /**
+     * Returns the number of entries dropped because the buffer was full.
+     *
+     * @return
+     *     Dropped entry count since agent load or the last {@link #clear()}.
+     */
+    long droppedCount()
+    {
+        synchronized (bufferLock)
+        {
+            return droppedCount;
+        }
+    }
+
+    /**
+     * Discards all captured entries and resets the dropped-entry counter.
+     */
+    void clear()
+    {
+        synchronized (bufferLock)
+        {
+            buffer.clear();
+            droppedCount = 0L;
+        }
+    }
+
+    /**
+     * Buffers one entry, dropping it (counted) when the buffer is full so the oldest entries survive.
+     *
+     * @param entry
+     *     The entry to buffer.
+     */
+    private void offer(ServerErrorEntry entry)
+    {
+        synchronized (bufferLock)
+        {
+            if (buffer.size() >= MAX_CAPTURED_ERRORS)
+            {
+                droppedCount++;
+                return;
+            }
+            buffer.addLast(entry);
+        }
+    }
+
+    /**
+     * Maps a WARN-or-worse log event into a structured entry and buffers it; sub-WARN events are ignored.
+     *
+     * @param event
+     *     The log event to capture.
+     */
+    private void capture(LogEvent event)
+    {
+        final Level level = event.getLevel();
+        if (level == null || !level.isMoreSpecificThan(Level.WARN))
+            return;
+
+        final Throwable thrown = event.getThrown();
+        offer(new ServerErrorEntry(
+            event.getTimeMillis(),
+            level.isMoreSpecificThan(Level.ERROR) ? SEVERITY_ERROR : SEVERITY_WARNING,
+            level.name(),
+            Objects.requireNonNullElse(event.getLoggerName(), ""),
+            Objects.requireNonNullElse(event.getThreadName(), ""),
+            event.getMessage() == null ? "" : Objects.requireNonNullElse(
+                event.getMessage().getFormattedMessage(), ""),
+            thrown == null ? null : thrown.getClass().getName(),
+            thrown == null ? null : thrown.getMessage(),
+            thrown == null ? List.of() : renderStackTrace(thrown)
+        ));
+    }
+
+    /**
+     * Renders a throwable's full stack trace (including cause chain) as lines, truncated to
+     * {@link #MAX_STACK_TRACE_LINES}.
+     *
+     * @param thrown
+     *     The throwable to render.
+     * @return
+     *     Rendered stack trace lines.
+     */
+    private static List<String> renderStackTrace(Throwable thrown)
+    {
+        final StringWriter stringWriter = new StringWriter();
+        thrown.printStackTrace(new PrintWriter(stringWriter));
+        final List<String> lines = stringWriter.toString().lines().toList();
+        if (lines.size() <= MAX_STACK_TRACE_LINES)
+            return lines;
+
+        final List<String> truncated = new ArrayList<>(lines.subList(0, MAX_STACK_TRACE_LINES));
+        truncated.add("... (%d more lines truncated)".formatted(lines.size() - MAX_STACK_TRACE_LINES));
+        return truncated;
+    }
+
+    /**
+     * Appender that funnels WARN-or-worse root-logger events into the capture buffer.
+     */
+    private final class CaptureAppender extends AbstractAppender
+    {
+        CaptureAppender()
+        {
+            super(APPENDER_NAME, null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event)
+        {
+            try
+            {
+                capture(event);
+            }
+            catch (RuntimeException exception)
+            {
+                // Never propagate capture failures into the server's logging pipeline, and never log from here:
+                // a log call would recurse straight back into this appender. Count the loss instead.
+                synchronized (bufferLock)
+                {
+                    droppedCount++;
+                }
+            }
+        }
+    }
+
+    /**
+     * Status listener that captures Log4j-internal failures, which are reported only through the status logger
+     * and would otherwise bypass every appender (they are written to the raw stderr file descriptor).
+     */
+    private final class CaptureStatusListener implements StatusListener
+    {
+        @Override
+        public void log(StatusData data)
+        {
+            try
+            {
+                final Level level = data.getLevel();
+                if (level == null || !level.isMoreSpecificThan(Level.WARN))
+                    return;
+
+                final Throwable thrown = data.getThrowable();
+                offer(new ServerErrorEntry(
+                    data.getTimestamp(),
+                    level.isMoreSpecificThan(Level.ERROR) ? SEVERITY_ERROR : SEVERITY_WARNING,
+                    level.name(),
+                    STATUS_LOGGER_NAME,
+                    Objects.requireNonNullElse(data.getThreadName(), ""),
+                    Objects.requireNonNullElse(data.getFormattedStatus(), ""),
+                    thrown == null ? null : thrown.getClass().getName(),
+                    thrown == null ? null : thrown.getMessage(),
+                    thrown == null ? List.of() : renderStackTrace(thrown)
+                ));
+            }
+            catch (RuntimeException exception)
+            {
+                // Same rule as the appender: never log from the capture path.
+                synchronized (bufferLock)
+                {
+                    droppedCount++;
+                }
+            }
+        }
+
+        @Override
+        public Level getStatusLevel()
+        {
+            return Level.WARN;
+        }
+
+        @Override
+        public void close()
+        {
+            // Nothing to release; unregistration happens in uninstall().
+        }
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -93,6 +93,25 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
      * Request dispatcher wired during startup.
      */
     private @Nullable AgentRequestDispatcher requestDispatcher;
+    /**
+     * Structured server-error capture, installed during {@link #onLoad()}.
+     */
+    private @Nullable AgentServerErrorCapture serverErrorCapture;
+
+    /**
+     * Installs the structured server-error capture appender.
+     *
+     * <p>This runs in {@code onLoad} — before any plugin's {@code onEnable} — so enable-time errors of the
+     * plugins under test are already captured. Install failures leave capture inactive but never break agent
+     * startup.
+     */
+    @Override
+    public void onLoad()
+    {
+        final AgentServerErrorCapture capture = new AgentServerErrorCapture(getLogger());
+        serverErrorCapture = capture;
+        capture.install();
+    }
 
     /**
      * Initializes agent configuration and socket server.
@@ -134,6 +153,11 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
             final AgentEventCapture eventCapture = new AgentEventCapture(this, mainThreadExecutor);
             final AgentEventActions eventActions = new AgentEventActions(eventCapture);
 
+            final AgentServerErrorCapture errorCapture = serverErrorCapture;
+            if (errorCapture == null)
+                throw new IllegalStateException("Server-error capture is not initialized; onLoad did not run.");
+            final AgentServerErrorActions serverErrorActions = new AgentServerErrorActions(errorCapture);
+
             requestDispatcher = new AgentRequestDispatcher(
                 objectMapper,
                 worldActions,
@@ -141,6 +165,7 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 playerStateActions,
                 menuActions,
                 eventActions,
+                serverErrorActions,
                 new AgentRequestDispatcher.Config(
                     configuration.authToken(),
                     configuration.protocolVersion(),
@@ -167,6 +192,10 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
     {
         running = false;
         closeQuietly(serverSocketChannel);
+
+        final AgentServerErrorCapture errorCapture = serverErrorCapture;
+        if (errorCapture != null)
+            errorCapture.uninstall();
 
         final AgentRequestDispatcher dispatcher = requestDispatcher;
         if (dispatcher != null)

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import nl.pim16aap2.lightkeeper.protocol.AgentProtocolMapper;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
+import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.ClickMenuSlot;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayer;
@@ -20,6 +21,7 @@ import nl.pim16aap2.lightkeeper.protocol.GetOpenMenu;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponents;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessages;
+import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.GetServerPlatform;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.Handshake;
@@ -355,6 +357,10 @@ class AgentRequestDispatcherTest
             .thenReturn(new GetPlayerChatComponents.Response("[]"));
         when(fixture.worldActions().handleGetServerPlatform(any(GetServerPlatform.Command.class)))
             .thenReturn(new GetServerPlatform.Response("SPIGOT"));
+        when(fixture.serverErrorActions().handleGetServerErrors(any(GetServerErrors.Command.class)))
+            .thenReturn(new GetServerErrors.Response(java.util.List.of(), 0L, true));
+        when(fixture.serverErrorActions().handleClearServerErrors(any(ClearServerErrors.Command.class)))
+            .thenReturn(new ClearServerErrors.Response());
 
         // execute
         dispatchExpectingSuccess(fixture, toJson(new NewWorld.Command("request-1", "w", "NORMAL", "NORMAL", 0L)));
@@ -385,6 +391,8 @@ class AgentRequestDispatcherTest
         dispatchExpectingSuccess(fixture, toJson(new UnregisterEventListener.Command("request-26", "org.bukkit.event.player.PlayerJoinEvent")));
         dispatchExpectingSuccess(fixture, toJson(new GetPlayerChatComponents.Command("request-27", uuid)));
         dispatchExpectingSuccess(fixture, toJson(new GetServerPlatform.Command("request-28")));
+        dispatchExpectingSuccess(fixture, toJson(new GetServerErrors.Command("request-29")));
+        dispatchExpectingSuccess(fixture, toJson(new ClearServerErrors.Command("request-30")));
 
         // verify
         verify(fixture.worldActions()).handleNewWorld(any(NewWorld.Command.class));
@@ -415,6 +423,8 @@ class AgentRequestDispatcherTest
         verify(fixture.eventActions()).handleUnregisterEventListener(any(UnregisterEventListener.Command.class));
         verify(fixture.playerStateActions()).handleGetPlayerChatComponents(any(GetPlayerChatComponents.Command.class));
         verify(fixture.worldActions()).handleGetServerPlatform(any(GetServerPlatform.Command.class));
+        verify(fixture.serverErrorActions()).handleGetServerErrors(any(GetServerErrors.Command.class));
+        verify(fixture.serverErrorActions()).handleClearServerErrors(any(ClearServerErrors.Command.class));
     }
 
     @Test
@@ -570,6 +580,8 @@ class AgentRequestDispatcherTest
         );
         final AgentEventCapture eventCapture = mock();
         final AgentEventActions eventActions = new AgentEventActions(eventCapture);
+        final AgentServerErrorCapture serverErrorCapture = mock();
+        final AgentServerErrorActions serverErrorActions = new AgentServerErrorActions(serverErrorCapture);
 
         return new AgentRequestDispatcher(
             objectMapper,
@@ -578,6 +590,7 @@ class AgentRequestDispatcherTest
             playerStateActions,
             menuActions,
             eventActions,
+            serverErrorActions,
             new AgentRequestDispatcher.Config(
                 authToken,
                 protocolVersion,
@@ -595,6 +608,7 @@ class AgentRequestDispatcherTest
         final AgentPlayerStateActions playerStateActions = mock();
         final AgentMenuActions menuActions = mock();
         final AgentEventActions eventActions = mock();
+        final AgentServerErrorActions serverErrorActions = mock();
         final AgentRequestDispatcher dispatcher = new AgentRequestDispatcher(
             objectMapper,
             worldActions,
@@ -602,6 +616,7 @@ class AgentRequestDispatcherTest
             playerStateActions,
             menuActions,
             eventActions,
+            serverErrorActions,
             new AgentRequestDispatcher.Config(
                 "token",
                 1,
@@ -610,7 +625,8 @@ class AgentRequestDispatcherTest
             )
         );
         return new DispatcherFixture(
-            dispatcher, worldActions, playerActions, playerStateActions, menuActions, eventActions);
+            dispatcher, worldActions, playerActions, playerStateActions, menuActions, eventActions,
+            serverErrorActions);
     }
 
     private record DispatcherFixture(
@@ -619,7 +635,8 @@ class AgentRequestDispatcherTest
         AgentPlayerActions playerActions,
         AgentPlayerStateActions playerStateActions,
         AgentMenuActions menuActions,
-        AgentEventActions eventActions)
+        AgentEventActions eventActions,
+        AgentServerErrorActions serverErrorActions)
     {
     }
 

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorActionsTest.java
@@ -1,0 +1,58 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
+import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
+import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentServerErrorActionsTest
+{
+    @Mock
+    private AgentServerErrorCapture serverErrorCapture;
+
+    @Test
+    void handleGetServerErrors_shouldReturnSnapshotDroppedCountAndActiveFlag()
+    {
+        // setup
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            1L, "ERROR", "ERROR", "logger", "thread", "message", null, null, List.of());
+        when(serverErrorCapture.snapshot()).thenReturn(List.of(entry));
+        when(serverErrorCapture.droppedCount()).thenReturn(3L);
+        when(serverErrorCapture.active()).thenReturn(true);
+        final AgentServerErrorActions actions = new AgentServerErrorActions(serverErrorCapture);
+
+        // execute
+        final GetServerErrors.Response response =
+            actions.handleGetServerErrors(new GetServerErrors.Command("request-1"));
+
+        // verify
+        assertThat(response.errors()).containsExactly(entry);
+        assertThat(response.droppedCount()).isEqualTo(3L);
+        assertThat(response.captureActive()).isTrue();
+    }
+
+    @Test
+    void handleClearServerErrors_shouldDelegateToCapture()
+    {
+        // setup
+        final AgentServerErrorActions actions = new AgentServerErrorActions(serverErrorCapture);
+
+        // execute
+        final ClearServerErrors.Response response =
+            actions.handleClearServerErrors(new ClearServerErrors.Command("request-2"));
+
+        // verify
+        assertThat(response).isNotNull();
+        verify(serverErrorCapture).clear();
+    }
+}

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCaptureTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCaptureTest.java
@@ -3,14 +3,28 @@ package nl.pim16aap2.lightkeeper.agent.spigot;
 import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.status.StatusListener;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 /**
  * Exercises {@link AgentServerErrorCapture} against the real Log4j runtime available on the test classpath:
@@ -199,5 +213,195 @@ class AgentServerErrorCaptureTest
         // verify
         assertThat(capture.snapshot())
             .noneSatisfy(entry -> assertThat(entry.message()).isEqualTo("capture-test-after-uninstall"));
+    }
+
+    @Test
+    void install_shouldReturnFalseWhenRootLoggerIsNotCoreLogger()
+    {
+        // setup
+        final org.apache.logging.log4j.Logger nonCoreRootLogger = mock(org.apache.logging.log4j.Logger.class);
+        try (MockedStatic<LogManager> logManagerMock = mockStatic(LogManager.class))
+        {
+            logManagerMock.when(LogManager::getRootLogger).thenReturn(nonCoreRootLogger);
+
+            // execute
+            final boolean installed = capture.install();
+
+            // verify
+            assertThat(installed).isFalse();
+            assertThat(capture.active()).isFalse();
+        }
+    }
+
+    @Test
+    void install_shouldRollBackAppenderWhenStatusListenerRegistrationFails()
+    {
+        // setup + execute
+        try (MockedStatic<StatusLogger> statusLoggerMock = mockStatic(StatusLogger.class))
+        {
+            final StatusLogger fakeStatusLogger = mock(StatusLogger.class);
+            statusLoggerMock.when(StatusLogger::getLogger).thenReturn(fakeStatusLogger);
+            doThrow(new IllegalStateException("register-boom")).when(fakeStatusLogger).registerListener(any());
+
+            final boolean installed = capture.install();
+
+            // verify
+            assertThat(installed).isFalse();
+            assertThat(capture.active()).isFalse();
+        }
+
+        // and the already-attached appender must be rolled back from the real root logger, not left dangling
+        final org.apache.logging.log4j.core.Logger coreLogger =
+            (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
+        assertThat(coreLogger.getAppenders()).doesNotContainKey("LightKeeperServerErrorCapture");
+    }
+
+    @Test
+    void append_shouldIgnoreEventsWithNullLevel()
+    {
+        // setup
+        capture.install();
+        final Appender appender = capturedAppender();
+        final LogEvent eventWithNullLevel = mock(LogEvent.class);
+        when(eventWithNullLevel.getLevel()).thenReturn(null);
+
+        // execute
+        appender.append(eventWithNullLevel);
+
+        // verify
+        assertThat(capture.snapshot()).isEmpty();
+    }
+
+    @Test
+    void append_shouldTreatNullMessageAsEmptyString()
+    {
+        // setup
+        capture.install();
+        final Appender appender = capturedAppender();
+        final LogEvent event = mock(LogEvent.class);
+        when(event.getLevel()).thenReturn(Level.ERROR);
+        when(event.getMessage()).thenReturn(null);
+
+        // execute
+        appender.append(event);
+
+        // verify
+        assertThat(capture.snapshot()).singleElement()
+            .extracting(ServerErrorEntry::message)
+            .isEqualTo("");
+    }
+
+    @Test
+    void append_shouldSwallowExceptionAndCountDroppedWhenCaptureFails()
+    {
+        // setup
+        capture.install();
+        final Appender appender = capturedAppender();
+        final LogEvent brokenEvent = mock(LogEvent.class);
+        when(brokenEvent.getLevel()).thenReturn(Level.ERROR);
+        when(brokenEvent.getMessage()).thenThrow(new RuntimeException("capture-boom"));
+
+        // execute
+        appender.append(brokenEvent);
+
+        // verify — capture failures are never propagated into the server's logging pipeline
+        assertThat(capture.snapshot()).isEmpty();
+        assertThat(capture.droppedCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void statusListener_shouldCaptureWarnAndErrorLog4jInternalStatusEvents()
+    {
+        // setup
+        capture.install();
+        final StatusListener listener = registeredStatusListener();
+        final IllegalStateException thrown = new IllegalStateException("status-boom");
+        final StatusData warnStatus = new StatusData(
+            null, Level.WARN, new SimpleMessage("status-test-warning"), null, "status-thread");
+        final StatusData errorStatus = new StatusData(
+            null, Level.ERROR, new SimpleMessage("status-test-error"), thrown, "status-thread");
+
+        // execute
+        listener.log(warnStatus);
+        listener.log(errorStatus);
+
+        // verify
+        final List<ServerErrorEntry> entries = capture.snapshot();
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0).loggerName()).isEqualTo("log4j.StatusLogger");
+        assertThat(entries.get(0).severity()).isEqualTo(AgentServerErrorCapture.SEVERITY_WARNING);
+        assertThat(entries.get(0).message()).contains("status-test-warning");
+        assertThat(entries.get(1).severity()).isEqualTo(AgentServerErrorCapture.SEVERITY_ERROR);
+        assertThat(entries.get(1).message()).contains("status-test-error");
+        assertThat(entries.get(1).throwableClass()).isEqualTo(IllegalStateException.class.getName());
+        assertThat(entries.get(1).throwableMessage()).isEqualTo("status-boom");
+        assertThat(entries.get(1).stackTrace()).isNotEmpty();
+    }
+
+    @Test
+    void statusListener_shouldIgnoreBelowWarnStatusData()
+    {
+        // setup
+        capture.install();
+        final StatusListener listener = registeredStatusListener();
+        final StatusData infoStatus = new StatusData(
+            null, Level.INFO, new SimpleMessage("status-test-info"), null, "status-thread");
+
+        // execute
+        listener.log(infoStatus);
+
+        // verify
+        assertThat(capture.snapshot()).isEmpty();
+    }
+
+    @Test
+    void statusListener_shouldIgnoreNullLevelStatusData()
+    {
+        // setup
+        capture.install();
+        final StatusListener listener = registeredStatusListener();
+        final StatusData nullLevelStatus = mock(StatusData.class);
+        when(nullLevelStatus.getLevel()).thenReturn(null);
+
+        // execute
+        listener.log(nullLevelStatus);
+
+        // verify
+        assertThat(capture.snapshot()).isEmpty();
+    }
+
+    @Test
+    void statusListener_shouldSwallowExceptionAndCountDroppedWhenCaptureFails()
+    {
+        // setup
+        capture.install();
+        final StatusListener listener = registeredStatusListener();
+        final StatusData brokenStatus = mock(StatusData.class);
+        when(brokenStatus.getLevel()).thenReturn(Level.ERROR);
+        when(brokenStatus.getFormattedStatus()).thenThrow(new RuntimeException("status-capture-boom"));
+
+        // execute
+        listener.log(brokenStatus);
+
+        // verify
+        assertThat(capture.snapshot()).isEmpty();
+        assertThat(capture.droppedCount()).isEqualTo(1L);
+    }
+
+    private static Appender capturedAppender()
+    {
+        final org.apache.logging.log4j.core.Logger coreLogger =
+            (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
+        return Objects.requireNonNull(
+            coreLogger.getAppenders().get("LightKeeperServerErrorCapture"), "appender");
+    }
+
+    private static StatusListener registeredStatusListener()
+    {
+        final Iterator<StatusListener> iterator = StatusLogger.getLogger().getListeners().iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        final StatusListener listener = iterator.next();
+        assertThat(iterator.hasNext()).isFalse();
+        return listener;
     }
 }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCaptureTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentServerErrorCaptureTest.java
@@ -1,0 +1,203 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises {@link AgentServerErrorCapture} against the real Log4j runtime available on the test classpath:
+ * {@code install()} attaches to the actual root logger, so logging through Log4j verifies the full capture path.
+ */
+class AgentServerErrorCaptureTest
+{
+    private AgentServerErrorCapture capture;
+
+    @BeforeEach
+    void setUp()
+    {
+        capture = new AgentServerErrorCapture(Logger.getLogger(AgentServerErrorCaptureTest.class.getName()));
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        capture.uninstall();
+    }
+
+    @Test
+    void install_shouldActivateCaptureAndBeIdempotent()
+    {
+        // execute
+        final boolean firstInstall = capture.install();
+        final boolean secondInstall = capture.install();
+
+        // verify
+        assertThat(firstInstall).isTrue();
+        assertThat(secondInstall).isTrue();
+        assertThat(capture.active()).isTrue();
+    }
+
+    @Test
+    void uninstall_shouldDeactivateCaptureAndBeSafeWithoutInstall()
+    {
+        // setup
+        capture.install();
+
+        // execute
+        capture.uninstall();
+        capture.uninstall();
+
+        // verify
+        assertThat(capture.active()).isFalse();
+    }
+
+    @Test
+    void snapshot_shouldContainErrorLoggedThroughLog4jWithThrowableMetadata()
+    {
+        // setup
+        capture.install();
+        final IllegalStateException thrown = new IllegalStateException("capture-test-boom");
+
+        // execute
+        LogManager.getLogger("lightkeeper.capture.test").error("capture-test-message", thrown);
+
+        // verify
+        final List<ServerErrorEntry> entries = capture.snapshot().stream()
+            .filter(entry -> "capture-test-message".equals(entry.message()))
+            .toList();
+        assertThat(entries).hasSize(1);
+        final ServerErrorEntry entry = entries.getFirst();
+        assertThat(entry.severity()).isEqualTo(AgentServerErrorCapture.SEVERITY_ERROR);
+        assertThat(entry.levelName()).isEqualTo("ERROR");
+        assertThat(entry.loggerName()).isEqualTo("lightkeeper.capture.test");
+        assertThat(entry.threadName()).isNotBlank();
+        assertThat(entry.timestampMillis()).isPositive();
+        assertThat(entry.throwableClass()).isEqualTo(IllegalStateException.class.getName());
+        assertThat(entry.throwableMessage()).isEqualTo("capture-test-boom");
+        assertThat(entry.stackTrace())
+            .isNotEmpty()
+            .first().asString().contains("capture-test-boom");
+    }
+
+    @Test
+    void snapshot_shouldBucketWarnAsWarningAndIgnoreInfo()
+    {
+        // setup
+        capture.install();
+
+        // execute
+        LogManager.getLogger("lightkeeper.capture.test").warn("capture-test-warning");
+        LogManager.getLogger("lightkeeper.capture.test").info("capture-test-info");
+
+        // verify
+        final List<ServerErrorEntry> entries = capture.snapshot();
+        assertThat(entries)
+            .anySatisfy(entry ->
+            {
+                assertThat(entry.message()).isEqualTo("capture-test-warning");
+                assertThat(entry.severity()).isEqualTo(AgentServerErrorCapture.SEVERITY_WARNING);
+                assertThat(entry.throwableClass()).isNull();
+                assertThat(entry.stackTrace()).isEmpty();
+            })
+            .noneSatisfy(entry -> assertThat(entry.message()).isEqualTo("capture-test-info"));
+    }
+
+    @Test
+    void snapshot_shouldRenderCauseChainInStackTrace()
+    {
+        // setup
+        capture.install();
+        final RuntimeException thrown =
+            new RuntimeException("outer", new IllegalArgumentException("inner-cause"));
+
+        // execute
+        LogManager.getLogger("lightkeeper.capture.test").error("capture-test-chained", thrown);
+
+        // verify
+        final ServerErrorEntry entry = capture.snapshot().stream()
+            .filter(candidate -> "capture-test-chained".equals(candidate.message()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(entry.stackTrace())
+            .anySatisfy(line -> assertThat(line).contains("Caused by:").contains("inner-cause"));
+    }
+
+    @Test
+    void clear_shouldDiscardEntriesAndResetDroppedCount()
+    {
+        // setup
+        capture.install();
+        LogManager.getLogger("lightkeeper.capture.test").error("capture-test-to-clear");
+
+        // execute
+        capture.clear();
+
+        // verify
+        assertThat(capture.snapshot())
+            .noneSatisfy(entry -> assertThat(entry.message()).isEqualTo("capture-test-to-clear"));
+        assertThat(capture.droppedCount()).isZero();
+    }
+
+    @Test
+    void offer_shouldDropNewEntriesAndCountThemWhenBufferIsFull()
+    {
+        // setup
+        capture.install();
+        final org.apache.logging.log4j.Logger logger = LogManager.getLogger("lightkeeper.capture.test");
+        capture.clear();
+
+        // execute
+        for (int i = 0; i < AgentServerErrorCapture.MAX_CAPTURED_ERRORS + 5; i++)
+            logger.error("capture-test-storm-" + i);
+
+        // verify — the buffer keeps the oldest (root-cause) entries and counts the dropped tail
+        assertThat(capture.snapshot()).hasSize(AgentServerErrorCapture.MAX_CAPTURED_ERRORS);
+        assertThat(capture.droppedCount()).isEqualTo(5L);
+        assertThat(capture.snapshot().getFirst().message()).isEqualTo("capture-test-storm-0");
+    }
+
+    @Test
+    void snapshot_shouldTruncateOverlongStackTraces()
+    {
+        // setup
+        capture.install();
+        final RuntimeException thrown = new RuntimeException("deep");
+        thrown.setStackTrace(java.util.stream.IntStream.range(0, AgentServerErrorCapture.MAX_STACK_TRACE_LINES + 50)
+            .mapToObj(i -> new StackTraceElement("Class" + i, "method", "File.java", i))
+            .toArray(StackTraceElement[]::new));
+
+        // execute
+        LogManager.getLogger("lightkeeper.capture.test").error("capture-test-deep", thrown);
+
+        // verify
+        final ServerErrorEntry entry = capture.snapshot().stream()
+            .filter(candidate -> "capture-test-deep".equals(candidate.message()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(entry.stackTrace()).hasSize(AgentServerErrorCapture.MAX_STACK_TRACE_LINES + 1);
+        assertThat(entry.stackTrace().getLast()).contains("truncated");
+    }
+
+    @Test
+    void snapshot_shouldNotContainEventsLoggedAfterUninstall()
+    {
+        // setup
+        capture.install();
+        capture.uninstall();
+
+        // execute
+        LogManager.getLogger("lightkeeper.capture.test").error("capture-test-after-uninstall");
+
+        // verify
+        assertThat(capture.snapshot())
+            .noneSatisfy(entry -> assertThat(entry.message()).isEqualTo("capture-test-after-uninstall"));
+    }
+}

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPluginTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPluginTest.java
@@ -137,6 +137,27 @@ class SpigotLightkeeperAgentPluginTest
     }
 
     @Test
+    void onDisable_shouldUninstallServerErrorCaptureWhenPresent()
+        throws Exception
+    {
+        // setup
+        final SpigotLightkeeperAgentPlugin plugin = allocatePlugin();
+        final AgentServerErrorCapture serverErrorCapture = mock(AgentServerErrorCapture.class);
+        final Path socketPath = Files.createTempFile("lk-agent-test", ".sock");
+
+        setField(plugin, "requestExecutor", mock(ExecutorService.class));
+        setField(plugin, "acceptExecutor", mock(ExecutorService.class));
+        setField(plugin, "socketPath", socketPath);
+        setField(plugin, "serverErrorCapture", serverErrorCapture);
+
+        // execute
+        plugin.onDisable();
+
+        // verify
+        verify(serverErrorCapture).uninstall();
+    }
+
+    @Test
     void validateNmsCompatibility_shouldThrowExceptionWhenServerPackageIsUnexpected()
         throws Exception
     {

--- a/lightkeeper-agent-spigot/src/test/resources/log4j2-test.xml
+++ b/lightkeeper-agent-spigot/src/test/resources/log4j2-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Mirrors the Minecraft server's root logger level (INFO) so AgentServerErrorCaptureTest exercises WARN-level
+    capture through the real Log4j pipeline; events are sunk into a Null appender to keep test output clean.
+-->
+<Configuration status="ERROR">
+    <Appenders>
+        <Null name="DevNull"/>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="DevNull"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/FrameworkHandleFactory.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/FrameworkHandleFactory.java
@@ -44,4 +44,12 @@ public final class FrameworkHandleFactory
     {
         return new EventCaptureHandle(frameworkGateway, eventClassName);
     }
+
+    /**
+     * Creates a server errors handle.
+     */
+    public static ServerErrorsHandle serverErrorsHandle(IFrameworkGatewayView frameworkGateway)
+    {
+        return new ServerErrorsHandle(frameworkGateway);
+    }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -135,4 +135,14 @@ public interface IFrameworkGatewayView
      * Unregisters an event listener.
      */
     void unregisterEventListener(String eventClassName);
+
+    /**
+     * Gets all captured server errors: structured log events plus raw stderr stack-trace detections.
+     */
+    List<ServerErrorSnapshot> capturedServerErrors();
+
+    /**
+     * Clears all captured server errors and advances the raw stderr scan window.
+     */
+    void clearServerErrors();
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
@@ -138,6 +138,23 @@ public interface ILightkeeperFramework extends AutoCloseable
      */
     EventCaptureHandle captureEvents(String eventClassName);
 
+    /**
+     * Gets a handle over the always-on server-error capture.
+     *
+     * <p>The agent captures every WARN-or-worse log event inside the server as a structured snapshot — with the
+     * real throwable class, message, and cause chain — from the moment the agent plugin loads (before any
+     * plugin's {@code onEnable}). Failures inside the logging system itself (reported via Log4j's status
+     * logger) and stack traces written to the server process's raw stderr file descriptor are captured as well.
+     *
+     * <p>In shared-server mode the capture buffer is cleared automatically at the end of every test method, so
+     * each test observes only the errors of its own window; the first test's window also covers server boot.
+     * Known gaps: exceptions that are caught and never logged are invisible, as are log events emitted before
+     * the agent plugin loads (use {@link #serverOutput()} for pre-boot inspection).
+     *
+     * @return A handle exposing the captured server errors.
+     */
+    ServerErrorsHandle serverErrors();
+
     @Override
     void close();
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshot.java
@@ -1,0 +1,86 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Snapshot of a single captured server error or warning.
+ *
+ * <p>Entries originate from two complementary sources:
+ * <ul>
+ *     <li><strong>Structured log events</strong> — captured inside the server by the agent's Log4j appender,
+ *     carrying the real throwable class, message, and rendered cause chain of the original log event.</li>
+ *     <li><strong>Raw stderr output</strong> — stack traces written to the server process's raw stderr file
+ *     descriptor, bypassing the logging system entirely (for example Log4j's own status logger or JVM-native
+ *     output). These entries use {@code "STDERR"} as {@link #levelName()} and
+ *     {@link #LOGGER_NAME_STDERR} as {@link #loggerName()}.</li>
+ * </ul>
+ *
+ * @param timestampMillis
+ *     Epoch milliseconds at which the event was created (structured events) or captured (raw stderr output).
+ * @param severity
+ *     Severity bucket; only {@link Severity#ERROR} entries fail
+ *     {@code LightkeeperAssertions.assertThat(framework).hasNoServerErrors()}.
+ * @param levelName
+ *     Original log level name (e.g. {@code "ERROR"}, {@code "WARN"}), or {@code "STDERR"} for raw stderr output.
+ * @param loggerName
+ *     Name of the logger that emitted the event, or {@link #LOGGER_NAME_STDERR} for raw stderr output.
+ * @param threadName
+ *     Name of the emitting thread; empty when unknown.
+ * @param message
+ *     Formatted log message; for raw stderr output, the first line of the detected stack trace.
+ * @param throwableClass
+ *     Fully-qualified class name of the attached or detected throwable, or {@code null} when absent.
+ * @param throwableMessage
+ *     Message of the attached or detected throwable, or {@code null} when absent.
+ * @param stackTrace
+ *     Rendered stack trace lines including the cause chain (possibly truncated); empty when no throwable was
+ *     attached.
+ */
+public record ServerErrorSnapshot(
+    long timestampMillis,
+    Severity severity,
+    String levelName,
+    String loggerName,
+    String threadName,
+    String message,
+    @Nullable String throwableClass,
+    @Nullable String throwableMessage,
+    List<String> stackTrace
+)
+{
+    /**
+     * {@link #loggerName()} used for entries detected in the server process's raw stderr output.
+     */
+    public static final String LOGGER_NAME_STDERR = "process.stderr";
+
+    /**
+     * Severity bucket of a captured entry.
+     */
+    public enum Severity
+    {
+        /**
+         * Warning-level entry; buffered for diagnostics but does not fail {@code hasNoServerErrors()}.
+         */
+        WARNING,
+        /**
+         * Error-or-worse entry; fails {@code hasNoServerErrors()} unless allowlisted.
+         */
+        ERROR
+    }
+
+    /**
+     * Validates required fields and defensively copies the stack trace.
+     */
+    public ServerErrorSnapshot
+    {
+        Objects.requireNonNull(severity, "severity may not be null.");
+        Objects.requireNonNull(levelName, "levelName may not be null.");
+        Objects.requireNonNull(loggerName, "loggerName may not be null.");
+        Objects.requireNonNull(threadName, "threadName may not be null.");
+        Objects.requireNonNull(message, "message may not be null.");
+        stackTrace = stackTrace == null ? List.of() : List.copyOf(stackTrace);
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ServerErrorsHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ServerErrorsHandle.java
@@ -1,0 +1,44 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Handle for the always-on server-error capture.
+ *
+ * <p>Unlike {@link EventCaptureHandle} there is nothing to register or close: capture starts when the agent
+ * plugin loads and stays active for the server's lifetime. This handle is a view over that capture buffer.
+ *
+ * <p>In shared-server mode the extension clears the buffer at the <em>end</em> of every test method, so each
+ * test observes the errors of its own window (the first test's window also covers server boot).
+ */
+public final class ServerErrorsHandle
+{
+    private final IFrameworkGatewayView frameworkGateway;
+
+    ServerErrorsHandle(IFrameworkGatewayView frameworkGateway)
+    {
+        this.frameworkGateway = Objects.requireNonNull(frameworkGateway, "frameworkGateway");
+    }
+
+    /**
+     * Gets all server errors and warnings captured since server boot or the last clear.
+     *
+     * @return List of captured server error snapshots, structured log events first, then raw stderr detections.
+     */
+    public List<ServerErrorSnapshot> getCaptured()
+    {
+        return frameworkGateway.capturedServerErrors();
+    }
+
+    /**
+     * Clears all captured server errors.
+     *
+     * @return This handle for fluent chaining.
+     */
+    public ServerErrorsHandle clear()
+    {
+        frameworkGateway.clearServerErrors();
+        return this;
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperFrameworkAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperFrameworkAssert.java
@@ -2,13 +2,15 @@ package nl.pim16aap2.lightkeeper.framework.assertions;
 
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.Platform;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
-import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Assertions for framework-level runtime state.
@@ -58,32 +60,80 @@ public final class LightkeeperFrameworkAssert
     }
 
     /**
-     * Asserts that captured server output does not contain common error or exception markers.
+     * Asserts that no error-severity server errors were captured.
+     *
+     * <p>Backed by structured capture (see {@link ILightkeeperFramework#serverErrors()}): entries are matched
+     * on their captured severity, not on console-line substrings, so a log message merely containing the word
+     * "exception" no longer trips this assertion. Warnings are never counted.
      *
      * @return This assertion for fluent chaining.
      */
     public LightkeeperFrameworkAssert hasNoServerErrors()
     {
-        final List<String> errorLines = nonNullActual().serverOutput().stream()
-            .filter(LightkeeperFrameworkAssert::isServerErrorLine)
+        return hasNoServerErrors(error -> false);
+    }
+
+    /**
+     * Asserts that no error-severity server errors were captured, ignoring entries matched by the allowlist.
+     *
+     * <p>Use the allowlist for known-benign errors, matching on structured fields rather than console text:
+     * <pre>{@code
+     * assertThat(framework).hasNoServerErrors(error ->
+     *     error.loggerName().equals("net.minecraft.server")
+     *         && error.message().contains("moving_piston"));
+     * }</pre>
+     *
+     * @param allowedErrors
+     *     Predicate matching captured errors that should not fail this assertion.
+     * @return This assertion for fluent chaining.
+     */
+    public LightkeeperFrameworkAssert hasNoServerErrors(Predicate<ServerErrorSnapshot> allowedErrors)
+    {
+        Objects.requireNonNull(allowedErrors, "allowedErrors may not be null.");
+        final List<ServerErrorSnapshot> failingErrors = nonNullActual().serverErrors().getCaptured().stream()
+            .filter(error -> error.severity() == ServerErrorSnapshot.Severity.ERROR)
+            .filter(error -> !allowedErrors.test(error))
             .toList();
-        if (!errorLines.isEmpty())
+        if (!failingErrors.isEmpty())
         {
             failWithMessage(
-                "Expected server output to contain no error lines, but found:%n%s",
-                String.join(System.lineSeparator(), errorLines)
+                "Expected no captured server errors, but found %d:%n%s",
+                failingErrors.size(),
+                renderServerErrors(failingErrors)
             );
         }
         return this;
     }
 
-    private static boolean isServerErrorLine(String line)
+    /**
+     * Renders captured errors for assertion failure messages: one header line per error plus an indented,
+     * capped stack trace so the failure carries its own diagnostic context.
+     */
+    private static String renderServerErrors(List<ServerErrorSnapshot> errors)
     {
-        final String normalized = line.toLowerCase(Locale.ROOT);
-        return normalized.contains("severe")
-            || normalized.contains("[error]")
-            || normalized.contains("exception")
-            || normalized.contains("caused by:");
+        final int maxRenderedStackTraceLines = 15;
+        final StringBuilder rendered = new StringBuilder(256);
+        for (final ServerErrorSnapshot error : errors)
+        {
+            rendered
+                .append("[%s] %s (thread: %s): %s".formatted(
+                    error.levelName(),
+                    error.loggerName(),
+                    error.threadName().isEmpty() ? "?" : error.threadName(),
+                    error.message()))
+                .append(System.lineSeparator());
+
+            final List<String> stackTrace = error.stackTrace();
+            stackTrace.stream()
+                .limit(maxRenderedStackTraceLines)
+                .forEach(line -> rendered.append("    ").append(line).append(System.lineSeparator()));
+            if (stackTrace.size() > maxRenderedStackTraceLines)
+                rendered
+                    .append("    ... (%d more stack trace lines)"
+                        .formatted(stackTrace.size() - maxRenderedStackTraceLines))
+                    .append(System.lineSeparator());
+        }
+        return rendered.toString();
     }
 
     @SuppressWarnings({"NullAway", "DataFlowIssue"}) // we call isNotNull() first, so actual is not null after that

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -85,6 +85,9 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
      * @param runtimeManifestPath
      *     Path to runtime manifest.
      * @return Started framework.
+      * <p>
+     * Fails loudly (rather than silently degrading to the stderr net alone) when the agent-side capture
+     * never attached: a disabled safety net must fail the tests that rely on it, not weaken them.
      */
     public static DefaultLightkeeperFramework start(Path runtimeManifestPath)
     {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -13,10 +13,14 @@ import nl.pim16aap2.lightkeeper.framework.InventorySnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
+import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifestReader;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifestValidator;
@@ -27,10 +31,12 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Default LightKeeper framework implementation.
@@ -53,6 +59,11 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     private final PlayerScopeRegistry playerScopeRegistry;
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicBoolean serverCrashed = new AtomicBoolean(false);
+    /**
+     * Total-line-count watermark delimiting the raw stderr scan window; advanced on every
+     * {@link #clearServerErrors()}.
+     */
+    private final AtomicLong stderrScanWatermark = new AtomicLong(0L);
 
     @Inject
     DefaultLightkeeperFramework(
@@ -465,6 +476,62 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
+    public ServerErrorsHandle serverErrors()
+    {
+        ensureOpen();
+        return FrameworkHandleFactory.serverErrorsHandle(this);
+    }
+
+    @Override
+    public List<ServerErrorSnapshot> capturedServerErrors()
+    {
+        ensureOpen();
+        final GetServerErrors.Response response = agentClient.getServerErrors();
+        if (!response.captureActive())
+            throw new IllegalStateException(
+                "Structured server-error capture is inactive: the agent could not attach its log appender. "
+                    + "Captured server errors are unavailable on this server.");
+        if (response.droppedCount() > 0L)
+            LOG.log(
+                System.Logger.Level.WARNING,
+                () -> "LK_FRAMEWORK: Server-error capture dropped %d entries because its buffer was full."
+                    .formatted(response.droppedCount())
+            );
+
+        final List<ServerErrorSnapshot> snapshots = new ArrayList<>(response.errors().size());
+        for (final ServerErrorEntry entry : response.errors())
+            snapshots.add(toServerErrorSnapshot(entry));
+        snapshots.addAll(ServerStderrErrorScanner.scan(
+            minecraftServerProcess.snapshotStderrLinesFrom(stderrScanWatermark.get())));
+        return List.copyOf(snapshots);
+    }
+
+    @Override
+    public void clearServerErrors()
+    {
+        ensureOpen();
+        agentClient.clearServerErrors();
+        stderrScanWatermark.set(minecraftServerProcess.totalOutputLineCount());
+    }
+
+    private static ServerErrorSnapshot toServerErrorSnapshot(ServerErrorEntry entry)
+    {
+        return new ServerErrorSnapshot(
+            entry.timestampMillis(),
+            "ERROR".equals(entry.severity())
+                ? ServerErrorSnapshot.Severity.ERROR
+                : ServerErrorSnapshot.Severity.WARNING,
+            entry.levelName(),
+            entry.loggerName(),
+            entry.threadName(),
+            entry.message(),
+            entry.throwableClass(),
+            entry.throwableMessage(),
+            entry.stackTrace()
+        );
+    }
+
+    @Override
     public Platform platform()
     {
         ensureOpen();
@@ -558,6 +625,11 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     {
         ensureOpen();
         playerScopeRegistry.endMethodScope(methodExecutionId, agentClient::removePlayer);
+        // Clear captured server errors at the END of each method (not the start): boot-window errors stay
+        // visible to the first test's assertions, and every later test only observes its own window. Skipped
+        // after a crash, when the agent connection is gone.
+        if (!serverCrashed.get())
+            clearServerErrors();
     }
 
     private void preloadConfiguredWorlds()

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -510,8 +510,11 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     public void clearServerErrors()
     {
         ensureOpen();
+        // Snapshot the watermark before the RPC: stderr lines written during the round trip must
+        // stay above the watermark so they still surface in later capturedServerErrors() calls.
+        final long watermark = minecraftServerProcess.totalOutputLineCount();
         agentClient.clearServerErrors();
-        stderrScanWatermark.set(minecraftServerProcess.totalOutputLineCount());
+        stderrScanWatermark.set(watermark);
     }
 
     private static ServerErrorSnapshot toServerErrorSnapshot(ServerErrorEntry entry)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
@@ -8,6 +8,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -53,11 +55,31 @@ final class MinecraftServerProcess
     private final Path diagnosticsDirectory;
     private final Object outputLinesLock = new Object();
     @GuardedBy("outputLinesLock")
-    private final ArrayDeque<String> outputLines = new ArrayDeque<>(MAX_CAPTURED_OUTPUT_LINES);
+    private final ArrayDeque<OutputLine> outputLines = new ArrayDeque<>(MAX_CAPTURED_OUTPUT_LINES);
     @GuardedBy("outputLinesLock")
     private long discardedOutputLineCount = 0L;
     private @Nullable Process process;
     private @Nullable Thread outputThread;
+    private @Nullable Thread errorThread;
+
+    /**
+     * A single captured server output line with its file-descriptor provenance.
+     *
+     * <p>The stdout pipe carries the server's console appender output (formatted log lines). The stderr pipe
+     * carries only writers that bypass the logging system — the server redirects {@code System.err} into Log4j
+     * during startup, so post-boot stderr content is limited to raw file-descriptor writers such as Log4j's
+     * status logger or JVM-native output. That makes stderr provenance a reliable "bypassed logging" signal.
+     *
+     * @param text
+     *     The captured line.
+     * @param fromStderr
+     *     Whether the line arrived on the process's stderr pipe rather than stdout.
+     * @param timestampMillis
+     *     Epoch milliseconds at which the line was captured.
+     */
+    record OutputLine(String text, boolean fromStderr, long timestampMillis)
+    {
+    }
 
     MinecraftServerProcess(RuntimeManifest runtimeManifest, Path diagnosticsDirectory)
     {
@@ -72,7 +94,7 @@ final class MinecraftServerProcess
             throw new IllegalStateException("Minecraft server is already running.");
 
         clearStoppedProcessState();
-        if (outputThread != null && outputThread.isAlive())
+        if ((outputThread != null && outputThread.isAlive()) || (errorThread != null && errorThread.isAlive()))
             throw new IllegalStateException("Previous Minecraft server output reader is still stopping.");
         waitForWorldSessionLockRelease(SESSION_LOCK_RELEASE_TIMEOUT);
 
@@ -84,9 +106,12 @@ final class MinecraftServerProcess
         {
             final Process startedProcess = processBuilder.start();
             final Thread startedOutputThread = createOutputReaderThread(startedProcess, startLatch);
+            final Thread startedErrorThread = createErrorReaderThread(startedProcess);
             process = startedProcess;
             outputThread = startedOutputThread;
+            errorThread = startedErrorThread;
             startedOutputThread.start();
+            startedErrorThread.start();
             awaitStartupOrFail(startedProcess, startLatch, timeout);
         }
         catch (Exception exception)
@@ -147,7 +172,8 @@ final class MinecraftServerProcess
         command.add("--nogui");
         final ProcessBuilder processBuilder = new ProcessBuilder(command);
         processBuilder.directory(serverDirectory.toFile());
-        processBuilder.redirectErrorStream(true);
+        // stdout and stderr are read through separate pipes so each captured line keeps its file-descriptor
+        // provenance; stderr content bypassed the server's logging system by definition (see OutputLine).
         return processBuilder;
     }
 
@@ -272,19 +298,24 @@ final class MinecraftServerProcess
 
     private void joinOutputThread(Duration timeout)
     {
-        if (outputThread != null)
+        outputThread = joinReaderThread(outputThread, timeout);
+        errorThread = joinReaderThread(errorThread, timeout);
+    }
+
+    private static @Nullable Thread joinReaderThread(@Nullable Thread readerThread, Duration timeout)
+    {
+        if (readerThread == null)
+            return null;
+
+        try
         {
-            try
-            {
-                outputThread.join(timeout.toMillis());
-            }
-            catch (InterruptedException exception)
-            {
-                Thread.currentThread().interrupt();
-            }
-            if (!outputThread.isAlive())
-                outputThread = null;
+            readerThread.join(timeout.toMillis());
         }
+        catch (InterruptedException exception)
+        {
+            Thread.currentThread().interrupt();
+        }
+        return readerThread.isAlive() ? readerThread : null;
     }
 
     private void clearProcessState(Process completedProcess)
@@ -293,6 +324,8 @@ final class MinecraftServerProcess
             process = null;
         if (outputThread != null && !outputThread.isAlive())
             outputThread = null;
+        if (errorThread != null && !errorThread.isAlive())
+            errorThread = null;
     }
 
     private void clearStoppedProcessState()
@@ -443,20 +476,58 @@ final class MinecraftServerProcess
     {
         synchronized (outputLinesLock)
         {
-            if (discardedOutputLineCount == 0L)
-                return List.copyOf(outputLines);
-
             final List<String> snapshot = new ArrayList<>(outputLines.size() + 1);
-            snapshot.add(
-                "[lightkeeper] Discarded %d older server log lines before this captured tail."
-                    .formatted(discardedOutputLineCount)
-            );
-            snapshot.addAll(outputLines);
+            if (discardedOutputLineCount > 0L)
+                snapshot.add(
+                    "[lightkeeper] Discarded %d older server log lines before this captured tail."
+                        .formatted(discardedOutputLineCount)
+                );
+            for (final OutputLine outputLine : outputLines)
+                snapshot.add(outputLine.text());
             return List.copyOf(snapshot);
         }
     }
 
-    private void appendOutputLine(String line)
+    /**
+     * Returns the total number of lines ever captured, including lines already discarded from the bounded
+     * buffer. Stable across evictions, so it can serve as a watermark for windowed scans.
+     *
+     * @return
+     *     Total captured line count since process start.
+     */
+    long totalOutputLineCount()
+    {
+        synchronized (outputLinesLock)
+        {
+            return discardedOutputLineCount + outputLines.size();
+        }
+    }
+
+    /**
+     * Returns the still-buffered stderr lines whose total line index is at or past the given watermark.
+     *
+     * @param fromTotalLineIndex
+     *     Watermark obtained from an earlier {@link #totalOutputLineCount()} call.
+     * @return
+     *     Captured stderr lines in arrival order.
+     */
+    List<OutputLine> snapshotStderrLinesFrom(long fromTotalLineIndex)
+    {
+        synchronized (outputLinesLock)
+        {
+            final List<OutputLine> stderrLines = new ArrayList<>();
+            long totalLineIndex = discardedOutputLineCount;
+            for (final OutputLine outputLine : outputLines)
+            {
+                if (totalLineIndex >= fromTotalLineIndex && outputLine.fromStderr())
+                    stderrLines.add(outputLine);
+                totalLineIndex++;
+            }
+            return List.copyOf(stderrLines);
+        }
+    }
+
+    private void appendOutputLine(String line, boolean fromStderr)
     {
         synchronized (outputLinesLock)
         {
@@ -465,36 +536,63 @@ final class MinecraftServerProcess
                 outputLines.removeFirst();
                 discardedOutputLineCount++;
             }
-            outputLines.addLast(line);
+            outputLines.addLast(new OutputLine(line, fromStderr, System.currentTimeMillis()));
         }
     }
 
     private Thread createOutputReaderThread(Process process, CountDownLatch startLatch)
     {
+        return createReaderThread(
+            "lightkeeper-minecraft-output-reader",
+            process.getInputStream(),
+            false,
+            line ->
+            {
+                if (line.contains("Done (") && line.endsWith(")! For help, type \"help\""))
+                    startLatch.countDown();
+            }
+        );
+    }
+
+    private Thread createErrorReaderThread(Process process)
+    {
+        return createReaderThread(
+            "lightkeeper-minecraft-stderr-reader",
+            process.getErrorStream(),
+            true,
+            line ->
+            {
+            }
+        );
+    }
+
+    private Thread createReaderThread(
+        String threadName,
+        InputStream stream,
+        boolean fromStderr,
+        Consumer<String> lineObserver)
+    {
         return Thread.ofPlatform()
-            .name("lightkeeper-minecraft-output-reader")
+            .name(threadName)
             .daemon(true)
             .unstarted(() ->
             {
                 try (
                     BufferedReader reader =
-                        new BufferedReader(
-                            new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8)))
+                        new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
                 {
                     String line;
                     while ((line = reader.readLine()) != null)
                     {
-                        appendOutputLine(line);
-
-                        if (line.contains("Done (") && line.endsWith(")! For help, type \"help\""))
-                            startLatch.countDown();
+                        appendOutputLine(line, fromStderr);
+                        lineObserver.accept(line);
                     }
                 }
                 catch (IOException exception)
                 {
                     LOG.log(
                         System.Logger.Level.TRACE,
-                        () -> "Minecraft output reader stopped: " + exception.getMessage()
+                        () -> "Minecraft reader '" + threadName + "' stopped: " + exception.getMessage()
                     );
                 }
             });

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
@@ -315,13 +315,18 @@ final class MinecraftServerProcess
         if (readerThread == null)
             return null;
 
-        try
+        // An exhausted budget must skip the join entirely: Thread.join(0) waits forever, which would
+        // turn a stuck first reader into an unbounded hang on the second.
+        if (!timeout.isZero() && !timeout.isNegative())
         {
-            readerThread.join(timeout.toMillis());
-        }
-        catch (InterruptedException exception)
-        {
-            Thread.currentThread().interrupt();
+            try
+            {
+                readerThread.join(timeout.toMillis());
+            }
+            catch (InterruptedException exception)
+            {
+                Thread.currentThread().interrupt();
+            }
         }
         return readerThread.isAlive() ? readerThread : null;
     }
@@ -518,6 +523,9 @@ final class MinecraftServerProcess
      *     Watermark obtained from an earlier {@link #totalOutputLineCount()} call.
      * @return
      *     Captured stderr lines in arrival order.
+      * <p>
+     * The scan window rides the bounded output buffer: under extreme stdout flooding, stderr lines older
+     * than the retained window can be evicted before they are scanned.
      */
     List<OutputLine> snapshotStderrLinesFrom(long fromTotalLineIndex)
     {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
@@ -298,8 +298,16 @@ final class MinecraftServerProcess
 
     private void joinOutputThread(Duration timeout)
     {
-        outputThread = joinReaderThread(outputThread, timeout);
-        errorThread = joinReaderThread(errorThread, timeout);
+        // Both reader threads share one budget so a stuck reader cannot double the worst-case wait.
+        final Instant deadline = Instant.now().plus(timeout);
+        outputThread = joinReaderThread(outputThread, remainingUntil(deadline));
+        errorThread = joinReaderThread(errorThread, remainingUntil(deadline));
+    }
+
+    private static Duration remainingUntil(Instant deadline)
+    {
+        final Duration remaining = Duration.between(Instant.now(), deadline);
+        return remaining.isNegative() ? Duration.ZERO : remaining;
     }
 
     private static @Nullable Thread joinReaderThread(@Nullable Thread readerThread, Duration timeout)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerStderrErrorScanner.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerStderrErrorScanner.java
@@ -1,0 +1,150 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects stack traces in the server process's raw stderr output and groups them into
+ * {@link ServerErrorSnapshot}s.
+ *
+ * <p>The server redirects {@code System.err} into its logging system during startup, so stderr-pipe content is
+ * limited to writers that bypass logging entirely (Log4j's status logger, JVM-native output, streams cached
+ * before the redirect). Such output is invisible to the agent's structured capture; this scanner is the
+ * complementary net. Only exception-shaped blocks become snapshots — benign stderr noise such as JVM warnings
+ * is ignored.
+ *
+ * <p>Grouping is line-based and best-effort: a block starts at a throwable header line (e.g.
+ * {@code java.util.concurrent.TimeoutException} or {@code Exception in thread "main" java.lang...}) and extends
+ * over its {@code at ...}/{@code Caused by: ...} continuation lines. Continuation lines without a preceding
+ * header (a window that begins mid-trace) are ignored.
+ */
+final class ServerStderrErrorScanner
+{
+    /**
+     * Level name used for snapshots produced by this scanner.
+     */
+    static final String LEVEL_NAME_STDERR = "STDERR";
+    /**
+     * Maximum number of continuation lines retained per detected block.
+     */
+    static final int MAX_BLOCK_LINES = 100;
+
+    /**
+     * Matches the header line of a rendered throwable: an optional {@code Exception in thread "..."} prefix,
+     * a fully-qualified class name whose simple name ends in {@code Exception}, {@code Error}, or
+     * {@code Throwable}, and an optional {@code : message} tail.
+     */
+    private static final Pattern THROWABLE_HEADER = Pattern.compile(
+        "^(?:Exception in thread \"[^\"]*\" )?((?:[\\w$]+\\.)+[\\w$]*(?:Exception|Error|Throwable))(?::\\s?(.*))?$"
+    );
+
+    /**
+     * Matches continuation lines of a rendered throwable: stack frames, cause/suppressed headers, and frame
+     * elision markers.
+     */
+    private static final Pattern THROWABLE_CONTINUATION = Pattern.compile(
+        "^(?:\\s+at\\s.+|Caused by:\\s.+|\\s+Suppressed:\\s.+|\\s*\\.\\.\\. \\d+ more)$"
+    );
+
+    private ServerStderrErrorScanner()
+    {
+    }
+
+    /**
+     * Scans captured stderr lines for rendered stack traces.
+     *
+     * @param stderrLines
+     *     Captured stderr lines in arrival order.
+     * @return
+     *     One snapshot per detected stack-trace block, in arrival order.
+     */
+    static List<ServerErrorSnapshot> scan(List<MinecraftServerProcess.OutputLine> stderrLines)
+    {
+        final List<ServerErrorSnapshot> snapshots = new ArrayList<>();
+        @Nullable BlockBuilder currentBlock = null;
+
+        for (final MinecraftServerProcess.OutputLine line : stderrLines)
+        {
+            final Matcher headerMatcher = THROWABLE_HEADER.matcher(line.text());
+            if (headerMatcher.matches())
+            {
+                if (currentBlock != null)
+                    snapshots.add(currentBlock.build());
+                currentBlock = new BlockBuilder(line, headerMatcher.group(1), headerMatcher.group(2));
+                continue;
+            }
+
+            if (currentBlock != null && THROWABLE_CONTINUATION.matcher(line.text()).matches())
+            {
+                currentBlock.addContinuation(line.text());
+                continue;
+            }
+
+            if (currentBlock != null)
+            {
+                snapshots.add(currentBlock.build());
+                currentBlock = null;
+            }
+        }
+
+        if (currentBlock != null)
+            snapshots.add(currentBlock.build());
+        return List.copyOf(snapshots);
+    }
+
+    /**
+     * Accumulates the lines of one detected stack-trace block.
+     */
+    private static final class BlockBuilder
+    {
+        private final MinecraftServerProcess.OutputLine headerLine;
+        private final String throwableClass;
+        private final @Nullable String throwableMessage;
+        private final List<String> blockLines = new ArrayList<>();
+        private int truncatedLineCount;
+
+        BlockBuilder(
+            MinecraftServerProcess.OutputLine headerLine,
+            String throwableClass,
+            @Nullable String throwableMessage)
+        {
+            this.headerLine = headerLine;
+            this.throwableClass = throwableClass;
+            this.throwableMessage = throwableMessage;
+            blockLines.add(headerLine.text());
+        }
+
+        void addContinuation(String text)
+        {
+            if (blockLines.size() >= MAX_BLOCK_LINES)
+            {
+                truncatedLineCount++;
+                return;
+            }
+            blockLines.add(text);
+        }
+
+        ServerErrorSnapshot build()
+        {
+            final List<String> stackTrace = new ArrayList<>(blockLines);
+            if (truncatedLineCount > 0)
+                stackTrace.add("... (%d more lines truncated)".formatted(truncatedLineCount));
+            return new ServerErrorSnapshot(
+                headerLine.timestampMillis(),
+                ServerErrorSnapshot.Severity.ERROR,
+                LEVEL_NAME_STDERR,
+                ServerErrorSnapshot.LOGGER_NAME_STDERR,
+                "",
+                headerLine.text(),
+                throwableClass,
+                throwableMessage == null || throwableMessage.isBlank() ? null : throwableMessage,
+                stackTrace
+            );
+        }
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
+import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.ClickMenuSlot;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayer;
@@ -20,6 +21,7 @@ import nl.pim16aap2.lightkeeper.protocol.GetOpenMenu;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponents;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessages;
+import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.GetServerPlatform;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.Handshake;
@@ -351,6 +353,18 @@ final class UdsAgentClient implements AutoCloseable
     {
         final UnregisterEventListener.Command command =
             new UnregisterEventListener.Command(nextRequestId(), eventClassName);
+        send(command);
+    }
+
+    GetServerErrors.Response getServerErrors()
+    {
+        final GetServerErrors.Command command = new GetServerErrors.Command(nextRequestId());
+        return send(command);
+    }
+
+    void clearServerErrors()
+    {
+        final ClearServerErrors.Command command = new ClearServerErrors.Command(nextRequestId());
         send(command);
     }
 

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/FrameworkApiVisibilityTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/FrameworkApiVisibilityTest.java
@@ -20,15 +20,19 @@ class FrameworkApiVisibilityTest
             MenuHandle.class.getDeclaredConstructor(IFrameworkGatewayView.class, PlayerHandle.class);
         final Constructor<WorldHandle> worldConstructor =
             WorldHandle.class.getDeclaredConstructor(IFrameworkGatewayView.class, String.class);
+        final Constructor<ServerErrorsHandle> serverErrorsConstructor =
+            ServerErrorsHandle.class.getDeclaredConstructor(IFrameworkGatewayView.class);
 
         // execute
         final boolean isPlayerConstructorPublic = Modifier.isPublic(playerConstructor.getModifiers());
         final boolean isMenuConstructorPublic = Modifier.isPublic(menuConstructor.getModifiers());
         final boolean isWorldConstructorPublic = Modifier.isPublic(worldConstructor.getModifiers());
+        final boolean isServerErrorsConstructorPublic = Modifier.isPublic(serverErrorsConstructor.getModifiers());
 
         // verify
         assertThat(isPlayerConstructorPublic).isFalse();
         assertThat(isMenuConstructorPublic).isFalse();
         assertThat(isWorldConstructorPublic).isFalse();
+        assertThat(isServerErrorsConstructorPublic).isFalse();
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshotTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshotTest.java
@@ -1,0 +1,29 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServerErrorSnapshotTest
+{
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void constructor_shouldDefaultStackTraceToEmptyListWhenNull()
+    {
+        // setup + execute
+        final ServerErrorSnapshot snapshot = new ServerErrorSnapshot(
+            1L,
+            ServerErrorSnapshot.Severity.ERROR,
+            "ERROR",
+            "net.example.SomePlugin",
+            "Server thread",
+            "boom",
+            null,
+            null,
+            null
+        );
+
+        // verify
+        assertThat(snapshot.stackTrace()).isEmpty();
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/ServerErrorsHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/ServerErrorsHandleTest.java
@@ -1,0 +1,60 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServerErrorsHandleTest
+{
+    private IFrameworkGatewayView frameworkGateway;
+    private ServerErrorsHandle serverErrorsHandle;
+
+    @BeforeEach
+    void setUp()
+    {
+        frameworkGateway = mock(IFrameworkGatewayView.class);
+        serverErrorsHandle = new ServerErrorsHandle(frameworkGateway);
+    }
+
+    @Test
+    void getCaptured_shouldDelegateToGateway()
+    {
+        // setup
+        final List<ServerErrorSnapshot> errors = List.of(new ServerErrorSnapshot(
+            1L,
+            ServerErrorSnapshot.Severity.ERROR,
+            "ERROR",
+            "net.example.SomePlugin",
+            "Server thread",
+            "boom",
+            null,
+            null,
+            List.of()
+        ));
+        when(frameworkGateway.capturedServerErrors()).thenReturn(errors);
+
+        // execute
+        final List<ServerErrorSnapshot> result = serverErrorsHandle.getCaptured();
+
+        // verify
+        assertThat(result).isSameAs(errors);
+        verify(frameworkGateway).capturedServerErrors();
+    }
+
+    @Test
+    void clear_shouldDelegateToGatewayAndReturnSelf()
+    {
+        // execute
+        final ServerErrorsHandle result = serverErrorsHandle.clear();
+
+        // verify
+        assertThat(result).isSameAs(serverErrorsHandle);
+        verify(frameworkGateway).clearServerErrors();
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
@@ -15,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -187,6 +188,51 @@ class HandleAssertionsTest
         // execute + verify
         LightkeeperAssertions.assertThat(framework)
             .hasNoServerErrors(error -> error.message().contains("moving_piston"));
+    }
+
+    @Test
+    void lightkeeperFrameworkAssert_shouldTruncateOverlongStackTraceInFailureMessage()
+    {
+        // setup — more stack trace lines than the 15-line rendering cap
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        final List<String> stackTrace = IntStream.range(0, 20)
+            .mapToObj(i -> "\tat net.example.SomePlugin.frame" + i + "(SomePlugin.java:" + i + ")")
+            .toList();
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of(new ServerErrorSnapshot(
+            1L,
+            ServerErrorSnapshot.Severity.ERROR,
+            "ERROR",
+            "net.example.SomePlugin",
+            "Server thread",
+            "boom",
+            "java.lang.IllegalStateException",
+            "boom",
+            stackTrace
+        )));
+
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.assertThat(framework).hasNoServerErrors())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("... (5 more stack trace lines)");
+    }
+
+    @Test
+    void lightkeeperFrameworkAssert_shouldRenderQuestionMarkWhenThreadNameIsEmpty()
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of(new ServerErrorSnapshot(
+            1L, ServerErrorSnapshot.Severity.ERROR, "ERROR", "net.example.SomePlugin", "", "boom",
+            null, null, List.of())));
+
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.assertThat(framework).hasNoServerErrors())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("(thread: ?)");
     }
 
     private static ServerErrorSnapshot serverError(

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
@@ -6,6 +6,8 @@ import nl.pim16aap2.lightkeeper.framework.InventorySnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import org.bukkit.Material;
@@ -130,8 +132,12 @@ class HandleAssertionsTest
     @Test
     void lightkeeperFrameworkAssert_shouldExposeServerOutputAndValidateNoErrors()
     {
-        // setup
+        // setup — a captured WARNING must not fail hasNoServerErrors()
         final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of(serverError(
+            ServerErrorSnapshot.Severity.WARNING, "WARN", "a warning, not an error")));
         when(framework.serverOutput()).thenReturn(List.of("Server started", "Done"));
 
         // execute + verify
@@ -142,16 +148,54 @@ class HandleAssertionsTest
     }
 
     @Test
-    void lightkeeperFrameworkAssert_shouldFailWhenServerOutputContainsErrors()
+    void lightkeeperFrameworkAssert_shouldFailWhenServerErrorsWereCaptured()
     {
         // setup
         final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
-        when(framework.serverOutput()).thenReturn(List.of("SEVERE: boom"));
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of(new ServerErrorSnapshot(
+            1L,
+            ServerErrorSnapshot.Severity.ERROR,
+            "ERROR",
+            "net.example.SomePlugin",
+            "Server thread",
+            "boom",
+            "java.lang.IllegalStateException",
+            "boom",
+            List.of("java.lang.IllegalStateException: boom", "\tat net.example.SomePlugin.on(SomePlugin.java:1)")
+        )));
 
-        // execute + verify
+        // execute + verify — the failure message carries the structured context, including the stack trace
         assertThatThrownBy(() -> LightkeeperAssertions.assertThat(framework).hasNoServerErrors())
             .isInstanceOf(AssertionError.class)
-            .hasMessageContaining("SEVERE: boom");
+            .hasMessageContaining("net.example.SomePlugin")
+            .hasMessageContaining("boom")
+            .hasMessageContaining("\tat net.example.SomePlugin.on(SomePlugin.java:1)");
+    }
+
+    @Test
+    void lightkeeperFrameworkAssert_shouldIgnoreAllowlistedServerErrors()
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of(serverError(
+            ServerErrorSnapshot.Severity.ERROR, "ERROR", "known moving_piston complaint")));
+
+        // execute + verify
+        LightkeeperAssertions.assertThat(framework)
+            .hasNoServerErrors(error -> error.message().contains("moving_piston"));
+    }
+
+    private static ServerErrorSnapshot serverError(
+        ServerErrorSnapshot.Severity severity,
+        String levelName,
+        String message)
+    {
+        return new ServerErrorSnapshot(
+            1L, severity, levelName, "net.example.SomePlugin", "Server thread", message, null, null, List.of());
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkServerErrorsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkServerErrorsTest.java
@@ -1,0 +1,216 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
+import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
+import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
+import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises {@link DefaultLightkeeperFramework}'s structured server-error surface: mapping agent-side entries to
+ * {@link ServerErrorSnapshot}s, appending raw stderr detections, and the stderr watermark advanced by
+ * {@link DefaultLightkeeperFramework#clearServerErrors()}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class DefaultLightkeeperFrameworkServerErrorsTest
+{
+    @Mock
+    private MinecraftServerProcess minecraftServerProcess;
+    @Mock
+    private UdsAgentClient agentClient;
+
+    private DefaultLightkeeperFramework framework()
+    {
+        return new DefaultLightkeeperFramework(
+            runtimeManifest(), minecraftServerProcess, agentClient, new PlayerScopeRegistry());
+    }
+
+    @Test
+    void serverErrors_shouldReturnHandleBoundToFramework()
+    {
+        // setup — the handle must delegate back through the very framework that created it
+        final DefaultLightkeeperFramework framework = framework();
+        when(agentClient.getServerErrors()).thenReturn(new GetServerErrors.Response(List.of(), 0L, true));
+        when(minecraftServerProcess.snapshotStderrLinesFrom(0L)).thenReturn(List.of());
+
+        // execute
+        final ServerErrorsHandle handle = framework.serverErrors();
+
+        // verify
+        assertThat(handle.getCaptured()).isEmpty();
+    }
+
+    @Test
+    void capturedServerErrors_shouldMapEntriesAndAppendStderrDetections()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = framework();
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            10L, "ERROR", "ERROR", "net.example.SomePlugin", "Server thread", "boom",
+            "java.lang.IllegalStateException", "boom", List.of("java.lang.IllegalStateException: boom"));
+        when(agentClient.getServerErrors()).thenReturn(new GetServerErrors.Response(List.of(entry), 0L, true));
+        when(minecraftServerProcess.snapshotStderrLinesFrom(0L)).thenReturn(List.of(
+            new MinecraftServerProcess.OutputLine(
+                "java.lang.RuntimeException: raw", true, 20L)));
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = framework.capturedServerErrors();
+
+        // verify — structured entries come first, then raw stderr detections
+        assertThat(snapshots).hasSize(2);
+        assertThat(snapshots.get(0).message()).isEqualTo("boom");
+        assertThat(snapshots.get(0).severity()).isEqualTo(ServerErrorSnapshot.Severity.ERROR);
+        assertThat(snapshots.get(1).message()).isEqualTo("java.lang.RuntimeException: raw");
+        assertThat(snapshots.get(1).loggerName()).isEqualTo(ServerErrorSnapshot.LOGGER_NAME_STDERR);
+    }
+
+    @Test
+    void capturedServerErrors_shouldMapWarningSeverityForNonErrorEntries()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = framework();
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            10L, "WARNING", "WARN", "net.example.SomePlugin", "Server thread", "careful", null, null, List.of());
+        when(agentClient.getServerErrors()).thenReturn(new GetServerErrors.Response(List.of(entry), 0L, true));
+        when(minecraftServerProcess.snapshotStderrLinesFrom(0L)).thenReturn(List.of());
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = framework.capturedServerErrors();
+
+        // verify
+        assertThat(snapshots).singleElement()
+            .extracting(ServerErrorSnapshot::severity)
+            .isEqualTo(ServerErrorSnapshot.Severity.WARNING);
+    }
+
+    @Test
+    void capturedServerErrors_shouldThrowWhenCaptureInactive()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = framework();
+        when(agentClient.getServerErrors()).thenReturn(new GetServerErrors.Response(List.of(), 0L, false));
+
+        // execute + verify
+        assertThatThrownBy(framework::capturedServerErrors)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Structured server-error capture is inactive");
+    }
+
+    @Test
+    void capturedServerErrors_shouldNotThrowWhenEntriesWereDropped()
+    {
+        // setup — a full buffer must not fail the call, only be reported
+        final DefaultLightkeeperFramework framework = framework();
+        when(agentClient.getServerErrors()).thenReturn(new GetServerErrors.Response(List.of(), 7L, true));
+        when(minecraftServerProcess.snapshotStderrLinesFrom(0L)).thenReturn(List.of());
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = framework.capturedServerErrors();
+
+        // verify
+        assertThat(snapshots).isEmpty();
+    }
+
+    @Test
+    void clearServerErrors_shouldSnapshotWatermarkBeforeSendingClearRpc()
+    {
+        // setup — the watermark must be taken before the RPC so stderr lines written during the round trip
+        // stay above it and still surface in later capturedServerErrors() calls
+        final DefaultLightkeeperFramework framework = framework();
+        when(minecraftServerProcess.totalOutputLineCount()).thenReturn(42L);
+
+        // execute
+        framework.clearServerErrors();
+
+        // verify
+        final InOrder callOrder = inOrder(minecraftServerProcess, agentClient);
+        callOrder.verify(minecraftServerProcess).totalOutputLineCount();
+        callOrder.verify(agentClient).clearServerErrors();
+    }
+
+    @Test
+    void capturedServerErrors_shouldUseWatermarkAdvancedByPriorClear()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = framework();
+        when(minecraftServerProcess.totalOutputLineCount()).thenReturn(42L);
+        framework.clearServerErrors();
+        when(agentClient.getServerErrors()).thenReturn(new GetServerErrors.Response(List.of(), 0L, true));
+        when(minecraftServerProcess.snapshotStderrLinesFrom(42L)).thenReturn(List.of());
+
+        // execute
+        framework.capturedServerErrors();
+
+        // verify — the scan window starts at the watermark set by the earlier clear, not at zero
+        verify(minecraftServerProcess).snapshotStderrLinesFrom(eq(42L));
+    }
+
+    @Test
+    void endMethodScope_shouldClearServerErrorsWhenNotCrashed()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = framework();
+        when(minecraftServerProcess.totalOutputLineCount()).thenReturn(5L);
+        framework.beginMethodScope("method-1");
+
+        // execute
+        framework.endMethodScope("method-1");
+
+        // verify
+        verify(agentClient).clearServerErrors();
+    }
+
+    @Test
+    void endMethodScope_shouldNotClearServerErrorsAfterCrash()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = framework();
+        framework.beginMethodScope("method-1");
+        framework.crashServer();
+
+        // execute
+        framework.endMethodScope("method-1");
+
+        // verify — the agent connection is gone after a crash; clearing must be skipped
+        verify(agentClient, never()).clearServerErrors();
+    }
+
+    private static RuntimeManifest runtimeManifest()
+    {
+        return new RuntimeManifest(
+            "paper",
+            "1.21.11",
+            1L,
+            "cache-key",
+            "/tmp/lightkeeper/server",
+            "/tmp/lightkeeper/server/server.jar",
+            1024,
+            "/tmp/lightkeeper/agent.sock",
+            "auth-token",
+            "/tmp/lightkeeper/agent.jar",
+            "agent-sha256",
+            1,
+            "agent-cache-identity",
+            null,
+            List.of()
+        );
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
@@ -468,4 +468,41 @@ class MinecraftServerProcessTest
         field.setAccessible(true);
         return field.get(target);
     }
+
+    @Test
+    @org.junit.jupiter.api.Timeout(10)
+    void joinReaderThread_shouldReturnImmediatelyWhenBudgetIsExhausted()
+        throws Exception
+    {
+        // setup
+        // Thread.join(0) waits forever; an exhausted shared budget must skip the join instead of hanging.
+        final Thread stuckReader = Thread.ofPlatform().daemon().start(() ->
+        {
+            try
+            {
+                Thread.sleep(60_000);
+            }
+            catch (InterruptedException exception)
+            {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        try
+        {
+            final java.lang.reflect.Method joinReaderThread = MinecraftServerProcess.class
+                .getDeclaredMethod("joinReaderThread", Thread.class, Duration.class);
+            joinReaderThread.setAccessible(true);
+
+            // execute — must return promptly despite the reader being stuck (guarded by @Timeout)
+            final Object result = joinReaderThread.invoke(null, stuckReader, Duration.ZERO);
+
+            // verify — the still-alive reader is retained for the caller to observe
+            assertThat(result).isSameAs(stuckReader);
+        }
+        finally
+        {
+            stuckReader.interrupt();
+        }
+    }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
@@ -9,14 +9,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.io.ByteArrayInputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -43,19 +47,24 @@ class MinecraftServerProcessTest
         final Thread outputThread = Thread.ofPlatform().unstarted(() -> { });
         outputThread.start();
         outputThread.join();
+        final Thread errorThread = Thread.ofPlatform().unstarted(() -> { });
+        errorThread.start();
+        errorThread.join();
         when(process.isAlive()).thenReturn(true, false);
         when(process.waitFor(5_000L, TimeUnit.MILLISECONDS)).thenReturn(true);
         setField(serverProcess, "process", process);
         setField(serverProcess, "outputThread", outputThread);
+        setField(serverProcess, "errorThread", errorThread);
 
         // execute
         serverProcess.kill();
 
-        // verify
+        // verify — both reader threads are joined and cleared, not just the output one
         verify(process).destroyForcibly();
         verify(process).waitFor(5_000L, TimeUnit.MILLISECONDS);
         assertThat(getField(serverProcess, "process")).isNull();
         assertThat(getField(serverProcess, "outputThread")).isNull();
+        assertThat(getField(serverProcess, "errorThread")).isNull();
     }
 
     @Test
@@ -127,6 +136,127 @@ class MinecraftServerProcessTest
             lingeringOutputThread.interrupt();
             lingeringOutputThread.join(Duration.ofSeconds(5));
         }
+    }
+
+    @Test
+    void start_shouldRejectLingeringErrorReaderBeforeNewProcessLaunch(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup — the output reader is absent/finished, only the stderr reader is still lingering
+        final MinecraftServerProcess serverProcess = new MinecraftServerProcess(
+            runtimeManifest(tempDirectory),
+            tempDirectory.resolve("diagnostics")
+        );
+        final Thread lingeringErrorThread = Thread.ofPlatform().unstarted(() ->
+        {
+            try
+            {
+                Thread.sleep(Duration.ofSeconds(30));
+            }
+            catch (InterruptedException exception)
+            {
+                Thread.currentThread().interrupt();
+            }
+        });
+        lingeringErrorThread.start();
+        setField(serverProcess, "errorThread", lingeringErrorThread);
+
+        // execute + verify
+        try
+        {
+            assertThatThrownBy(() -> serverProcess.start(Duration.ofMillis(1)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("output reader is still stopping");
+        }
+        finally
+        {
+            lingeringErrorThread.interrupt();
+            lingeringErrorThread.join(Duration.ofSeconds(5));
+        }
+    }
+
+    @Test
+    void getProcessBuilder_shouldNotRedirectErrorStreamIntoStdout(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup — stdout and stderr must stay on separate pipes so OutputLine provenance is meaningful
+        final MinecraftServerProcess serverProcess = new MinecraftServerProcess(
+            runtimeManifest(tempDirectory),
+            tempDirectory.resolve("diagnostics")
+        );
+        final Method getProcessBuilder =
+            MinecraftServerProcess.class.getDeclaredMethod("getProcessBuilder", Path.class);
+        getProcessBuilder.setAccessible(true);
+
+        // execute
+        final ProcessBuilder processBuilder =
+            (ProcessBuilder) getProcessBuilder.invoke(serverProcess, Path.of("java"));
+
+        // verify
+        assertThat(processBuilder.redirectErrorStream()).isFalse();
+    }
+
+    @Test
+    void createOutputReaderThread_shouldCaptureLinesAndSignalStartupOnReadyMarker(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final MinecraftServerProcess serverProcess = new MinecraftServerProcess(
+            runtimeManifest(tempDirectory),
+            tempDirectory.resolve("diagnostics")
+        );
+        final Process process = mock();
+        final String content = "Starting server" + System.lineSeparator()
+            + "Done (1.234s)! For help, type \"help\"" + System.lineSeparator();
+        when(process.getInputStream())
+            .thenReturn(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final Method createOutputReaderThread = MinecraftServerProcess.class
+            .getDeclaredMethod("createOutputReaderThread", Process.class, CountDownLatch.class);
+        createOutputReaderThread.setAccessible(true);
+        final Thread readerThread = (Thread) createOutputReaderThread.invoke(serverProcess, process, startLatch);
+
+        // execute
+        readerThread.start();
+        readerThread.join(Duration.ofSeconds(5).toMillis());
+
+        // verify — the readiness marker line signals startup, and both lines land on the stdout pipe
+        assertThat(startLatch.getCount()).isZero();
+        assertThat(serverProcess.snapshotOutputLines())
+            .containsExactly("Starting server", "Done (1.234s)! For help, type \"help\"");
+        assertThat(serverProcess.snapshotStderrLinesFrom(0L)).isEmpty();
+    }
+
+    @Test
+    void createErrorReaderThread_shouldCaptureLinesWithStderrProvenance(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final MinecraftServerProcess serverProcess = new MinecraftServerProcess(
+            runtimeManifest(tempDirectory),
+            tempDirectory.resolve("diagnostics")
+        );
+        final Process process = mock();
+        final String content = "java.lang.RuntimeException: raw" + System.lineSeparator();
+        when(process.getErrorStream())
+            .thenReturn(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+        final Method createErrorReaderThread =
+            MinecraftServerProcess.class.getDeclaredMethod("createErrorReaderThread", Process.class);
+        createErrorReaderThread.setAccessible(true);
+        final Thread readerThread = (Thread) createErrorReaderThread.invoke(serverProcess, process);
+
+        // execute
+        readerThread.start();
+        readerThread.join(Duration.ofSeconds(5).toMillis());
+
+        // verify — the line is captured with stderr provenance, distinct from the stdout pipe
+        assertThat(serverProcess.snapshotStderrLinesFrom(0L))
+            .singleElement()
+            .satisfies(line ->
+            {
+                assertThat(line.text()).isEqualTo("java.lang.RuntimeException: raw");
+                assertThat(line.fromStderr()).isTrue();
+            });
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
@@ -205,16 +205,13 @@ class MinecraftServerProcessTest
             runtimeManifest(tempDirectory),
             tempDirectory.resolve("diagnostics")
         );
-        final java.lang.reflect.Method appendOutputLine =
-            MinecraftServerProcess.class.getDeclaredMethod("appendOutputLine", String.class);
-        appendOutputLine.setAccessible(true);
-        appendOutputLine.invoke(serverProcess, "line one");
-        appendOutputLine.invoke(serverProcess, "line two");
+        appendOutputLine(serverProcess, "line one", false);
+        appendOutputLine(serverProcess, "line two", true);
 
         // execute
         final List<String> lines = serverProcess.snapshotOutputLines();
 
-        // verify
+        // verify — snapshotOutputLines merges both pipes in arrival order
         assertThat(lines).containsExactly("line one", "line two");
     }
 
@@ -232,10 +229,7 @@ class MinecraftServerProcessTest
         discardedField.setAccessible(true);
         discardedField.set(serverProcess, 5L);
 
-        final java.lang.reflect.Method appendOutputLine =
-            MinecraftServerProcess.class.getDeclaredMethod("appendOutputLine", String.class);
-        appendOutputLine.setAccessible(true);
-        appendOutputLine.invoke(serverProcess, "survivor line");
+        appendOutputLine(serverProcess, "survivor line", false);
 
         // execute
         final List<String> lines = serverProcess.snapshotOutputLines();
@@ -244,6 +238,68 @@ class MinecraftServerProcessTest
         assertThat(lines).hasSize(2);
         assertThat(lines.getFirst()).contains("Discarded").contains("5");
         assertThat(lines.get(1)).isEqualTo("survivor line");
+    }
+
+    @Test
+    void totalOutputLineCount_shouldIncludeDiscardedLines(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final MinecraftServerProcess serverProcess = new MinecraftServerProcess(
+            runtimeManifest(tempDirectory),
+            tempDirectory.resolve("diagnostics")
+        );
+        final java.lang.reflect.Field discardedField =
+            MinecraftServerProcess.class.getDeclaredField("discardedOutputLineCount");
+        discardedField.setAccessible(true);
+        discardedField.set(serverProcess, 7L);
+        appendOutputLine(serverProcess, "line one", false);
+        appendOutputLine(serverProcess, "line two", true);
+
+        // execute
+        final long totalLineCount = serverProcess.totalOutputLineCount();
+
+        // verify
+        assertThat(totalLineCount).isEqualTo(9L);
+    }
+
+    @Test
+    void snapshotStderrLinesFrom_shouldFilterByProvenanceAndWatermark(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final MinecraftServerProcess serverProcess = new MinecraftServerProcess(
+            runtimeManifest(tempDirectory),
+            tempDirectory.resolve("diagnostics")
+        );
+        appendOutputLine(serverProcess, "stdout before", false);
+        appendOutputLine(serverProcess, "stderr before", true);
+        final long watermark = serverProcess.totalOutputLineCount();
+        appendOutputLine(serverProcess, "stdout after", false);
+        appendOutputLine(serverProcess, "stderr after", true);
+
+        // execute
+        final List<MinecraftServerProcess.OutputLine> stderrLines =
+            serverProcess.snapshotStderrLinesFrom(watermark);
+
+        // verify — only stderr lines at or past the watermark are returned
+        assertThat(stderrLines)
+            .singleElement()
+            .satisfies(line ->
+            {
+                assertThat(line.text()).isEqualTo("stderr after");
+                assertThat(line.fromStderr()).isTrue();
+                assertThat(line.timestampMillis()).isPositive();
+            });
+    }
+
+    private static void appendOutputLine(MinecraftServerProcess serverProcess, String line, boolean fromStderr)
+        throws ReflectiveOperationException
+    {
+        final java.lang.reflect.Method appendOutputLine =
+            MinecraftServerProcess.class.getDeclaredMethod("appendOutputLine", String.class, boolean.class);
+        appendOutputLine.setAccessible(true);
+        appendOutputLine.invoke(serverProcess, line, fromStderr);
     }
 
     private static RuntimeManifest runtimeManifest(Path tempDirectory)

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/ServerStderrErrorScannerTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/ServerStderrErrorScannerTest.java
@@ -168,4 +168,21 @@ class ServerStderrErrorScannerTest
         // execute + verify
         assertThat(ServerStderrErrorScanner.scan(List.of())).isEmpty();
     }
+
+    @Test
+    void scan_shouldTreatBlankThrowableMessageAsNull()
+    {
+        // setup — a header line with a colon but no message text after it
+        final List<OutputLine> lines = List.of(
+            stderrLine("java.lang.RuntimeException:"),
+            stderrLine("\tat net.example.Foo.bar(Foo.java:1)")
+        );
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify
+        assertThat(snapshots).hasSize(1);
+        assertThat(snapshots.getFirst().throwableMessage()).isNull();
+    }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/ServerStderrErrorScannerTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/ServerStderrErrorScannerTest.java
@@ -1,0 +1,171 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import nl.pim16aap2.lightkeeper.framework.internal.MinecraftServerProcess.OutputLine;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServerStderrErrorScannerTest
+{
+    private static OutputLine stderrLine(String text)
+    {
+        return new OutputLine(text, true, 1_720_000_000_000L);
+    }
+
+    @Test
+    void scan_shouldGroupBareThrowableWithFramesIntoOneSnapshot()
+    {
+        // setup — the exact shape of a raw printStackTrace() that bypassed the logging system
+        final List<OutputLine> lines = List.of(
+            stderrLine("java.util.concurrent.TimeoutException"),
+            stderrLine("\tat java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960)"),
+            stderrLine("\tat java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)")
+        );
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify
+        assertThat(snapshots).hasSize(1);
+        final ServerErrorSnapshot snapshot = snapshots.getFirst();
+        assertThat(snapshot.severity()).isEqualTo(ServerErrorSnapshot.Severity.ERROR);
+        assertThat(snapshot.levelName()).isEqualTo("STDERR");
+        assertThat(snapshot.loggerName()).isEqualTo(ServerErrorSnapshot.LOGGER_NAME_STDERR);
+        assertThat(snapshot.message()).isEqualTo("java.util.concurrent.TimeoutException");
+        assertThat(snapshot.throwableClass()).isEqualTo("java.util.concurrent.TimeoutException");
+        assertThat(snapshot.throwableMessage()).isNull();
+        assertThat(snapshot.stackTrace()).hasSize(3);
+        assertThat(snapshot.timestampMillis()).isEqualTo(1_720_000_000_000L);
+    }
+
+    @Test
+    void scan_shouldExtractMessageAndCauseChain()
+    {
+        // setup
+        final List<OutputLine> lines = List.of(
+            stderrLine("java.lang.IllegalStateException: outer failure"),
+            stderrLine("\tat net.example.Foo.bar(Foo.java:10)"),
+            stderrLine("Caused by: java.lang.IllegalArgumentException: root cause"),
+            stderrLine("\tat net.example.Foo.baz(Foo.java:20)"),
+            stderrLine("\t... 3 more")
+        );
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify
+        assertThat(snapshots).hasSize(1);
+        final ServerErrorSnapshot snapshot = snapshots.getFirst();
+        assertThat(snapshot.throwableClass()).isEqualTo("java.lang.IllegalStateException");
+        assertThat(snapshot.throwableMessage()).isEqualTo("outer failure");
+        assertThat(snapshot.stackTrace())
+            .hasSize(5)
+            .contains("Caused by: java.lang.IllegalArgumentException: root cause");
+    }
+
+    @Test
+    void scan_shouldHandleExceptionInThreadPrefix()
+    {
+        // setup
+        final List<OutputLine> lines = List.of(
+            stderrLine("Exception in thread \"Worker-1\" java.lang.RuntimeException: kaboom"),
+            stderrLine("\tat net.example.Worker.run(Worker.java:42)")
+        );
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify
+        assertThat(snapshots).hasSize(1);
+        assertThat(snapshots.getFirst().throwableClass()).isEqualTo("java.lang.RuntimeException");
+        assertThat(snapshots.getFirst().throwableMessage()).isEqualTo("kaboom");
+    }
+
+    @Test
+    void scan_shouldSplitConsecutiveTracesIntoSeparateSnapshots()
+    {
+        // setup
+        final List<OutputLine> lines = List.of(
+            stderrLine("java.lang.IllegalStateException: first"),
+            stderrLine("\tat net.example.Foo.a(Foo.java:1)"),
+            stderrLine("java.lang.IllegalArgumentException: second"),
+            stderrLine("\tat net.example.Foo.b(Foo.java:2)")
+        );
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify
+        assertThat(snapshots).hasSize(2);
+        assertThat(snapshots.get(0).throwableMessage()).isEqualTo("first");
+        assertThat(snapshots.get(1).throwableMessage()).isEqualTo("second");
+    }
+
+    @Test
+    void scan_shouldIgnoreNonExceptionNoiseAndOrphanContinuations()
+    {
+        // setup — benign JVM warnings and a window that starts mid-trace must not produce snapshots
+        final List<OutputLine> lines = List.of(
+            stderrLine("OpenJDK 64-Bit Server VM warning: Options -Xverify:none deprecated"),
+            stderrLine("\tat net.example.Orphan.frame(Orphan.java:1)"),
+            stderrLine("Caused by: java.lang.RuntimeException: orphan cause"),
+            stderrLine("some plain diagnostic text")
+        );
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify
+        assertThat(snapshots).isEmpty();
+    }
+
+    @Test
+    void scan_shouldTerminateBlockOnNonContinuationLine()
+    {
+        // setup
+        final List<OutputLine> lines = List.of(
+            stderrLine("java.lang.IllegalStateException: first"),
+            stderrLine("\tat net.example.Foo.a(Foo.java:1)"),
+            stderrLine("unrelated diagnostic output"),
+            stderrLine("\tat net.example.Foo.b(Foo.java:2)")
+        );
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify — the trailing orphan frame after the block ended is not attached to anything
+        assertThat(snapshots).hasSize(1);
+        assertThat(snapshots.getFirst().stackTrace()).hasSize(2);
+    }
+
+    @Test
+    void scan_shouldCapOverlongBlocksWithTruncationMarker()
+    {
+        // setup
+        final List<OutputLine> lines = Stream.concat(
+            Stream.of(stderrLine("java.lang.RuntimeException: deep")),
+            IntStream.range(0, ServerStderrErrorScanner.MAX_BLOCK_LINES + 25)
+                .mapToObj(i -> stderrLine("\tat net.example.Deep.frame" + i + "(Deep.java:" + i + ")"))
+        ).toList();
+
+        // execute
+        final List<ServerErrorSnapshot> snapshots = ServerStderrErrorScanner.scan(lines);
+
+        // verify
+        assertThat(snapshots).hasSize(1);
+        assertThat(snapshots.getFirst().stackTrace()).hasSize(ServerStderrErrorScanner.MAX_BLOCK_LINES + 1);
+        assertThat(snapshots.getFirst().stackTrace().getLast()).contains("truncated");
+    }
+
+    @Test
+    void scan_shouldReturnEmptyListForEmptyInput()
+    {
+        // execute + verify
+        assertThat(ServerStderrErrorScanner.scan(List.of())).isEmpty();
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -324,6 +324,56 @@ class UdsAgentClientTest
     }
 
     @Test
+    void getServerErrors_shouldReturnTypedEntriesFromResponse(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("server-errors.sock");
+        final String responseJson =
+            "{\"requestId\":\"1\",\"success\":true,\"droppedCount\":2,\"captureActive\":true,\"errors\":["
+                + "{\"timestampMillis\":123,\"severity\":\"ERROR\",\"levelName\":\"ERROR\","
+                + "\"loggerName\":\"net.example\",\"threadName\":\"Server thread\",\"message\":\"boom\","
+                + "\"throwableClass\":\"java.lang.IllegalStateException\",\"throwableMessage\":\"boom\","
+                + "\"stackTrace\":[\"java.lang.IllegalStateException: boom\"]}]}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final nl.pim16aap2.lightkeeper.protocol.GetServerErrors.Response response = client.getServerErrors();
+
+            // verify
+            assertThat(server.capturedRequest()).contains("\"action\":\"GET_SERVER_ERRORS\"");
+            assertThat(response.droppedCount()).isEqualTo(2L);
+            assertThat(response.captureActive()).isTrue();
+            assertThat(response.errors()).singleElement().satisfies(entry ->
+            {
+                assertThat(entry.severity()).isEqualTo("ERROR");
+                assertThat(entry.message()).isEqualTo("boom");
+                assertThat(entry.throwableClass()).isEqualTo("java.lang.IllegalStateException");
+                assertThat(entry.stackTrace()).hasSize(1);
+            });
+        }
+    }
+
+    @Test
+    void clearServerErrors_shouldSendClearRequest(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("clear-server-errors.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.clearServerErrors();
+
+            // verify
+            assertThat(server.capturedRequest()).contains("\"action\":\"CLEAR_SERVER_ERRORS\"");
+        }
+    }
+
+    @Test
     void serverPlatform_shouldMapPaperResponseToPaper(@TempDir Path tempDirectory)
         throws Exception
     {

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperServerErrorCaptureIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperServerErrorCaptureIT.java
@@ -1,0 +1,132 @@
+package nl.pim16aap2.lightkeeper.maven.test;
+
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
+import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end coverage for structured server-error capture on a shared server.
+ *
+ * <p>Methods are ordered because the auto-clear contract is inherently cross-method: the error provoked in an
+ * earlier test must be invisible to the next one.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(LightkeeperExtension.class)
+class LightkeeperServerErrorCaptureIT
+{
+    /**
+     * Message logged at SEVERE by {@code /lktesterror severe} (see the test plugin's
+     * {@code LkTestErrorCommandExecutor}).
+     */
+    private static final String SEVERE_MARKER = "LK_TEST_ERROR provoked severe";
+    /**
+     * Message logged at WARNING by {@code /lktesterror warning}.
+     */
+    private static final String WARNING_MARKER = "LK_TEST_ERROR provoked warning";
+    /**
+     * Message of the throwable attached to the SEVERE log event.
+     */
+    private static final String THROWABLE_MARKER = "LK_TEST_ERROR boom";
+
+    private static final Duration CAPTURE_TIMEOUT = Duration.ofSeconds(20);
+
+    @Test
+    @Order(1)
+    void serverErrors_shouldCaptureProvokedSevereWithThrowableMetadata(ILightkeeperFramework framework)
+    {
+        // setup
+        final ServerErrorsHandle serverErrors = framework.serverErrors();
+
+        // execute
+        framework.executeCommand(CommandSource.CONSOLE, "lktesterror severe");
+        framework.waitUntil(() -> containsMessage(serverErrors, SEVERE_MARKER), CAPTURE_TIMEOUT);
+
+        // verify — the entry carries the real throwable, not scraped console text
+        final ServerErrorSnapshot error = findByMessage(serverErrors, SEVERE_MARKER);
+        assertThat(error.severity()).isEqualTo(ServerErrorSnapshot.Severity.ERROR);
+        assertThat(error.throwableClass()).isEqualTo("java.lang.IllegalStateException");
+        assertThat(error.throwableMessage()).isEqualTo(THROWABLE_MARKER);
+        assertThat(error.stackTrace()).isNotEmpty();
+        assertThat(error.loggerName()).isNotBlank();
+        assertThat(error.threadName()).isNotBlank();
+        assertThat(error.timestampMillis()).isPositive();
+
+        // verify — hasNoServerErrors() fails with the structured context, and the allowlist can exempt it
+        assertThatThrownBy(() -> assertThat(framework).hasNoServerErrors())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining(SEVERE_MARKER)
+            .hasMessageContaining("java.lang.IllegalStateException");
+        assertThat(framework).hasNoServerErrors(candidate -> candidate.message().contains(SEVERE_MARKER));
+    }
+
+    @Test
+    @Order(2)
+    void serverErrors_shouldBeClearedAutomaticallyBetweenTestMethods(ILightkeeperFramework framework)
+    {
+        // verify — the severe error provoked by the previous test must not leak into this test's window
+        assertThat(framework.serverErrors().getCaptured())
+            .noneSatisfy(error -> assertThat(error.message()).contains(SEVERE_MARKER));
+        assertThat(framework).hasNoServerErrors();
+    }
+
+    @Test
+    @Order(3)
+    void serverErrors_shouldBufferWarningsWithoutFailingHealthCheck(ILightkeeperFramework framework)
+    {
+        // setup
+        final ServerErrorsHandle serverErrors = framework.serverErrors();
+
+        // execute
+        framework.executeCommand(CommandSource.CONSOLE, "lktesterror warning");
+        framework.waitUntil(() -> containsMessage(serverErrors, WARNING_MARKER), CAPTURE_TIMEOUT);
+
+        // verify — the warning is available for diagnostics but does not gate the health check
+        final ServerErrorSnapshot warning = findByMessage(serverErrors, WARNING_MARKER);
+        assertThat(warning.severity()).isEqualTo(ServerErrorSnapshot.Severity.WARNING);
+        assertThat(warning.throwableClass()).isNull();
+        assertThat(framework).hasNoServerErrors();
+    }
+
+    @Test
+    @Order(4)
+    void serverErrors_clearShouldDiscardProvokedError(ILightkeeperFramework framework)
+    {
+        // setup
+        final ServerErrorsHandle serverErrors = framework.serverErrors();
+        framework.executeCommand(CommandSource.CONSOLE, "lktesterror severe");
+        framework.waitUntil(() -> containsMessage(serverErrors, SEVERE_MARKER), CAPTURE_TIMEOUT);
+
+        // execute
+        serverErrors.clear();
+
+        // verify
+        assertThat(serverErrors.getCaptured())
+            .noneSatisfy(error -> assertThat(error.message()).contains(SEVERE_MARKER));
+        assertThat(framework).hasNoServerErrors();
+    }
+
+    private static boolean containsMessage(ServerErrorsHandle serverErrors, String marker)
+    {
+        return serverErrors.getCaptured().stream().anyMatch(error -> error.message().contains(marker));
+    }
+
+    private static ServerErrorSnapshot findByMessage(ServerErrorsHandle serverErrors, String marker)
+    {
+        return serverErrors.getCaptured().stream()
+            .filter(error -> error.message().contains(marker))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No captured server error contains marker '%s'.".formatted(marker)));
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ClearServerErrors.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ClearServerErrors.java
@@ -1,0 +1,43 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+/**
+ * Discards all server errors captured by the agent's log appender and resets its dropped-entry counter.
+ */
+public final class ClearServerErrors
+{
+    private ClearServerErrors()
+    {
+    }
+
+    /**
+     * Command record for {@code CLEAR_SERVER_ERRORS}.
+     *
+     * @param requestId
+     *     Correlation identifier matching the response's {@code requestId}.
+     */
+    public record Command(
+        String requestId
+    ) implements IAgentCommand<Response>
+    {
+        /**
+         * Validates command inputs.
+         */
+        public Command
+        {
+            ProtocolPreconditions.requireNonBlank(requestId, "requestId");
+        }
+
+        @Override
+        public Class<Response> responseType()
+        {
+            return Response.class;
+        }
+    }
+
+    /**
+     * Response record for {@code CLEAR_SERVER_ERRORS}.
+     */
+    public record Response() implements IAgentResponse
+    {
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetServerErrors.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetServerErrors.java
@@ -1,0 +1,66 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import java.util.List;
+
+/**
+ * Returns all server errors and warnings captured by the agent's log appender since agent load or the last
+ * {@code CLEAR_SERVER_ERRORS}.
+ */
+public final class GetServerErrors
+{
+    private GetServerErrors()
+    {
+    }
+
+    /**
+     * Command record for {@code GET_SERVER_ERRORS}.
+     *
+     * @param requestId
+     *     Correlation identifier matching the response's {@code requestId}.
+     */
+    public record Command(
+        String requestId
+    ) implements IAgentCommand<Response>
+    {
+        /**
+         * Validates command inputs.
+         */
+        public Command
+        {
+            ProtocolPreconditions.requireNonBlank(requestId, "requestId");
+        }
+
+        @Override
+        public Class<Response> responseType()
+        {
+            return Response.class;
+        }
+    }
+
+    /**
+     * Response record for {@code GET_SERVER_ERRORS}.
+     *
+     * @param errors
+     *     Captured error entries ordered oldest-to-newest.
+     * @param droppedCount
+     *     Number of entries discarded because the agent-side capture buffer was full. The buffer keeps the
+     *     oldest entries, so the retained entries always include the first (root-cause) errors.
+     * @param captureActive
+     *     Whether the agent's log appender is attached. {@code false} means structured capture is unavailable
+     *     on this server and the entry list is not authoritative.
+     */
+    public record Response(
+        List<ServerErrorEntry> errors,
+        long droppedCount,
+        boolean captureActive
+    ) implements IAgentResponse
+    {
+        /**
+         * Defensively copies the error list.
+         */
+        public Response
+        {
+            errors = errors == null ? List.of() : List.copyOf(errors);
+        }
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
@@ -51,6 +51,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = UnregisterEventListener.Command.class, name = "UNREGISTER_EVENT_LISTENER"),
     @JsonSubTypes.Type(value = GetPlayerChatComponents.Command.class, name = "GET_PLAYER_CHAT_COMPONENTS"),
     @JsonSubTypes.Type(value = GetServerPlatform.Command.class, name = "GET_SERVER_PLATFORM"),
+    @JsonSubTypes.Type(value = GetServerErrors.Command.class, name = "GET_SERVER_ERRORS"),
+    @JsonSubTypes.Type(value = ClearServerErrors.Command.class, name = "CLEAR_SERVER_ERRORS"),
 })
 public sealed interface IAgentCommand<R extends IAgentResponse>
     permits Handshake.Command, MainWorld.Command, NewWorld.Command, ExecuteCommand.Command,
@@ -62,7 +64,8 @@ public sealed interface IAgentCommand<R extends IAgentResponse>
             UnloadChunk.Command, IsChunkLoaded.Command, GetPlayerInventory.Command,
             DropItem.Command, RegisterEventListener.Command, GetCapturedEvents.Command,
             ClearCapturedEvents.Command, UnregisterEventListener.Command,
-            GetPlayerChatComponents.Command, GetServerPlatform.Command
+            GetPlayerChatComponents.Command, GetServerPlatform.Command,
+            GetServerErrors.Command, ClearServerErrors.Command
 {
     /**
      * Correlation identifier matching the response's {@code requestId}.

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
@@ -15,6 +15,7 @@ public sealed interface IAgentResponse
     permits
     BlockType.Response,
     ClearCapturedEvents.Response,
+    ClearServerErrors.Response,
     ClickMenuSlot.Response,
     CreatePlayer.Response,
     DragMenuSlots.Response,
@@ -26,6 +27,7 @@ public sealed interface IAgentResponse
     GetPlayerChatComponents.Response,
     GetPlayerInventory.Response,
     GetPlayerMessages.Response,
+    GetServerErrors.Response,
     GetServerPlatform.Response,
     GetServerTick.Response,
     Handshake.Response,

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ServerErrorEntry.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ServerErrorEntry.java
@@ -1,0 +1,58 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Typed snapshot of a single captured server error or warning, carried directly inside protocol responses.
+ *
+ * <p>Entries are captured by the agent's Log4j appender as structured log events, so the throwable metadata
+ * reflects the actual {@code Throwable} attached to the log event rather than text scraped from console output.
+ *
+ * @param timestampMillis
+ *     Epoch milliseconds at which the log event was created.
+ * @param severity
+ *     Severity bucket derived from the numeric log level: {@code "ERROR"} for error-or-worse events,
+ *     {@code "WARNING"} otherwise.
+ * @param levelName
+ *     Original log level name (e.g. {@code "ERROR"}, {@code "WARN"}, {@code "FATAL"}) for display purposes.
+ * @param loggerName
+ *     Name of the logger that emitted the event.
+ * @param threadName
+ *     Name of the thread that emitted the event.
+ * @param message
+ *     Formatted log message.
+ * @param throwableClass
+ *     Fully-qualified class name of the attached throwable, or {@code null} when the event carried none.
+ * @param throwableMessage
+ *     Message of the attached throwable, or {@code null} when absent.
+ * @param stackTrace
+ *     Rendered stack trace lines of the attached throwable including its cause chain (possibly truncated);
+ *     empty when the event carried no throwable.
+ */
+public record ServerErrorEntry(
+    long timestampMillis,
+    String severity,
+    String levelName,
+    String loggerName,
+    String threadName,
+    String message,
+    @Nullable String throwableClass,
+    @Nullable String throwableMessage,
+    List<String> stackTrace
+)
+{
+    /**
+     * Validates required fields and defensively copies the stack trace.
+     */
+    public ServerErrorEntry
+    {
+        ProtocolPreconditions.requireNonBlank(severity, "severity");
+        ProtocolPreconditions.requireNonBlank(levelName, "levelName");
+        ProtocolPreconditions.requireNonNull(loggerName, "loggerName");
+        ProtocolPreconditions.requireNonNull(threadName, "threadName");
+        ProtocolPreconditions.requireNonNull(message, "message");
+        stackTrace = stackTrace == null ? List.of() : List.copyOf(stackTrace);
+    }
+}

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
@@ -288,6 +288,21 @@ class AgentCommandSerializationTest
         assertThat(deserialized.requestId()).isEqualTo("req-10");
     }
 
+    @Test
+    void serialize_clearServerErrorsResponse_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final ClearServerErrors.Response original = new ClearServerErrors.Response();
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final ClearServerErrors.Response result = mapper.readValue(json, ClearServerErrors.Response.class);
+
+        // verify
+        assertThat(result).isEqualTo(original);
+    }
+
     // -----------------------------------------------------------------------
     // Round-trip: GetServerErrors.Response with and without throwable metadata
     // -----------------------------------------------------------------------

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
@@ -253,6 +253,104 @@ class AgentCommandSerializationTest
     }
 
     // -----------------------------------------------------------------------
+    // Deserialization from raw JSON: GET_SERVER_ERRORS / CLEAR_SERVER_ERRORS subtypes
+    // -----------------------------------------------------------------------
+
+    @Test
+    void deserialize_getServerErrorsJson_selectsGetServerErrorsCommand() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final String json = "{\"action\":\"GET_SERVER_ERRORS\",\"requestId\":\"req-9\"}";
+
+        // execute
+        @SuppressWarnings("rawtypes")
+        final IAgentCommand deserialized = mapper.readValue(json, IAgentCommand.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(GetServerErrors.Command.class);
+        assertThat(deserialized.requestId()).isEqualTo("req-9");
+    }
+
+    @Test
+    void deserialize_clearServerErrorsJson_selectsClearServerErrorsCommand() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final String json = "{\"action\":\"CLEAR_SERVER_ERRORS\",\"requestId\":\"req-10\"}";
+
+        // execute
+        @SuppressWarnings("rawtypes")
+        final IAgentCommand deserialized = mapper.readValue(json, IAgentCommand.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(ClearServerErrors.Command.class);
+        assertThat(deserialized.requestId()).isEqualTo("req-10");
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip: GetServerErrors.Response with and without throwable metadata
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_getServerErrorsResponse_withThrowableEntry_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            1_720_000_000_000L,
+            "ERROR",
+            "ERROR",
+            "net.example.SomePlugin",
+            "Server thread",
+            "Could not pass event to plugin",
+            "java.lang.IllegalStateException",
+            "boom",
+            List.of("java.lang.IllegalStateException: boom", "\tat net.example.SomePlugin.onEvent(SomePlugin.java:1)")
+        );
+        final GetServerErrors.Response original = new GetServerErrors.Response(List.of(entry), 5L, true);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final GetServerErrors.Response result = mapper.readValue(json, GetServerErrors.Response.class);
+
+        // verify
+        assertThat(result.droppedCount()).isEqualTo(5L);
+        assertThat(result.captureActive()).isTrue();
+        assertThat(result.errors()).containsExactly(entry);
+    }
+
+    @Test
+    void serialize_getServerErrorsResponse_withoutThrowableEntry_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            1_720_000_000_001L,
+            "WARNING",
+            "WARN",
+            "net.minecraft.server",
+            "Worker-1",
+            "Something looked off",
+            null,
+            null,
+            List.of()
+        );
+        final GetServerErrors.Response original = new GetServerErrors.Response(List.of(entry), 0L, false);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final GetServerErrors.Response result = mapper.readValue(json, GetServerErrors.Response.class);
+
+        // verify
+        assertThat(result.droppedCount()).isZero();
+        assertThat(result.captureActive()).isFalse();
+        assertThat(result.errors()).containsExactly(entry);
+        assertThat(result.errors().getFirst().throwableClass()).isNull();
+        assertThat(result.errors().getFirst().throwableMessage()).isNull();
+    }
+
+    // -----------------------------------------------------------------------
     // Round-trip: MainWorld.Response
     // -----------------------------------------------------------------------
 

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolDefensiveCopyTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolDefensiveCopyTest.java
@@ -61,6 +61,18 @@ class ProtocolDefensiveCopyTest
     }
 
     @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void stackTrace_shouldDefaultToEmptyListWhenServerErrorEntryConstructedWithNull()
+    {
+        // setup + execute
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            0L, "ERROR", "ERROR", "logger", "thread", "message", null, null, null);
+
+        // verify
+        assertThat(entry.stackTrace()).isEmpty();
+    }
+
+    @Test
     void errors_shouldNotExposeGetServerErrorsResponseState()
     {
         // setup
@@ -76,6 +88,17 @@ class ProtocolDefensiveCopyTest
         assertThat(response.errors()).containsExactly(entry);
         assertThatThrownBy(() -> response.errors().add(entry))
             .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void errors_shouldDefaultToEmptyListWhenGetServerErrorsResponseConstructedWithNull()
+    {
+        // setup + execute
+        final GetServerErrors.Response response = new GetServerErrors.Response(null, 0L, true);
+
+        // verify
+        assertThat(response.errors()).isEmpty();
     }
 
     @Test

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolDefensiveCopyTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolDefensiveCopyTest.java
@@ -44,6 +44,41 @@ class ProtocolDefensiveCopyTest
     }
 
     @Test
+    void stackTrace_shouldNotExposeServerErrorEntryState()
+    {
+        // setup
+        final List<String> source = new ArrayList<>(List.of("java.lang.IllegalStateException: boom"));
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            0L, "ERROR", "ERROR", "logger", "thread", "message", null, null, source);
+
+        // execute
+        source.add("\tat net.example.SomePlugin.onEvent(SomePlugin.java:1)");
+
+        // verify
+        assertThat(entry.stackTrace()).containsExactly("java.lang.IllegalStateException: boom");
+        assertThatThrownBy(() -> entry.stackTrace().add("extra"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void errors_shouldNotExposeGetServerErrorsResponseState()
+    {
+        // setup
+        final ServerErrorEntry entry = new ServerErrorEntry(
+            0L, "ERROR", "ERROR", "logger", "thread", "message", null, null, List.of());
+        final List<ServerErrorEntry> source = new ArrayList<>(List.of(entry));
+        final GetServerErrors.Response response = new GetServerErrors.Response(source, 0L, true);
+
+        // execute
+        source.clear();
+
+        // verify
+        assertThat(response.errors()).containsExactly(entry);
+        assertThatThrownBy(() -> response.errors().add(entry))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
     @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
     void response_shouldRejectNullMessages()
     {

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -20,7 +20,7 @@ public final class RuntimeProtocol
      * in a backward-incompatible way. Both the framework and the agent must agree on this value;
      * a mismatch causes an {@code HANDSHAKE} failure.
      */
-    public static final int VERSION = 2;
+    public static final int VERSION = 3;
 
     /**
      * Minecraft server version supported by this LightKeeper build.

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
@@ -55,10 +55,10 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent"
             }
-            """.replace("\"%s\": \"%s\"".formatted(fieldName, defaultValueFor(fieldName)),
+            """.formatted(RuntimeProtocol.VERSION).replace("\"%s\": \"%s\"".formatted(fieldName, defaultValueFor(fieldName)),
             "\"%s\": \"\"".formatted(fieldName));
         Files.writeString(manifestPath, manifestContents);
 
@@ -85,10 +85,10 @@ class RuntimeManifestReaderTest
               "memoryMb": 0,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent"
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION)
         );
 
         // execute + verify
@@ -114,10 +114,10 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 4,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent"
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION + 1)
         );
 
         // execute + verify
@@ -145,7 +145,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {
@@ -156,7 +156,7 @@ class RuntimeManifestReaderTest
                 }
               ]
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION)
         );
 
         // execute + verify
@@ -182,7 +182,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {
@@ -193,7 +193,7 @@ class RuntimeManifestReaderTest
                 }
               ]
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION)
         );
 
         // execute + verify
@@ -219,7 +219,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {
@@ -230,7 +230,7 @@ class RuntimeManifestReaderTest
                 }
               ]
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION)
         );
 
         // execute + verify
@@ -255,10 +255,10 @@ class RuntimeManifestReaderTest
               "serverJar": "/tmp/server/paper.jar",
               "memoryMb": 2048,
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent"
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION)
         );
 
         // execute
@@ -287,10 +287,10 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent"
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION)
         );
 
         // execute
@@ -320,7 +320,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {
@@ -331,7 +331,7 @@ class RuntimeManifestReaderTest
                 }
               ]
             }
-            """
+            """.formatted(RuntimeProtocol.VERSION)
         );
 
         // execute

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
@@ -55,7 +55,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent"
             }
             """.replace("\"%s\": \"%s\"".formatted(fieldName, defaultValueFor(fieldName)),
@@ -85,7 +85,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 0,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent"
             }
             """
@@ -114,7 +114,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 3,
+              "runtimeProtocolVersion": 4,
               "agentCacheIdentity": "no-agent"
             }
             """
@@ -124,8 +124,8 @@ class RuntimeManifestReaderTest
         assertThatThrownBy(() -> new RuntimeManifestReader().read(manifestPath))
             .isInstanceOf(IOException.class)
             .hasMessageContaining("protocol version mismatch")
-            .hasMessageContaining("expected=2")
-            .hasMessageContaining("actual=3");
+            .hasMessageContaining("expected=3")
+            .hasMessageContaining("actual=4");
     }
 
     @Test
@@ -145,7 +145,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {
@@ -182,7 +182,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {
@@ -219,7 +219,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {
@@ -255,7 +255,7 @@ class RuntimeManifestReaderTest
               "serverJar": "/tmp/server/paper.jar",
               "memoryMb": 2048,
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent"
             }
             """
@@ -287,7 +287,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent"
             }
             """
@@ -320,7 +320,7 @@ class RuntimeManifestReaderTest
               "memoryMb": 2048,
               "udsSocketPath": "/tmp/lightkeeper.sock",
               "agentAuthToken": "token",
-              "runtimeProtocolVersion": 2,
+              "runtimeProtocolVersion": 3,
               "agentCacheIdentity": "no-agent",
               "preloadedWorlds": [
                 {

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
@@ -27,7 +27,7 @@ class RuntimeManifestWriterTest
             "auth-token",
             "/tmp/plugins/lightkeeper-agent-spigot.jar",
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-            2,
+            RuntimeProtocol.VERSION,
             "agent-cache-id",
             "-Dfoo=bar",
             List.of(new RuntimeManifest.PreloadedWorld("fixture-world", "NORMAL", "FLAT", 42L))

--- a/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LightkeeperSpigotTestPlugin.java
+++ b/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LightkeeperSpigotTestPlugin.java
@@ -29,6 +29,10 @@ public final class LightkeeperSpigotTestPlugin extends JavaPlugin implements Lis
      */
     private static final String COMMAND_NAME = "lktestgui";
     /**
+     * Command name used to provoke log events for error-capture integration tests.
+     */
+    private static final String ERROR_COMMAND_NAME = "lktesterror";
+    /**
      * Prefix used for deterministic block interaction messages.
      */
     static final String BLOCK_CLICK_MESSAGE_PREFIX = "LK_BLOCK_CLICK";
@@ -48,7 +52,13 @@ public final class LightkeeperSpigotTestPlugin extends JavaPlugin implements Lis
             throw new IllegalStateException(
                 "Required command '/%s' is not declared in plugin metadata.".formatted(COMMAND_NAME));
 
+        final PluginCommand errorCommand = getCommand(ERROR_COMMAND_NAME);
+        if (errorCommand == null)
+            throw new IllegalStateException(
+                "Required command '/%s' is not declared in plugin metadata.".formatted(ERROR_COMMAND_NAME));
+
         pluginCommand.setExecutor(new LkTestGuiCommandExecutor(guiMenuService));
+        errorCommand.setExecutor(new LkTestErrorCommandExecutor(getLogger()));
         Bukkit.getPluginManager().registerEvents(this, this);
     }
 

--- a/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LkTestErrorCommandExecutor.java
+++ b/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LkTestErrorCommandExecutor.java
@@ -1,0 +1,78 @@
+package nl.pim16aap2.lightkeeper.spigot.testplugin;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Handles {@code /lktesterror} command execution for the standalone test plugin.
+ *
+ * <p>Deliberately emits log events at a requested level so integration tests can exercise LightKeeper's
+ * structured server-error capture end-to-end: {@code /lktesterror severe} logs a SEVERE message with an
+ * attached throwable, {@code /lktesterror warning} logs a plain WARNING.
+ */
+final class LkTestErrorCommandExecutor implements CommandExecutor
+{
+    /**
+     * Marker embedded in the SEVERE log message so tests can identify the provoked event.
+     */
+    static final String SEVERE_MESSAGE = "LK_TEST_ERROR provoked severe";
+    /**
+     * Marker embedded in the WARNING log message so tests can identify the provoked event.
+     */
+    static final String WARNING_MESSAGE = "LK_TEST_ERROR provoked warning";
+    /**
+     * Message of the throwable attached to the SEVERE log event.
+     */
+    static final String THROWABLE_MESSAGE = "LK_TEST_ERROR boom";
+    /**
+     * Reply sent for an unknown or missing mode argument.
+     */
+    static final String USAGE_MESSAGE = "Usage: /lktesterror <severe|warning>";
+
+    /**
+     * Logger the provoked events are emitted through.
+     */
+    private final Logger logger;
+
+    /**
+     * @param logger
+     *     Logger to emit the provoked events through (the owning plugin's logger).
+     */
+    LkTestErrorCommandExecutor(Logger logger)
+    {
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    /**
+     * Emits a log event at the requested level.
+     *
+     * @param sender
+     *     Sender that invoked the command.
+     * @param command
+     *     Command metadata.
+     * @param label
+     *     Used command label.
+     * @param args
+     *     Command arguments; the first argument selects the mode ({@code severe} or {@code warning}).
+     * @return
+     *     Always {@code true} because this executor handles all command outcomes directly.
+     */
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
+    {
+        final String mode = args.length == 0 ? "" : args[0].toLowerCase(Locale.ROOT);
+        switch (mode)
+        {
+            case "severe" -> logger.log(Level.SEVERE, SEVERE_MESSAGE, new IllegalStateException(THROWABLE_MESSAGE));
+            case "warning" -> logger.log(Level.WARNING, WARNING_MESSAGE);
+            default -> sender.sendMessage(USAGE_MESSAGE);
+        }
+        return true;
+    }
+}

--- a/lightkeeper-spigot-test-plugin/src/main/resources/plugin.yml
+++ b/lightkeeper-spigot-test-plugin/src/main/resources/plugin.yml
@@ -9,6 +9,9 @@ commands:
   lktestgui:
     description: Opens the standalone LightKeeper integration test GUI
     usage: /lktestgui
+  lktesterror:
+    description: Emits a SEVERE or WARNING log event for LightKeeper error-capture integration tests
+    usage: /lktesterror <severe|warning>
 permissions:
   lightkeeper.testplugin.lktestgui:
     description: Allows opening the LightKeeper test GUI.

--- a/lightkeeper-spigot-test-plugin/src/main/resources/plugin.yml
+++ b/lightkeeper-spigot-test-plugin/src/main/resources/plugin.yml
@@ -16,3 +16,6 @@ permissions:
   lightkeeper.testplugin.lktestgui:
     description: Allows opening the LightKeeper test GUI.
     default: false
+  lightkeeper.testplugin.lktesterror:
+    description: Allows emitting LightKeeper error-capture test log events.
+    default: false

--- a/lightkeeper-spigot-test-plugin/src/test/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LkTestErrorCommandExecutorTest.java
+++ b/lightkeeper-spigot-test-plugin/src/test/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LkTestErrorCommandExecutorTest.java
@@ -1,0 +1,143 @@
+package nl.pim16aap2.lightkeeper.spigot.testplugin;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class LkTestErrorCommandExecutorTest
+{
+    @Test
+    void onCommand_shouldLogSevereWithThrowableWhenModeIsSevere()
+    {
+        // setup
+        final AtomicReference<LogRecord> captured = new AtomicReference<>();
+        final Logger logger = loggerWithHandler(captured);
+        final LkTestErrorCommandExecutor executor = new LkTestErrorCommandExecutor(logger);
+        final CommandSender sender = mock();
+        final Command command = mock();
+
+        // execute
+        final boolean handled = executor.onCommand(sender, command, "lktesterror", new String[]{"severe"});
+
+        // verify
+        assertThat(handled).isTrue();
+        final LogRecord record = Objects.requireNonNull(captured.get(), "record");
+        assertThat(record.getLevel()).isEqualTo(Level.SEVERE);
+        assertThat(record.getMessage()).isEqualTo(LkTestErrorCommandExecutor.SEVERE_MESSAGE);
+        assertThat(record.getThrown())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(LkTestErrorCommandExecutor.THROWABLE_MESSAGE);
+        verifyNoInteractions(sender);
+    }
+
+    @Test
+    void onCommand_shouldLogWarningWithoutThrowableWhenModeIsWarning()
+    {
+        // setup
+        final AtomicReference<LogRecord> captured = new AtomicReference<>();
+        final Logger logger = loggerWithHandler(captured);
+        final LkTestErrorCommandExecutor executor = new LkTestErrorCommandExecutor(logger);
+        final CommandSender sender = mock();
+        final Command command = mock();
+
+        // execute
+        final boolean handled = executor.onCommand(sender, command, "lktesterror", new String[]{"warning"});
+
+        // verify
+        assertThat(handled).isTrue();
+        final LogRecord record = Objects.requireNonNull(captured.get(), "record");
+        assertThat(record.getLevel()).isEqualTo(Level.WARNING);
+        assertThat(record.getMessage()).isEqualTo(LkTestErrorCommandExecutor.WARNING_MESSAGE);
+        assertThat(record.getThrown()).isNull();
+        verifyNoInteractions(sender);
+    }
+
+    @Test
+    void onCommand_shouldBeCaseInsensitiveForMode()
+    {
+        // setup
+        final AtomicReference<LogRecord> captured = new AtomicReference<>();
+        final Logger logger = loggerWithHandler(captured);
+        final LkTestErrorCommandExecutor executor = new LkTestErrorCommandExecutor(logger);
+        final CommandSender sender = mock();
+        final Command command = mock();
+
+        // execute
+        executor.onCommand(sender, command, "lktesterror", new String[]{"SEVERE"});
+
+        // verify
+        assertThat(Objects.requireNonNull(captured.get(), "record").getLevel()).isEqualTo(Level.SEVERE);
+    }
+
+    @Test
+    void onCommand_shouldSendUsageMessageWhenArgsAreEmpty()
+    {
+        // setup
+        final Logger logger = Logger.getLogger(LkTestErrorCommandExecutorTest.class.getName());
+        final LkTestErrorCommandExecutor executor = new LkTestErrorCommandExecutor(logger);
+        final CommandSender sender = mock();
+        final Command command = mock();
+
+        // execute
+        final boolean handled = executor.onCommand(sender, command, "lktesterror", new String[0]);
+
+        // verify
+        assertThat(handled).isTrue();
+        verify(sender).sendMessage(LkTestErrorCommandExecutor.USAGE_MESSAGE);
+    }
+
+    @Test
+    void onCommand_shouldSendUsageMessageWhenModeIsUnrecognized()
+    {
+        // setup
+        final Logger logger = Logger.getLogger(LkTestErrorCommandExecutorTest.class.getName());
+        final LkTestErrorCommandExecutor executor = new LkTestErrorCommandExecutor(logger);
+        final CommandSender sender = mock();
+        final Command command = mock();
+
+        // execute
+        final boolean handled = executor.onCommand(sender, command, "lktesterror", new String[]{"bogus"});
+
+        // verify
+        assertThat(handled).isTrue();
+        verify(sender).sendMessage(LkTestErrorCommandExecutor.USAGE_MESSAGE);
+    }
+
+    private static Logger loggerWithHandler(AtomicReference<LogRecord> captured)
+    {
+        final Logger logger = Logger.getLogger(LkTestErrorCommandExecutorTest.class.getName() + "." + captured.hashCode());
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.ALL);
+        logger.addHandler(new Handler()
+        {
+            @Override
+            public void publish(LogRecord record)
+            {
+                captured.set(record);
+            }
+
+            @Override
+            public void flush()
+            {
+            }
+
+            @Override
+            public void close()
+            {
+            }
+        });
+        return logger;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,9 @@
         <version.jimfs>1.3.1</version.jimfs>
         <version.jspecify>1.0.0</version.jspecify>
         <version.junit>6.0.3</version.junit>
-        <!-- Matches the log4j bundled with the supported Minecraft 1.21 server builds (Paper and Spigot). -->
-        <version.log4j>2.25.2</version.log4j>
+        <!-- Compatible with the log4j bundled with the supported Minecraft 1.21 server builds (Paper and
+             Spigot); kept at the latest 2.25.x patch to stay clear of known log4j-core advisories. -->
+        <version.log4j>2.25.5</version.log4j>
         <version.lombok>1.18.46</version.lombok>
         <version.mockito>5.23.0</version.mockito>
         <version.nullaway>0.13.7</version.nullaway>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
         <version.jimfs>1.3.1</version.jimfs>
         <version.jspecify>1.0.0</version.jspecify>
         <version.junit>6.0.3</version.junit>
+        <!-- Matches the log4j bundled with the supported Minecraft 1.21 server builds (Paper and Spigot). -->
+        <version.log4j>2.25.2</version.log4j>
         <version.lombok>1.18.46</version.lombok>
         <version.mockito>5.23.0</version.mockito>
         <version.nullaway>0.13.7</version.nullaway>


### PR DESCRIPTION
**Why**
- `hasNoServerErrors()` scraped console output with substring matching: false positives (a message merely containing "exception"), no diagnostic context (stack frames dropped by the line filter), and full-log accumulation let one root cause fail every subsequent test's health check.
- Before reaching the console, errors are still structured `LogEvent`s with the real `Throwable` attached — capturing at that layer yields exact class, message, and cause chain.

**How**
- The agent attaches a Log4j appender to the root logger in its new `onLoad()` (before any plugin's `onEnable`, so enable-time errors are caught) plus a `StatusListener` for Log4j-internal failures; WARN+ events are buffered as typed `ServerErrorEntry`s (bounded keep-oldest buffer, dropped counter) and exposed via new `GET_SERVER_ERRORS`/`CLEAR_SERVER_ERRORS` commands (protocol version 2→3).
- `framework.serverErrors()` merges those with stack traces detected on the server's stderr pipe, which is now read separately from stdout: post-boot stderr content has by definition bypassed the logging system (Log4j status logger, JVM-native writes), so provenance replaces console-format heuristics. The buffer auto-clears at the *end* of each test method in shared mode — per-test attribution without hiding boot-window errors from the first test.
- `hasNoServerErrors()` now gates on structured ERROR severity (warnings are buffered but don't gate), gains a `Predicate<ServerErrorSnapshot>` allowlist overload, and renders logger/thread/message plus a capped stack trace per offending error.

Known gaps, documented on `serverErrors()`: exceptions that are caught and never logged, and log events emitted before the agent plugin loads (`serverOutput()` still covers boot).

**Tests**
- `mvn --batch-mode -Perrorprone clean verify checkstyle:checkstyle pmd:check jacoco:report -Dgoal=helpmojo` → BUILD SUCCESS (ErrorProne+NullAway, Checkstyle, PMD all green).
- Integration: 21 ITs per fork (Paper + Spigot), including the new `LightkeeperServerErrorCaptureIT`: SEVERE capture with real throwable metadata, automatic per-method clearing, WARNING bucketing below the gate, manual `clear()`.
- New unit coverage: appender capture through the real Log4j pipeline, buffer cap/drop accounting, stderr stack-trace scanner, handle/assertion behavior, protocol round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured capture of server warnings/errors with typed metadata (severity, message, throwable details, stack traces).
  * Added APIs to retrieve and clear captured server errors, including new agent protocol actions.
  * Added framework assertion support for validating structured server errors, with an allowlist option.
  * Added test commands to generate warning/error log events.
* **Bug Fixes**
  * Improved diagnostics by separating and tracking stdout vs stderr output provenance for more reliable error detection.
* **Tests**
  * Added unit and end-to-end coverage for capture, clearing, lifecycle behavior, and protocol communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->