### PR TITLE
feat: skip parameters and orphan-reaper watchdog (LK-17, LK-19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ runtime, and the framework module provides the API used by your tests.
 </dependencies>
 ```
 
+Both goals support `-Dlightkeeper.skip=true` to disable a whole LightKeeper lane (e.g. per job in a
+CI matrix) without pom changes. Skipping `prepare-server` deletes any stale runtime manifest, so
+integration tests that still run will fail fast instead of using leftover server state; combine
+with `-DskipITs` to skip the tests too.
+
+
 ### Gradle
 
 ```gradle
@@ -156,11 +162,6 @@ dependencies {
             </executions>
         </plugin>
     </plugins>
-
-Both goals support `-Dlightkeeper.skip=true` to disable a whole LightKeeper lane (e.g. per job in a
-CI matrix) without pom changes. Skipping `prepare-server` deletes any stale runtime manifest, so
-integration tests that still run will fail fast instead of using leftover server state; combine
-with `-DskipITs` to skip the tests too.
 
 </build>
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ dependencies {
             </executions>
         </plugin>
     </plugins>
+
+Both goals support `-Dlightkeeper.skip=true` to disable a whole LightKeeper lane (e.g. per job in a
+CI matrix) without pom changes. Skipping `prepare-server` deletes any stale runtime manifest, so
+integration tests that still run will fail fast instead of using leftover server state; combine
+with `-DskipITs` to skip the tests too.
+
 </build>
 
 <dependencies>

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcess.java
@@ -61,6 +61,7 @@ final class MinecraftServerProcess
     private @Nullable Process process;
     private @Nullable Thread outputThread;
     private @Nullable Thread errorThread;
+    private @Nullable Process orphanReaperProcess;
 
     /**
      * A single captured server output line with its file-descriptor provenance.
@@ -110,6 +111,10 @@ final class MinecraftServerProcess
             process = startedProcess;
             outputThread = startedOutputThread;
             errorThread = startedErrorThread;
+            // Safety net for hard kills of this JVM (CI timeout, OOM killer): a separate watchdog
+            // process reaps the server tree. A shutdown hook cannot cover SIGKILL, and the watchdog
+            // detaches into its own session (setsid) so whole-group kills do not take it down too.
+            orphanReaperProcess = OrphanReaperLauncher.launch(ProcessHandle.current().pid(), startedProcess.pid());
             startedOutputThread.start();
             startedErrorThread.start();
             awaitStartupOrFail(startedProcess, startLatch, timeout);
@@ -334,11 +339,27 @@ final class MinecraftServerProcess
     private void clearProcessState(Process completedProcess)
     {
         if (Objects.equals(process, completedProcess) && !completedProcess.isAlive())
+        {
             process = null;
+            stopOrphanReaper();
+        }
         if (outputThread != null && !outputThread.isAlive())
             outputThread = null;
         if (errorThread != null && !errorThread.isAlive())
             errorThread = null;
+    }
+
+    /**
+     * Stops the orphan-reaper watchdog for a server process that is confirmed dead.
+     * <p>
+     * The reaper also exits on its own once it observes the dead server; destroying it here is only for promptness.
+     */
+    private void stopOrphanReaper()
+    {
+        final Process currentOrphanReaperProcess = orphanReaperProcess;
+        orphanReaperProcess = null;
+        if (currentOrphanReaperProcess != null && currentOrphanReaperProcess.isAlive())
+            currentOrphanReaperProcess.destroy();
     }
 
     private void clearStoppedProcessState()

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaper.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaper.java
@@ -96,7 +96,7 @@ public final class OrphanReaper
 
             if (watchedJvm == null || !watchedJvm.isAliveAndSame())
             {
-                killProcessTree(serverProcess.handle());
+                killProcessTree(serverProcess);
                 return;
             }
 
@@ -114,14 +114,19 @@ public final class OrphanReaper
 
     /**
      * Forcibly destroys a process and all of its descendants.
+     * <p>
+     * Re-verifies the process's identity immediately before the kill: the process may exit and its PID be recycled
+     * between the caller's liveness check and this call, and a stranger must never be destroyed.
      *
      * @param root
      *     The root of the process tree to destroy.
      */
-    static void killProcessTree(ProcessHandle root)
+    static void killProcessTree(WatchedProcess root)
     {
-        root.descendants().forEach(ProcessHandle::destroyForcibly);
-        root.destroyForcibly();
+        if (!root.isAliveAndSame())
+            return;
+        root.handle().descendants().forEach(ProcessHandle::destroyForcibly);
+        root.handle().destroyForcibly();
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaper.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaper.java
@@ -1,6 +1,9 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import org.jspecify.annotations.Nullable;
+
 import java.time.Duration;
+import java.time.Instant;
 
 /**
  * Standalone watchdog that force-kills the Minecraft server process tree when the test JVM dies.
@@ -10,13 +13,21 @@ import java.time.Duration;
  * killed test JVM leaks a running Minecraft server that holds the agent socket and the world session lock.
  * <p>
  * The watchdog polls both processes and exits as soon as either side is gone: if the server exits first there is
- * nothing to guard; if the watched (test) JVM exits first, the server process tree is destroyed forcibly.
+ * nothing to guard; if the watched (test) JVM exits first, the server process tree is destroyed forcibly. Process
+ * identity is verified via the process start time where available, so a recycled PID is never mistaken for the
+ * original process (a reused watched-JVM PID would otherwise disable the reap forever; a reused server PID would
+ * get an unrelated process killed).
  * <p>
  * This class must only use JDK classes: it runs with nothing but the framework code location on its classpath.
  */
 public final class OrphanReaper
 {
     static final Duration DEFAULT_POLL_INTERVAL = Duration.ofMillis(500);
+
+    /**
+     * Sentinel for "process start time unknown"; identity checks are skipped for that side when set.
+     */
+    static final long START_INSTANT_UNKNOWN = -1L;
 
     private OrphanReaper()
     {
@@ -26,18 +37,34 @@ public final class OrphanReaper
      * Entry point for the watchdog process.
      *
      * @param args
-     *     Exactly two arguments: the PID of the test JVM to watch and the PID of the server process to reap.
+     *     Exactly four arguments: the PID of the test JVM to watch, its start time in epoch milliseconds (or
+     *     {@code -1} when unknown), the PID of the server process to reap, and its start time in epoch milliseconds
+     *     (or {@code -1} when unknown).
      */
     public static void main(String[] args)
     {
-        if (args.length != 2)
+        if (args.length != 4)
         {
-            System.err.println("Usage: OrphanReaper <watchedJvmPid> <serverPid>");
+            System.err.println(
+                "Usage: OrphanReaper <watchedJvmPid> <watchedJvmStartEpochMillis> <serverPid> <serverStartEpochMillis>"
+            );
             System.exit(2);
+            return;
         }
 
-        final ProcessHandle watchedJvm = ProcessHandle.of(Long.parseLong(args[0])).orElse(null);
-        final ProcessHandle serverProcess = ProcessHandle.of(Long.parseLong(args[1])).orElse(null);
+        runFromArgs(args);
+    }
+
+    /**
+     * Parses the validated arguments and runs the watchdog loop.
+     *
+     * @param args
+     *     The four arguments described on {@link #main(String[])}.
+     */
+    static void runFromArgs(String... args)
+    {
+        final WatchedProcess watchedJvm = WatchedProcess.of(Long.parseLong(args[0]), Long.parseLong(args[1]));
+        final WatchedProcess serverProcess = WatchedProcess.of(Long.parseLong(args[2]), Long.parseLong(args[3]));
 
         // A missing server process means there is nothing to guard. A missing watched JVM means it already died,
         // which run() handles by reaping immediately.
@@ -50,7 +77,7 @@ public final class OrphanReaper
     /**
      * Watches both processes until one of them exits.
      * <p>
-     * Returns when the server process has exited (either on its own, or because this method destroyed it after the
+     * Returns when the server process is gone (either on its own, or because this method destroyed it after the
      * watched JVM died).
      *
      * @param watchedJvm
@@ -60,16 +87,16 @@ public final class OrphanReaper
      * @param pollInterval
      *     How long to sleep between liveness checks.
      */
-    static void run(ProcessHandle watchedJvm, ProcessHandle serverProcess, Duration pollInterval)
+    static void run(@Nullable WatchedProcess watchedJvm, WatchedProcess serverProcess, Duration pollInterval)
     {
         while (true)
         {
-            if (!serverProcess.isAlive())
+            if (!serverProcess.isAliveAndSame())
                 return;
 
-            if (watchedJvm == null || !watchedJvm.isAlive())
+            if (watchedJvm == null || !watchedJvm.isAliveAndSame())
             {
-                killProcessTree(serverProcess);
+                killProcessTree(serverProcess.handle());
                 return;
             }
 
@@ -95,5 +122,65 @@ public final class OrphanReaper
     {
         root.descendants().forEach(ProcessHandle::destroyForcibly);
         root.destroyForcibly();
+    }
+
+    /**
+     * A process handle paired with the start time it is expected to have.
+     *
+     * @param handle
+     *     The handle to the process.
+     * @param expectedStartEpochMillis
+     *     The start time the process had when it was first observed, or {@link #START_INSTANT_UNKNOWN} to skip the
+     *     identity check.
+     */
+    record WatchedProcess(ProcessHandle handle, long expectedStartEpochMillis)
+    {
+        /**
+         * Looks up a process by PID.
+         *
+         * @param pid
+         *     The PID to look up.
+         * @param expectedStartEpochMillis
+         *     The expected start time of the process, or {@link #START_INSTANT_UNKNOWN}.
+         * @return The watched process, or {@code null} when no process with that PID exists.
+         */
+        static @Nullable WatchedProcess of(long pid, long expectedStartEpochMillis)
+        {
+            return ProcessHandle
+                .of(pid)
+                .map(handle -> new WatchedProcess(handle, expectedStartEpochMillis))
+                .orElse(null);
+        }
+
+        /**
+         * Whether the process is alive and still the process it was when first observed.
+         * <p>
+         * A start-time mismatch means the PID was recycled by an unrelated process, which is treated the same as
+         * "the original process is gone". The check is skipped when either side's start time is unknown.
+         *
+         * @return {@code true} when the process is alive and its identity matches.
+         */
+        boolean isAliveAndSame()
+        {
+            if (!handle.isAlive())
+                return false;
+            if (expectedStartEpochMillis == START_INSTANT_UNKNOWN)
+                return true;
+            final long actualStartEpochMillis = startEpochMillis(handle);
+            return actualStartEpochMillis == START_INSTANT_UNKNOWN
+                || actualStartEpochMillis == expectedStartEpochMillis;
+        }
+
+        /**
+         * Reads a process's start time.
+         *
+         * @param handle
+         *     The process to read.
+         * @return The start time in epoch milliseconds, or {@link #START_INSTANT_UNKNOWN} when unavailable.
+         */
+        static long startEpochMillis(ProcessHandle handle)
+        {
+            return handle.info().startInstant().map(Instant::toEpochMilli).orElse(START_INSTANT_UNKNOWN);
+        }
     }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaper.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaper.java
@@ -1,0 +1,99 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import java.time.Duration;
+
+/**
+ * Standalone watchdog that force-kills the Minecraft server process tree when the test JVM dies.
+ * <p>
+ * This class runs as its own JVM process (see {@link OrphanReaperLauncher}) so that it survives a hard kill of the
+ * test JVM (CI timeout, OOM killer, {@code kill -9}) — the one case a JVM shutdown hook cannot cover. Without it, a
+ * killed test JVM leaks a running Minecraft server that holds the agent socket and the world session lock.
+ * <p>
+ * The watchdog polls both processes and exits as soon as either side is gone: if the server exits first there is
+ * nothing to guard; if the watched (test) JVM exits first, the server process tree is destroyed forcibly.
+ * <p>
+ * This class must only use JDK classes: it runs with nothing but the framework code location on its classpath.
+ */
+public final class OrphanReaper
+{
+    static final Duration DEFAULT_POLL_INTERVAL = Duration.ofMillis(500);
+
+    private OrphanReaper()
+    {
+    }
+
+    /**
+     * Entry point for the watchdog process.
+     *
+     * @param args
+     *     Exactly two arguments: the PID of the test JVM to watch and the PID of the server process to reap.
+     */
+    public static void main(String[] args)
+    {
+        if (args.length != 2)
+        {
+            System.err.println("Usage: OrphanReaper <watchedJvmPid> <serverPid>");
+            System.exit(2);
+        }
+
+        final ProcessHandle watchedJvm = ProcessHandle.of(Long.parseLong(args[0])).orElse(null);
+        final ProcessHandle serverProcess = ProcessHandle.of(Long.parseLong(args[1])).orElse(null);
+
+        // A missing server process means there is nothing to guard. A missing watched JVM means it already died,
+        // which run() handles by reaping immediately.
+        if (serverProcess == null)
+            return;
+
+        run(watchedJvm, serverProcess, DEFAULT_POLL_INTERVAL);
+    }
+
+    /**
+     * Watches both processes until one of them exits.
+     * <p>
+     * Returns when the server process has exited (either on its own, or because this method destroyed it after the
+     * watched JVM died).
+     *
+     * @param watchedJvm
+     *     The test JVM to watch. When {@code null} or dead, the server process tree is destroyed immediately.
+     * @param serverProcess
+     *     The server process to reap.
+     * @param pollInterval
+     *     How long to sleep between liveness checks.
+     */
+    static void run(ProcessHandle watchedJvm, ProcessHandle serverProcess, Duration pollInterval)
+    {
+        while (true)
+        {
+            if (!serverProcess.isAlive())
+                return;
+
+            if (watchedJvm == null || !watchedJvm.isAlive())
+            {
+                killProcessTree(serverProcess);
+                return;
+            }
+
+            try
+            {
+                Thread.sleep(pollInterval.toMillis());
+            }
+            catch (InterruptedException exception)
+            {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    /**
+     * Forcibly destroys a process and all of its descendants.
+     *
+     * @param root
+     *     The root of the process tree to destroy.
+     */
+    static void killProcessTree(ProcessHandle root)
+    {
+        root.descendants().forEach(ProcessHandle::destroyForcibly);
+        root.destroyForcibly();
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
@@ -112,10 +112,12 @@ final class OrphanReaperLauncher
 
     /**
      * Locates a usable {@code setsid} executable for session detachment, if any.
+     * <p>
+     * Package-private so tests can gate session-detachment assertions on the same discovery logic.
      *
      * @return The path to {@code setsid}, or {@code null} when not available on this system.
      */
-    private static @Nullable Path findSetsid()
+    static @Nullable Path findSetsid()
     {
         for (final Path candidate : SETSID_CANDIDATES)
         {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
@@ -2,11 +2,21 @@ package nl.pim16aap2.lightkeeper.framework.internal;
 
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Launches the {@link OrphanReaper} watchdog process for a started Minecraft server.
+ * <p>
+ * On POSIX systems the watchdog is detached into its own session via {@code setsid} when available. This matters
+ * because CI harnesses (e.g. GNU {@code timeout}) commonly kill the whole process group on timeout — a watchdog in
+ * the test JVM's process group would die in the same blast radius it is meant to survive. Without {@code setsid}
+ * (e.g. on Windows), the watchdog still covers single-PID kills of the test JVM (targeted OOM kill, {@code kill -9}),
+ * just not whole-group kills.
  * <p>
  * Launch failures are logged and swallowed: the reaper is a safety net, not a prerequisite — a missing watchdog must
  * never fail a test run that would otherwise work.
@@ -15,12 +25,21 @@ final class OrphanReaperLauncher
 {
     private static final System.Logger LOG = System.getLogger(OrphanReaperLauncher.class.getName());
 
+    private static final List<Path> SETSID_CANDIDATES = List.of(
+        Path.of("/usr/bin/setsid"),
+        Path.of("/bin/setsid")
+    );
+
     private OrphanReaperLauncher()
     {
     }
 
     /**
      * Starts a watchdog process that kills the given server process tree when the given JVM dies.
+     * <p>
+     * Note: when the watchdog is wrapped in {@code setsid}, the returned process may be the (short-lived) wrapper
+     * rather than the watchdog itself. That is fine for the eager-destroy use case: the watchdog always exits on its
+     * own once it observes the dead server.
      *
      * @param watchedJvmPid
      *     The PID of the JVM whose death should trigger the reap (in production: the current test JVM).
@@ -35,26 +54,33 @@ final class OrphanReaperLauncher
             return null;
 
         final Path javaExecutable = Path.of(System.getProperty("java.home"), "bin", "java");
-        final ProcessBuilder processBuilder = new ProcessBuilder(
-            javaExecutable.toString(),
-            "-Xms16m",
-            "-Xmx32m",
-            "-cp",
-            codeLocation.toString(),
-            OrphanReaper.class.getName(),
-            Long.toString(watchedJvmPid),
-            Long.toString(serverPid)
-        );
+        final List<String> command = new ArrayList<>();
+        final Path setsid = findSetsid();
+        if (setsid != null)
+            command.add(setsid.toString());
+        command.add(javaExecutable.toString());
+        command.add("-Xms16m");
+        command.add("-Xmx32m");
+        command.add("-cp");
+        command.add(codeLocation.toString());
+        command.add(OrphanReaper.class.getName());
+        command.add(Long.toString(watchedJvmPid));
+        command.add(Long.toString(startEpochMillisOf(watchedJvmPid)));
+        command.add(Long.toString(serverPid));
+        command.add(Long.toString(startEpochMillisOf(serverPid)));
+
+        final ProcessBuilder processBuilder = new ProcessBuilder(command);
         processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
         processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
 
         try
         {
             final Process process = processBuilder.start();
+            closeUnusedStdin(process);
             LOG.log(
                 System.Logger.Level.DEBUG,
-                "Started orphan reaper (pid {0}) watching JVM {1}, guarding server {2}.",
-                process.pid(), watchedJvmPid, serverPid
+                "Started orphan reaper (pid {0}, setsid: {1}) watching JVM {2}, guarding server {3}.",
+                process.pid(), setsid != null, watchedJvmPid, serverPid
             );
             return process;
         }
@@ -66,6 +92,54 @@ final class OrphanReaperLauncher
                 exception
             );
             return null;
+        }
+    }
+
+    /**
+     * Reads a process's start time for the PID-identity check in the watchdog.
+     *
+     * @param pid
+     *     The PID whose start time to read.
+     * @return The start time in epoch milliseconds, or {@link OrphanReaper#START_INSTANT_UNKNOWN} when unavailable.
+     */
+    private static long startEpochMillisOf(long pid)
+    {
+        return ProcessHandle
+            .of(pid)
+            .map(OrphanReaper.WatchedProcess::startEpochMillis)
+            .orElse(OrphanReaper.START_INSTANT_UNKNOWN);
+    }
+
+    /**
+     * Locates a usable {@code setsid} executable for session detachment, if any.
+     *
+     * @return The path to {@code setsid}, or {@code null} when not available on this system.
+     */
+    private static @Nullable Path findSetsid()
+    {
+        for (final Path candidate : SETSID_CANDIDATES)
+        {
+            if (Files.isExecutable(candidate))
+                return candidate;
+        }
+        return null;
+    }
+
+    /**
+     * Closes the never-used stdin pipe to the watchdog; the other streams are already discarded.
+     *
+     * @param process
+     *     The started watchdog process.
+     */
+    private static void closeUnusedStdin(Process process)
+    {
+        try
+        {
+            process.getOutputStream().close();
+        }
+        catch (IOException exception)
+        {
+            LOG.log(System.Logger.Level.DEBUG, "Failed to close the orphan reaper's stdin pipe.", exception);
         }
     }
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
@@ -1,0 +1,102 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import org.jspecify.annotations.Nullable;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+/**
+ * Launches the {@link OrphanReaper} watchdog process for a started Minecraft server.
+ * <p>
+ * Launch failures are logged and swallowed: the reaper is a safety net, not a prerequisite — a missing watchdog must
+ * never fail a test run that would otherwise work.
+ */
+final class OrphanReaperLauncher
+{
+    private static final System.Logger LOG = System.getLogger(OrphanReaperLauncher.class.getName());
+
+    private OrphanReaperLauncher()
+    {
+    }
+
+    /**
+     * Starts a watchdog process that kills the given server process tree when the given JVM dies.
+     *
+     * @param watchedJvmPid
+     *     The PID of the JVM whose death should trigger the reap (in production: the current test JVM).
+     * @param serverPid
+     *     The PID of the Minecraft server process to reap.
+     * @return The started watchdog process, or {@code null} if it could not be started.
+     */
+    static @Nullable Process launch(long watchedJvmPid, long serverPid)
+    {
+        final Path codeLocation = resolveCodeLocation();
+        if (codeLocation == null)
+            return null;
+
+        final Path javaExecutable = Path.of(System.getProperty("java.home"), "bin", "java");
+        final ProcessBuilder processBuilder = new ProcessBuilder(
+            javaExecutable.toString(),
+            "-Xms16m",
+            "-Xmx32m",
+            "-cp",
+            codeLocation.toString(),
+            OrphanReaper.class.getName(),
+            Long.toString(watchedJvmPid),
+            Long.toString(serverPid)
+        );
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+        processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+
+        try
+        {
+            final Process process = processBuilder.start();
+            LOG.log(
+                System.Logger.Level.DEBUG,
+                "Started orphan reaper (pid {0}) watching JVM {1}, guarding server {2}.",
+                process.pid(), watchedJvmPid, serverPid
+            );
+            return process;
+        }
+        catch (Exception exception)
+        {
+            LOG.log(
+                System.Logger.Level.WARNING,
+                "Failed to start the orphan reaper; a killed test JVM may leak the Minecraft server process.",
+                exception
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Resolves the classpath entry (jar or classes directory) that contains {@link OrphanReaper}.
+     *
+     * @return The code location, or {@code null} when it cannot be determined (e.g. exotic classloaders).
+     */
+    private static @Nullable Path resolveCodeLocation()
+    {
+        try
+        {
+            final var codeSource = OrphanReaper.class.getProtectionDomain().getCodeSource();
+            if (codeSource == null || codeSource.getLocation() == null)
+            {
+                LOG.log(
+                    System.Logger.Level.WARNING,
+                    "Cannot determine the code location of the orphan reaper; skipping watchdog startup."
+                );
+                return null;
+            }
+            return Path.of(codeSource.getLocation().toURI());
+        }
+        catch (URISyntaxException | RuntimeException exception)
+        {
+            LOG.log(
+                System.Logger.Level.WARNING,
+                "Failed to resolve the code location of the orphan reaper; skipping watchdog startup.",
+                exception
+            );
+            return null;
+        }
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperLauncher.java
@@ -124,6 +124,19 @@ final class OrphanReaperLauncher
             if (Files.isExecutable(candidate))
                 return candidate;
         }
+
+        // Fall back to a PATH scan for container images with non-standard layouts.
+        final String pathEnvironment = System.getenv("PATH");
+        if (pathEnvironment == null || pathEnvironment.isBlank())
+            return null;
+        for (final String entry : pathEnvironment.split(java.io.File.pathSeparator, -1))
+        {
+            if (entry.isBlank())
+                continue;
+            final Path candidate = Path.of(entry).resolve("setsid");
+            if (Files.isExecutable(candidate))
+                return candidate;
+        }
         return null;
     }
 

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
@@ -68,6 +68,31 @@ class MinecraftServerProcessTest
     }
 
     @Test
+    void kill_shouldDestroyOrphanReaperWhenServerIsConfirmedDead(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final MinecraftServerProcess serverProcess = new MinecraftServerProcess(
+            runtimeManifest(tempDirectory),
+            tempDirectory.resolve("diagnostics")
+        );
+        final Process process = mock();
+        final Process orphanReaperProcess = mock();
+        when(process.isAlive()).thenReturn(true, false);
+        when(process.waitFor(5_000L, TimeUnit.MILLISECONDS)).thenReturn(true);
+        when(orphanReaperProcess.isAlive()).thenReturn(true);
+        setField(serverProcess, "process", process);
+        setField(serverProcess, "orphanReaperProcess", orphanReaperProcess);
+
+        // execute
+        serverProcess.kill();
+
+        // verify
+        verify(orphanReaperProcess).destroy();
+        assertThat(getField(serverProcess, "orphanReaperProcess")).isNull();
+    }
+
+    @Test
     void stop_shouldForceKillAndThrowWhenProcessSurvivesShutdownFailure(@TempDir Path tempDirectory)
         throws Exception
     {

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperTest.java
@@ -144,15 +144,30 @@ class OrphanReaperTest
         final ProcessHandle root = mock();
         final ProcessHandle childA = mock();
         final ProcessHandle childB = mock();
+        when(root.isAlive()).thenReturn(true);
         when(root.descendants()).thenReturn(Stream.of(childA, childB));
 
         // execute
-        OrphanReaper.killProcessTree(root);
+        OrphanReaper.killProcessTree(anyIdentity(root));
 
         // verify
         verify(childA).destroyForcibly();
         verify(childB).destroyForcibly();
         verify(root).destroyForcibly();
+    }
+
+    @Test
+    void killProcessTree_shouldNotKillWhenIdentityWasLostSinceLastCheck()
+    {
+        // setup
+        // The PID may be recycled between the caller's liveness check and the kill; never destroy a stranger.
+        final ProcessHandle root = aliveHandleWithStartMillis(9_999L);
+
+        // execute
+        OrphanReaper.killProcessTree(new WatchedProcess(root, 1_234L));
+
+        // verify
+        verify(root, never()).destroyForcibly();
     }
 
     @Test
@@ -221,7 +236,7 @@ class OrphanReaperTest
         // setup
         // Whole-group kills (e.g. GNU timeout in CI) must not take the reaper down with the test JVM.
         org.junit.jupiter.api.Assumptions.assumeTrue(
-            java.nio.file.Files.isExecutable(Path.of("/usr/bin/setsid")),
+            OrphanReaperLauncher.findSetsid() != null,
             "setsid not available; session detachment is best-effort on this platform");
         final Process fakeServer = startHelperJvm(LongLivedMain.class);
 
@@ -394,6 +409,11 @@ class OrphanReaperTest
     {
         final Process shortLived = startHelperJvm(ShortLivedMain.class);
         shortLived.waitFor(10, java.util.concurrent.TimeUnit.SECONDS);
+        // On a PID-churning system the freed PID could already belong to a new process; the tests using
+        // this helper assume a dead PID, so skip rather than flake in that (rare) case.
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+            ProcessHandle.of(shortLived.pid()).isEmpty(),
+            "freed PID was immediately reused on this system");
         return shortLived.pid();
     }
 

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import nl.pim16aap2.lightkeeper.framework.internal.OrphanReaper.WatchedProcess;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,6 +10,8 @@ import org.mockito.quality.Strictness;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +35,7 @@ class OrphanReaperTest
         when(serverProcess.isAlive()).thenReturn(false);
 
         // execute
-        OrphanReaper.run(watchedJvm, serverProcess, TEST_POLL_INTERVAL);
+        OrphanReaper.run(anyIdentity(watchedJvm), anyIdentity(serverProcess), TEST_POLL_INTERVAL);
 
         // verify
         verify(serverProcess, never()).destroyForcibly();
@@ -50,7 +53,7 @@ class OrphanReaperTest
         when(serverProcess.descendants()).thenReturn(Stream.of(serverChild));
 
         // execute
-        OrphanReaper.run(watchedJvm, serverProcess, TEST_POLL_INTERVAL);
+        OrphanReaper.run(anyIdentity(watchedJvm), anyIdentity(serverProcess), TEST_POLL_INTERVAL);
 
         // verify
         verify(serverChild).destroyForcibly();
@@ -66,7 +69,7 @@ class OrphanReaperTest
         when(serverProcess.descendants()).thenReturn(Stream.empty());
 
         // execute
-        OrphanReaper.run(null, serverProcess, TEST_POLL_INTERVAL);
+        OrphanReaper.run(null, anyIdentity(serverProcess), TEST_POLL_INTERVAL);
 
         // verify
         verify(serverProcess).destroyForcibly();
@@ -83,10 +86,55 @@ class OrphanReaperTest
         when(serverProcess.descendants()).thenReturn(Stream.empty());
 
         // execute
-        OrphanReaper.run(watchedJvm, serverProcess, TEST_POLL_INTERVAL);
+        OrphanReaper.run(anyIdentity(watchedJvm), anyIdentity(serverProcess), TEST_POLL_INTERVAL);
 
         // verify
         verify(serverProcess).destroyForcibly();
+    }
+
+    @Test
+    void run_shouldKillServerWhenWatchedJvmPidWasReused()
+    {
+        // setup
+        // The watched PID is alive but belongs to a different (recycled) process: treat as dead and reap.
+        final ProcessHandle watchedJvm = aliveHandleWithStartMillis(9_999L);
+        final ProcessHandle serverProcess = mock();
+        when(serverProcess.isAlive()).thenReturn(true);
+        when(serverProcess.descendants()).thenReturn(Stream.empty());
+
+        // execute
+        OrphanReaper.run(
+            new WatchedProcess(watchedJvm, 1_234L),
+            anyIdentity(serverProcess),
+            TEST_POLL_INTERVAL
+        );
+
+        // verify
+        verify(serverProcess).destroyForcibly();
+    }
+
+    @Test
+    void run_shouldNotKillWhenServerPidWasReused()
+    {
+        // setup
+        // The server PID is alive but belongs to a different (recycled) process: never kill a stranger.
+        final ProcessHandle serverProcess = aliveHandleWithStartMillis(9_999L);
+
+        // execute
+        OrphanReaper.run(null, new WatchedProcess(serverProcess, 1_234L), TEST_POLL_INTERVAL);
+
+        // verify
+        verify(serverProcess, never()).destroyForcibly();
+    }
+
+    @Test
+    void isAliveAndSame_shouldAcceptMatchingStartInstant()
+    {
+        // setup
+        final ProcessHandle handle = aliveHandleWithStartMillis(1_234L);
+
+        // execute + verify
+        assertThat(new WatchedProcess(handle, 1_234L).isAliveAndSame()).isTrue();
     }
 
     @Test
@@ -130,9 +178,6 @@ class OrphanReaperTest
             assertThat(fakeServer.waitFor(15, java.util.concurrent.TimeUnit.SECONDS))
                 .as("the reaper should kill the fake server once the fake test JVM died")
                 .isTrue();
-            assertThat(reaper.waitFor(10, java.util.concurrent.TimeUnit.SECONDS))
-                .as("the reaper should exit once the server is gone")
-                .isTrue();
         }
         finally
         {
@@ -161,17 +206,210 @@ class OrphanReaperTest
             assertThat(fakeServer.isAlive())
                 .as("the server must not be reaped while the watched JVM is alive")
                 .isTrue();
-
-            // Once the server dies on its own, the reaper should follow.
-            fakeServer.destroyForcibly();
-            assertThat(reaper.waitFor(10, java.util.concurrent.TimeUnit.SECONDS))
-                .as("the reaper should exit once the server is gone")
-                .isTrue();
         }
         finally
         {
             fakeServer.destroyForcibly();
         }
+    }
+
+    @Test
+    @Timeout(30)
+    void launch_shouldDetachReaperIntoItsOwnProcessGroup()
+        throws Exception
+    {
+        // setup
+        // Whole-group kills (e.g. GNU timeout in CI) must not take the reaper down with the test JVM.
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+            java.nio.file.Files.isExecutable(Path.of("/usr/bin/setsid")),
+            "setsid not available; session detachment is best-effort on this platform");
+        final Process fakeServer = startHelperJvm(LongLivedMain.class);
+
+        try
+        {
+            // execute
+            final Process reaper = OrphanReaperLauncher.launch(ProcessHandle.current().pid(), fakeServer.pid());
+
+            // verify
+            assertThat(reaper).isNotNull();
+            final long ownProcessGroup = readProcessGroup(ProcessHandle.current().pid());
+            final long reaperProcessGroup = readProcessGroup(reaper.pid());
+            assertThat(reaperProcessGroup)
+                .as("the reaper must not share the test JVM's process group")
+                .isNotEqualTo(ownProcessGroup);
+        }
+        finally
+        {
+            fakeServer.destroyForcibly();
+        }
+    }
+
+    /** Reads field 5 (pgrp) of /proc/[pid]/stat; only called when setsid exists, i.e. on Linux-like systems. */
+    private static long readProcessGroup(long pid)
+        throws Exception
+    {
+        final String stat = java.nio.file.Files.readString(Path.of("/proc/" + pid + "/stat"));
+        // The comm field (2) is parenthesized and may contain spaces; parse from after the closing paren.
+        // pgrp is the third space-separated token after the comm field.
+        final String afterComm = stat.substring(stat.lastIndexOf(')') + 2);
+        int start = 0;
+        for (int skippedTokens = 0; skippedTokens < 2; ++skippedTokens)
+            start = afterComm.indexOf(' ', start) + 1;
+        return Long.parseLong(afterComm.substring(start, afterComm.indexOf(' ', start)));
+    }
+
+    @Test
+    void run_shouldReturnAndRestoreInterruptFlagWhenInterrupted()
+        throws Exception
+    {
+        // setup
+        final ProcessHandle watchedJvm = mock();
+        final ProcessHandle serverProcess = mock();
+        when(serverProcess.isAlive()).thenReturn(true);
+        when(watchedJvm.isAlive()).thenReturn(true);
+        final java.util.concurrent.atomic.AtomicBoolean interruptRestored =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+        final Thread reaperThread = Thread.ofPlatform().unstarted(() ->
+        {
+            OrphanReaper.run(anyIdentity(watchedJvm), anyIdentity(serverProcess), Duration.ofSeconds(30));
+            interruptRestored.set(Thread.currentThread().isInterrupted());
+        });
+
+        // execute
+        reaperThread.start();
+        Thread.sleep(100);
+        reaperThread.interrupt();
+        reaperThread.join(5_000);
+
+        // verify
+        assertThat(reaperThread.isAlive()).isFalse();
+        assertThat(interruptRestored).isTrue();
+        verify(serverProcess, never()).destroyForcibly();
+    }
+
+    @Test
+    void isAliveAndSame_shouldAcceptWhenActualStartInstantIsUnavailable()
+    {
+        // setup
+        final ProcessHandle handle = mock();
+        final ProcessHandle.Info info = mock();
+        when(handle.isAlive()).thenReturn(true);
+        when(handle.info()).thenReturn(info);
+        when(info.startInstant()).thenReturn(Optional.empty());
+
+        // execute + verify
+        assertThat(new WatchedProcess(handle, 1_234L).isAliveAndSame()).isTrue();
+    }
+
+    @Test
+    @Timeout(30)
+    void runFromArgs_shouldReturnImmediatelyWhenServerProcessDoesNotExist()
+        throws Exception
+    {
+        // setup
+        final long freedPid = exitedProcessPid();
+
+        // execute + verify — returns without looping because there is nothing to guard
+        OrphanReaper.runFromArgs(new String[]{
+            Long.toString(ProcessHandle.current().pid()),
+            Long.toString(OrphanReaper.START_INSTANT_UNKNOWN),
+            Long.toString(freedPid),
+            Long.toString(OrphanReaper.START_INSTANT_UNKNOWN),
+        });
+    }
+
+    @Test
+    @Timeout(30)
+    void runFromArgs_shouldWatchUntilServerExits()
+        throws Exception
+    {
+        // setup
+        final Process fakeServer = startHelperJvm(ShortLivedMain.class);
+
+        try
+        {
+            // execute — blocks while the short-lived server is alive, then returns on its own
+            OrphanReaper.runFromArgs(new String[]{
+                Long.toString(ProcessHandle.current().pid()),
+                Long.toString(WatchedProcess.startEpochMillis(ProcessHandle.current())),
+                Long.toString(fakeServer.pid()),
+                Long.toString(WatchedProcess.startEpochMillis(fakeServer.toHandle())),
+            });
+
+            // verify
+            assertThat(fakeServer.isAlive()).isFalse();
+        }
+        finally
+        {
+            fakeServer.destroyForcibly();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void main_shouldExitWithCodeTwoWhenArgumentCountIsWrong()
+        throws Exception
+    {
+        // setup
+        final Path javaExecutable = Path.of(System.getProperty("java.home"), "bin", "java");
+        final Path mainClasses =
+            Path.of(OrphanReaper.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        final ProcessBuilder processBuilder = new ProcessBuilder(
+            javaExecutable.toString(),
+            "-cp",
+            mainClasses.toString(),
+            OrphanReaper.class.getName(),
+            "only-one-argument"
+        );
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+        processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+
+        // execute
+        final Process reaper = processBuilder.start();
+
+        // verify
+        assertThat(reaper.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        assertThat(reaper.exitValue()).isEqualTo(2);
+    }
+
+    @Test
+    @Timeout(30)
+    void launch_shouldStillLaunchWhenServerPidDoesNotExist()
+        throws Exception
+    {
+        // setup
+        final long freedPid = exitedProcessPid();
+
+        // execute
+        final Process reaper = OrphanReaperLauncher.launch(ProcessHandle.current().pid(), freedPid);
+
+        // verify — the reaper starts and exits on its own since there is nothing to guard
+        assertThat(reaper).isNotNull();
+        assertThat(reaper.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+    }
+
+    /** Returns the PID of a process that has already exited, i.e. a PID with no live process behind it. */
+    private static long exitedProcessPid()
+        throws Exception
+    {
+        final Process shortLived = startHelperJvm(ShortLivedMain.class);
+        shortLived.waitFor(10, java.util.concurrent.TimeUnit.SECONDS);
+        return shortLived.pid();
+    }
+
+    private static WatchedProcess anyIdentity(ProcessHandle handle)
+    {
+        return new WatchedProcess(handle, OrphanReaper.START_INSTANT_UNKNOWN);
+    }
+
+    private static ProcessHandle aliveHandleWithStartMillis(long startEpochMillis)
+    {
+        final ProcessHandle handle = mock();
+        final ProcessHandle.Info info = mock();
+        when(handle.isAlive()).thenReturn(true);
+        when(handle.info()).thenReturn(info);
+        when(info.startInstant()).thenReturn(Optional.of(Instant.ofEpochMilli(startEpochMillis)));
+        return handle;
     }
 
     private static Process startHelperJvm(Class<?> mainClass)

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/OrphanReaperTest.java
@@ -1,0 +1,215 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class OrphanReaperTest
+{
+    private static final Duration TEST_POLL_INTERVAL = Duration.ofMillis(10);
+
+    @Test
+    void run_shouldReturnWithoutKillingWhenServerAlreadyExited()
+    {
+        // setup
+        final ProcessHandle watchedJvm = mock();
+        final ProcessHandle serverProcess = mock();
+        when(serverProcess.isAlive()).thenReturn(false);
+
+        // execute
+        OrphanReaper.run(watchedJvm, serverProcess, TEST_POLL_INTERVAL);
+
+        // verify
+        verify(serverProcess, never()).destroyForcibly();
+    }
+
+    @Test
+    void run_shouldKillServerTreeWhenWatchedJvmIsDead()
+    {
+        // setup
+        final ProcessHandle watchedJvm = mock();
+        final ProcessHandle serverProcess = mock();
+        final ProcessHandle serverChild = mock();
+        when(watchedJvm.isAlive()).thenReturn(false);
+        when(serverProcess.isAlive()).thenReturn(true);
+        when(serverProcess.descendants()).thenReturn(Stream.of(serverChild));
+
+        // execute
+        OrphanReaper.run(watchedJvm, serverProcess, TEST_POLL_INTERVAL);
+
+        // verify
+        verify(serverChild).destroyForcibly();
+        verify(serverProcess).destroyForcibly();
+    }
+
+    @Test
+    void run_shouldKillServerTreeWhenWatchedJvmIsNull()
+    {
+        // setup
+        final ProcessHandle serverProcess = mock();
+        when(serverProcess.isAlive()).thenReturn(true);
+        when(serverProcess.descendants()).thenReturn(Stream.empty());
+
+        // execute
+        OrphanReaper.run(null, serverProcess, TEST_POLL_INTERVAL);
+
+        // verify
+        verify(serverProcess).destroyForcibly();
+    }
+
+    @Test
+    void run_shouldKeepWaitingWhileBothProcessesAreAlive()
+    {
+        // setup
+        final ProcessHandle watchedJvm = mock();
+        final ProcessHandle serverProcess = mock();
+        when(serverProcess.isAlive()).thenReturn(true, true, true);
+        when(watchedJvm.isAlive()).thenReturn(true, true, false);
+        when(serverProcess.descendants()).thenReturn(Stream.empty());
+
+        // execute
+        OrphanReaper.run(watchedJvm, serverProcess, TEST_POLL_INTERVAL);
+
+        // verify
+        verify(serverProcess).destroyForcibly();
+    }
+
+    @Test
+    void killProcessTree_shouldDestroyDescendantsAndRoot()
+    {
+        // setup
+        final ProcessHandle root = mock();
+        final ProcessHandle childA = mock();
+        final ProcessHandle childB = mock();
+        when(root.descendants()).thenReturn(Stream.of(childA, childB));
+
+        // execute
+        OrphanReaper.killProcessTree(root);
+
+        // verify
+        verify(childA).destroyForcibly();
+        verify(childB).destroyForcibly();
+        verify(root).destroyForcibly();
+    }
+
+    @Test
+    @Timeout(30)
+    void launch_shouldReapServerProcessWhenWatchedJvmDies()
+        throws Exception
+    {
+        // setup
+        // Real end-to-end: a short-lived JVM plays the test JVM, a long-lived JVM plays the server.
+        final Process fakeTestJvm = startHelperJvm(ShortLivedMain.class);
+        final Process fakeServer = startHelperJvm(LongLivedMain.class);
+
+        try
+        {
+            // execute
+            final Process reaper = OrphanReaperLauncher.launch(fakeTestJvm.pid(), fakeServer.pid());
+
+            // verify
+            assertThat(reaper).isNotNull();
+            assertThat(fakeTestJvm.waitFor(10, java.util.concurrent.TimeUnit.SECONDS))
+                .as("the fake test JVM should exit on its own")
+                .isTrue();
+            assertThat(fakeServer.waitFor(15, java.util.concurrent.TimeUnit.SECONDS))
+                .as("the reaper should kill the fake server once the fake test JVM died")
+                .isTrue();
+            assertThat(reaper.waitFor(10, java.util.concurrent.TimeUnit.SECONDS))
+                .as("the reaper should exit once the server is gone")
+                .isTrue();
+        }
+        finally
+        {
+            fakeTestJvm.destroyForcibly();
+            fakeServer.destroyForcibly();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void launch_shouldLeaveServerAloneWhileWatchedJvmIsAlive()
+        throws Exception
+    {
+        // setup
+        // This JVM plays the watched test JVM, so the server must not be reaped.
+        final Process fakeServer = startHelperJvm(LongLivedMain.class);
+
+        try
+        {
+            // execute
+            final Process reaper = OrphanReaperLauncher.launch(ProcessHandle.current().pid(), fakeServer.pid());
+
+            // verify
+            assertThat(reaper).isNotNull();
+            Thread.sleep(2_000);
+            assertThat(fakeServer.isAlive())
+                .as("the server must not be reaped while the watched JVM is alive")
+                .isTrue();
+
+            // Once the server dies on its own, the reaper should follow.
+            fakeServer.destroyForcibly();
+            assertThat(reaper.waitFor(10, java.util.concurrent.TimeUnit.SECONDS))
+                .as("the reaper should exit once the server is gone")
+                .isTrue();
+        }
+        finally
+        {
+            fakeServer.destroyForcibly();
+        }
+    }
+
+    private static Process startHelperJvm(Class<?> mainClass)
+        throws Exception
+    {
+        final Path javaExecutable = Path.of(System.getProperty("java.home"), "bin", "java");
+        final Path testClasses =
+            Path.of(OrphanReaperTest.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        final ProcessBuilder processBuilder = new ProcessBuilder(
+            javaExecutable.toString(),
+            "-Xms16m",
+            "-Xmx32m",
+            "-cp",
+            testClasses.toString(),
+            mainClass.getName()
+        );
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+        processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+        return processBuilder.start();
+    }
+
+    /** Helper main that exits quickly, simulating a test JVM that died. */
+    public static final class ShortLivedMain
+    {
+        public static void main(String[] args)
+            throws InterruptedException
+        {
+            Thread.sleep(500);
+        }
+    }
+
+    /** Helper main that lives long enough to require reaping, simulating a leaked server. */
+    public static final class LongLivedMain
+    {
+        public static void main(String[] args)
+            throws InterruptedException
+        {
+            Thread.sleep(120_000);
+        }
+    }
+}

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/cleanupserver/CleanupServerMojo.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/cleanupserver/CleanupServerMojo.java
@@ -23,6 +23,13 @@ import java.util.Objects;
 @Mojo(name = "cleanup-server", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
 public final class CleanupServerMojo extends AbstractMojo
 {
+    /**
+     * Skips cleanup entirely when set. Shared with the prepare-server goal so a single
+     * {@code -Dlightkeeper.skip=true} disables a whole LightKeeper lane, e.g. from a CI matrix.
+     */
+    @Parameter(property = "lightkeeper.skip", defaultValue = "false")
+    private boolean skip;
+
     @Parameter(property = "lightkeeper.deleteTargetServerOnSuccess", defaultValue = "false")
     private boolean deleteTargetServerOnSuccess;
 
@@ -64,6 +71,12 @@ public final class CleanupServerMojo extends AbstractMojo
     public void execute()
         throws MojoExecutionException
     {
+        if (skip)
+        {
+            getLog().info("LK_CLEANUP: Skipping cleanup because 'lightkeeper.skip' is set.");
+            return;
+        }
+
         if (!deleteTargetServerOnSuccess)
         {
             getLog().info("LK_CLEANUP: Skipping cleanup because deleteTargetServerOnSuccess=false.");

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
@@ -30,6 +30,8 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
@@ -192,6 +194,7 @@ public class PrepareServerMojo extends AbstractMojo
         if (skip)
         {
             getLog().info("Skipping server preparation because 'lightkeeper.skip' is set.");
+            deleteStaleRuntimeManifest();
             return;
         }
 
@@ -222,6 +225,32 @@ public class PrepareServerMojo extends AbstractMojo
             executionContext.worldInputSpecs()
         );
         writeRuntimeManifest(runtimeManifest, executionContext.runtimeManifestPath());
+    }
+
+    /**
+     * Deletes a runtime manifest left behind by a previous run.
+     * <p>
+     * Without this, skipping preparation in a non-clean workspace would leave integration tests silently running
+     * against the stale manifest instead of failing fast on a missing one.
+     *
+     * @throws MojoExecutionException
+     *     When a stale manifest exists but cannot be deleted.
+     */
+    private void deleteStaleRuntimeManifest()
+        throws MojoExecutionException
+    {
+        if (runtimeManifestPath == null)
+            return;
+        try
+        {
+            if (Files.deleteIfExists(runtimeManifestPath))
+                getLog().info("Deleted stale runtime manifest '%s'.".formatted(runtimeManifestPath));
+        }
+        catch (IOException exception)
+        {
+            throw new MojoExecutionException(
+                "Failed to delete stale runtime manifest '%s'.".formatted(runtimeManifestPath), exception);
+        }
     }
 
     PrepareServerRuntimePreparation prepareRuntimePreparation(PrepareServerExecutionContext executionContext)

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
@@ -47,6 +47,16 @@ public class PrepareServerMojo extends AbstractMojo
     private static final String SERVER_TYPE_SPIGOT = "spigot";
     private static final List<String> SUPPORTED_SERVER_TYPES = List.of(SERVER_TYPE_PAPER, SERVER_TYPE_SPIGOT);
 
+    /**
+     * Skips server preparation entirely when set. Shared with the cleanup goal so a single
+     * {@code -Dlightkeeper.skip=true} disables a whole LightKeeper lane, e.g. from a CI matrix.
+     * <p>
+     * Note: skipping preparation without also skipping the integration tests (e.g. {@code -DskipITs}) leaves
+     * failsafe without a runtime manifest, so the tests will fail to start.
+     */
+    @Parameter(property = "lightkeeper.skip", defaultValue = "false")
+    private boolean skip;
+
     @Parameter(property = "lightkeeper.serverType", defaultValue = SERVER_TYPE_PAPER)
     @Nullable
     private String serverType;
@@ -179,6 +189,12 @@ public class PrepareServerMojo extends AbstractMojo
     public void execute()
         throws MojoExecutionException
     {
+        if (skip)
+        {
+            getLog().info("Skipping server preparation because 'lightkeeper.skip' is set.");
+            return;
+        }
+
         validateConfiguration();
         final PrepareServerExecutionContext executionContext = buildExecutionContext();
         logPreparationStart(executionContext);

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/serverprocess/MinecraftServerProcess.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/serverprocess/MinecraftServerProcess.java
@@ -30,6 +30,9 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * This class is responsible for managing the lifecycle of a Minecraft server process, including starting it with the
  * specified Java executable and memory settings, and stopping it gracefully.
+  * <p>
+ * Intentionally not guarded by the framework's orphan reaper: this build-time server is short-lived and
+ * driven synchronously by the mojo, unlike the long-lived per-test server the reaper protects.
  */
 @RequiredArgsConstructor
 public class MinecraftServerProcess

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/cleanupserver/CleanupServerMojoTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/cleanupserver/CleanupServerMojoTest.java
@@ -216,4 +216,42 @@ class CleanupServerMojoTest
         assertThat(unrelatedDirectory).isDirectory();
     }
 
+    @Test
+    void execute_shouldKeepServerDirectoryWhenSkipIsSet(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        // Cleanup is enabled and the summary is successful, so only 'skip' prevents deletion.
+        final Path serverDirectory = tempDirectory.resolve("lightkeeper-server");
+        Files.createDirectories(serverDirectory);
+        Files.writeString(serverDirectory.resolve("marker.txt"), "marker");
+
+        final Path summaryPath = tempDirectory.resolve("failsafe-summary.xml");
+        Files.writeString(summaryPath, """
+            <failsafe-summary result="null" timeout="false">
+                <completed>1</completed>
+                <errors>0</errors>
+                <failures>0</failures>
+                <skipped>0</skipped>
+            </failsafe-summary>
+            """);
+
+        final CleanupServerMojo cleanupServerMojo = new CleanupServerMojo(true, serverDirectory, summaryPath);
+        setField(cleanupServerMojo, "skip", true);
+
+        // execute
+        cleanupServerMojo.execute();
+
+        // verify
+        assertThat(serverDirectory).isDirectory();
+        assertThat(serverDirectory.resolve("marker.txt")).exists();
+    }
+
+    private static void setField(Object target, String fieldName, Object value)
+        throws Exception
+    {
+        final java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
 }

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
@@ -664,6 +664,19 @@ class PrepareServerMojoInternalTest
     }
 
     @Test
+    void execute_shouldDoNothingWhenSkipIsSet()
+        throws Exception
+    {
+        // setup
+        // No other configuration: if skip did not short-circuit, validateConfiguration would throw.
+        final PrepareServerMojo mojo = new PrepareServerMojo();
+        setField(mojo, "skip", true);
+
+        // execute + verify
+        mojo.execute();
+    }
+
+    @Test
     void execute_shouldPrepareServerAndWriteRuntimeManifestUsingResolvedSetup(@TempDir Path tempDirectory)
         throws Exception
     {

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojoInternalTest.java
@@ -677,6 +677,26 @@ class PrepareServerMojoInternalTest
     }
 
     @Test
+    void execute_shouldDeleteStaleRuntimeManifestWhenSkipIsSet(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        // A manifest from a previous run must not survive a skipped preparation: failsafe would
+        // otherwise silently run the integration tests against stale server state.
+        final Path staleManifest = tempDirectory.resolve("runtime-manifest.json");
+        Files.writeString(staleManifest, "{}");
+        final PrepareServerMojo mojo = new PrepareServerMojo();
+        setField(mojo, "skip", true);
+        setField(mojo, "runtimeManifestPath", staleManifest);
+
+        // execute
+        mojo.execute();
+
+        // verify
+        assertThat(staleManifest).doesNotExist();
+    }
+
+    @Test
     void execute_shouldPrepareServerAndWriteRuntimeManifestUsingResolvedSetup(@TempDir Path tempDirectory)
         throws Exception
     {


### PR DESCRIPTION
## Why
- CI matrices need to toggle whole LightKeeper lanes per job (`-Dlightkeeper.skip=true`) without pom surgery — LK-17 in the AnimatedArchitecture test master plan.
- A hard-killed test JVM (CI timeout, OOM killer) leaks the running Minecraft server, which keeps holding the agent socket and world session lock — LK-19.

## How
- `skip` parameter (property `lightkeeper.skip`) on both `prepare-server` and `cleanup-server`, with an early-return and a javadoc note that skipping preparation without `-DskipITs` leaves failsafe without a manifest.
- `OrphanReaper`: a JDK-only watchdog JVM spawned per server start that polls both processes and force-kills the server process tree once the test JVM dies. Detached into its own session via `setsid` where available (whole-process-group kills, e.g. GNU `timeout`, would otherwise take the watchdog down with the JVM — verified empirically during review); PID identity is guarded via process start times so recycled PIDs are never reaped by mistake. Launch failures are logged, never fatal.

## Tests
- `mvn clean install -DskipITs`: green, all unit tests (incl. 11 new reaper tests — mocked lifecycle, PID-reuse both directions, two real-process end-to-end cases, and a /proc-based session-detachment check — plus mojo skip tests and a reaper/lifecycle wiring test in `MinecraftServerProcessTest`).
- `mvn verify -pl lightkeeper-integration-tests -Dit.test=LightkeeperFrameworkIT`: green on Paper and Spigot with the reaper active on real server boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P15FjGQzyNmX9T6Qmyq8Dn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-Dlightkeeper.skip=true` to bypass both server preparation and cleanup.
  * When skipping preparation, stale `runtime-manifest.json` is removed.
  * Added an orphan-reaping watchdog to automatically destroy server process trees when a controlling test JVM exits unexpectedly.
* **Documentation**
  * Updated the Quick Start guide to describe skip behavior and suggested pairing with skipping integration tests.
* **Tests**
  * Added/expanded coverage for skip handling, stale manifest removal, watchdog safety/identity checks, and orphan reaper shutdown/interrupt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->