### PR TITLE
feat: world templates, menu ergonomics, and observable interaction results (S1 remainder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,12 @@ class MyPluginIT
 - Config overlay support (copy tree into prepared server directory)
 - Synthetic players and fluent interaction API
 - Runtime permission control per player (`player.permissions().grant/revoke/unset/has`)
-- Menu interaction and assertions
+- Observable interaction outcomes: block clicks return `InteractionResult` (event fired + cancellation),
+  drops return `DropResult` (`DROPPED`/`CANCELLED`/`EMPTY_HAND`)
+- Menu interaction and assertions; menu actions auto-wait for an open menu, and `clickItem("name")`
+  clicks by item display name
+- World templates: provision world folders via `<worlds>` and load them with
+  `newWorldFromTemplate("name")` — typos fail loudly instead of silently creating a fresh world
 - Received-message assertions with AssertJ string chaining
 - Graceful server lifecycle control from tests (`stopServer()`, `startServer()`, `restartServer()`), plus
   `crashServer()` for hard-kill scenarios

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerStateActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerStateActions.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import nl.pim16aap2.lightkeeper.protocol.DropItem;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponents;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessages;
@@ -105,12 +106,12 @@ final class AgentPlayerStateActions
         throws Exception
     {
         final UUID uuid = command.uuid();
-        final Boolean dropped = mainThreadExecutor.callOnMainThread(() ->
+        final DropResult result = mainThreadExecutor.callOnMainThread(() ->
         {
             final Player player = playerStore.getRequiredPlayer(uuid);
             final ItemStack item = player.getInventory().getItemInMainHand();
             if (item == null || AgentMaterials.isAir(item.getType()))
-                return Boolean.FALSE;
+                return DropResult.EMPTY_HAND;
 
             final ItemStack singleItem = item.clone();
             singleItem.setAmount(1);
@@ -121,7 +122,7 @@ final class AgentPlayerStateActions
             if (event.isCancelled())
             {
                 droppedItem.remove();
-                return Boolean.FALSE;
+                return DropResult.CANCELLED;
             }
 
             if (item.getAmount() > 1)
@@ -133,8 +134,8 @@ final class AgentPlayerStateActions
             {
                 player.getInventory().setItemInMainHand(null);
             }
-            return Boolean.TRUE;
+            return DropResult.DROPPED;
         });
-        return new DropItem.Response(dropped);
+        return new DropItem.Response(result);
     }
 }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
@@ -4,6 +4,7 @@ import tools.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayer;
 import nl.pim16aap2.lightkeeper.protocol.DropItem;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerChatComponents;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
@@ -158,7 +159,7 @@ class AgentPlayerActionsTest
         }
 
         // verify
-        assertThat(response.dropped()).isTrue();
+        assertThat(response.result()).isEqualTo(DropResult.DROPPED);
         verify(entity, never()).remove();
         verify(item).setAmount(2);
         verify(inventory).setItemInMainHand(item);
@@ -204,7 +205,7 @@ class AgentPlayerActionsTest
         }
 
         // verify
-        assertThat(response.dropped()).isFalse();
+        assertThat(response.result()).isEqualTo(DropResult.CANCELLED);
         verify(entity).remove();
         verify(inventory, never()).setItemInMainHand(any());
     }
@@ -537,8 +538,8 @@ class AgentPlayerActionsTest
             response = fixture.stateActions().handleDropItem(command);
         }
 
-        // verify - no item to drop, so dropped=false
-        assertThat(response.dropped()).isFalse();
+        // verify - no item to drop, so the empty hand is reported distinctly
+        assertThat(response.result()).isEqualTo(DropResult.EMPTY_HAND);
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -14,6 +14,7 @@ import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayer;
 import nl.pim16aap2.lightkeeper.protocol.DragMenuSlots;
 import nl.pim16aap2.lightkeeper.protocol.DropItem;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.ExecuteCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
@@ -346,7 +347,7 @@ class AgentRequestDispatcherTest
         when(fixture.playerStateActions().handleGetPlayerInventory(any(GetPlayerInventory.Command.class)))
             .thenReturn(new GetPlayerInventory.Response(java.util.List.of()));
         when(fixture.playerStateActions().handleDropItem(any(DropItem.Command.class)))
-            .thenReturn(new DropItem.Response(false));
+            .thenReturn(new DropItem.Response(DropResult.EMPTY_HAND));
         when(fixture.eventActions().handleRegisterEventListener(any(RegisterEventListener.Command.class)))
             .thenReturn(new RegisterEventListener.Response());
         when(fixture.eventActions().handleGetCapturedEvents(any(GetCapturedEvents.Command.class)))

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -1,5 +1,7 @@
 package nl.pim16aap2.lightkeeper.framework;
 
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -78,13 +80,17 @@ public interface IFrameworkGatewayView
 
     /**
      * Fires a left-click block interaction as a synthetic player.
+     *
+     * @return {@code true} when a plugin cancelled the fired {@code PlayerInteractEvent}.
      */
-    void leftClickBlock(UUID playerId, Vector3Di position, String blockFace);
+    boolean leftClickBlock(UUID playerId, Vector3Di position, String blockFace);
 
     /**
      * Fires a right-click block interaction as a synthetic player.
+     *
+     * @return {@code true} when a plugin cancelled the fired {@code PlayerInteractEvent}.
      */
-    void rightClickBlock(UUID playerId, Vector3Di position, String blockFace);
+    boolean rightClickBlock(UUID playerId, Vector3Di position, String blockFace);
 
     /**
      * Retrieves menu snapshot for a synthetic player.
@@ -133,8 +139,10 @@ public interface IFrameworkGatewayView
 
     /**
      * Drops item from player's main hand.
+     *
+     * @return The drop outcome, distinguishing a successful drop from a cancelled event and an empty hand.
      */
-    boolean dropItem(UUID playerId);
+    DropResult dropItem(UUID playerId);
 
     /**
      * Registers an event listener.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
@@ -36,6 +36,22 @@ public interface ILightkeeperFramework extends AutoCloseable
     WorldHandle newWorld(WorldSpec worldSpec);
 
     /**
+     * Loads a world from a pre-provisioned template folder.
+     *
+     * <p>Templates are world folders provisioned into the server directory by the Maven plugin's
+     * {@code <worlds>} configuration (typically with {@code loadOnStartup=false}). The name is validated
+     * against the runtime manifest's provisioned-template list <em>before</em> touching the server: a typo
+     * fails loudly instead of silently creating a fresh world.
+     *
+     * @param templateName
+     *     The provisioned world folder's name.
+     * @return A handle for the loaded world.
+     * @throws IllegalArgumentException
+     *     If no template with that name was provisioned; the message lists the available templates.
+     */
+    WorldHandle newWorldFromTemplate(String templateName);
+
+    /**
      * Creates a synthetic player in a world at spawn.
      *
      * @param name

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
@@ -43,6 +43,9 @@ public interface ILightkeeperFramework extends AutoCloseable
      * against the runtime manifest's provisioned-template list <em>before</em> touching the server: a typo
      * fails loudly instead of silently creating a fresh world.
      *
+     * <p>A provisioned world that is already loaded (e.g. one with {@code loadOnStartup=true}) is returned
+     * as-is rather than reloaded.
+     *
      * @param templateName
      *     The provisioned world folder's name.
      * @return A handle for the loaded world.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/InteractionResult.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/InteractionResult.java
@@ -1,0 +1,17 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+/**
+ * Outcome of a synthetic player interaction that fires a real, cancellable Bukkit event.
+ *
+ * @param eventFired
+ *     Whether a real Bukkit event was fired for the interaction. Block clicks always fire a
+ *     {@code PlayerInteractEvent}; bypass-style operations (e.g. direct block sets) never do.
+ * @param cancelled
+ *     Whether a plugin cancelled the fired event. Always {@code false} when no event was fired.
+ */
+public record InteractionResult(
+    boolean eventFired,
+    boolean cancelled
+)
+{
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/MenuHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/MenuHandle.java
@@ -107,6 +107,9 @@ public final class MenuHandle
      */
     public MenuHandle clickAtIndex(int slot)
     {
+        // Validate before the auto-wait so invalid arguments fail immediately instead of after the menu wait.
+        if (slot < 0)
+            throw new IllegalArgumentException("slot must be >= 0.");
         awaitOpenMenu();
         frameworkGateway.clickMenuSlot(player.uniqueId(), slot);
         return this;
@@ -177,8 +180,20 @@ public final class MenuHandle
      */
     public MenuHandle dragWithMaterial(String materialKey, int... slots)
     {
+        // Validate before the auto-wait so invalid arguments fail immediately instead of after the menu wait.
+        final String trimmedMaterialKey =
+            Objects.requireNonNull(materialKey, "materialKey may not be null.").trim();
+        if (trimmedMaterialKey.isEmpty())
+            throw new IllegalArgumentException("materialKey may not be blank.");
+        if (slots.length == 0)
+            throw new IllegalArgumentException("slots may not be empty.");
+        for (final int slot : slots)
+        {
+            if (slot < 0)
+                throw new IllegalArgumentException("slot must be >= 0.");
+        }
         awaitOpenMenu();
-        frameworkGateway.dragMenuSlots(player.uniqueId(), materialKey, slots);
+        frameworkGateway.dragMenuSlots(player.uniqueId(), trimmedMaterialKey, slots);
         return this;
     }
 
@@ -196,10 +211,21 @@ public final class MenuHandle
         }
         catch (IllegalStateException exception)
         {
-            final MenuSnapshot lastSnapshot = snapshot();
+            // The diagnostic snapshot is best-effort: if it fails too, the original wait failure must
+            // still surface, with the snapshot failure attached instead of masking it.
+            String menuState = "menu state unavailable";
+            try
+            {
+                final MenuSnapshot lastSnapshot = snapshot();
+                menuState = "open=%s, title='%s'".formatted(lastSnapshot.open(), lastSnapshot.title());
+            }
+            catch (RuntimeException snapshotException)
+            {
+                exception.addSuppressed(snapshotException);
+            }
             throw new IllegalStateException(
-                "No open menu for player '%s' within %s (open=%s, title='%s').".formatted(
-                    player.name(), DEFAULT_MENU_WAIT_TIMEOUT, lastSnapshot.open(), lastSnapshot.title()),
+                "No open menu for player '%s' within %s (%s).".formatted(
+                    player.name(), DEFAULT_MENU_WAIT_TIMEOUT, menuState),
                 exception);
         }
     }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/MenuHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/MenuHandle.java
@@ -11,10 +11,19 @@ import java.util.Optional;
 
 /**
  * Handle for an open player menu.
+ * <p>
+ * Menu actions ({@link #clickAtIndex(int)}, {@link #clickItem(String)}, {@link #dragWithMaterial}) auto-wait for
+ * an open menu (bounded, default 10 seconds) before acting. This is the one deliberate implicit wait in the
+ * framework API: waiting for the menu is the only correct behavior before interacting with it. Probes and
+ * verifications ({@link #isOpen()}, {@link #snapshot()}, {@link #verifyMenuName}, {@link #hasTitle},
+ * {@link #hasItemAt}) never wait.
  */
 public final class MenuHandle
 {
-    private static final Duration DEFAULT_MENU_WAIT_TIMEOUT = Duration.ofSeconds(10);
+    /**
+     * Default bound for menu-related waits; shared with {@link PlayerHandle}'s menu-open waits.
+     */
+    static final Duration DEFAULT_MENU_WAIT_TIMEOUT = Duration.ofSeconds(10);
 
     private final IFrameworkGatewayView frameworkGateway;
     private final PlayerHandle player;
@@ -76,31 +85,106 @@ public final class MenuHandle
     }
 
     /**
-     * Clicks a slot in the open menu.
+     * Checks whether an actionable menu is currently open. An instant probe suitable for
+     * {@code waitUntil(...)} conditions; never waits.
+     *
+     * @return {@code true} when a menu is open.
+     */
+    public boolean isOpen()
+    {
+        return snapshot().open();
+    }
+
+    /**
+     * Clicks a slot in the open menu, auto-waiting for an open menu first (bounded, default 10 seconds).
      *
      * @param slot
      *     Inventory slot index.
      * @return This handle.
+     * @throws IllegalStateException
+     *     When no menu opens within the wait bound.
      */
     public MenuHandle clickAtIndex(int slot)
     {
+        awaitOpenMenu();
         frameworkGateway.clickMenuSlot(player.uniqueId(), slot);
         return this;
     }
 
     /**
-     * Performs a drag operation using a material over the provided slots.
+     * Clicks the first menu item whose display name contains the given fragment, auto-waiting for an open menu
+     * first (bounded, default 10 seconds).
+     *
+     * @param displayNameFragment
+     *     Fragment to match against item display names (case-sensitive contains).
+     * @return This handle.
+     * @throws IllegalStateException
+     *     When no menu opens within the wait bound, or no item in the open menu matches the fragment.
+     */
+    public MenuHandle clickItem(String displayNameFragment)
+    {
+        final String trimmedFragment =
+            Objects.requireNonNull(displayNameFragment, "displayNameFragment may not be null.").trim();
+        if (trimmedFragment.isEmpty())
+            throw new IllegalArgumentException("displayNameFragment may not be blank.");
+
+        final MenuSnapshot openSnapshot = awaitOpenMenu();
+        final MenuItemSnapshot item = openSnapshot.items().stream()
+            .filter(candidate -> candidate.displayName().contains(trimmedFragment))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(
+                "No item with a display name containing '%s' in menu '%s'. Items: %s".formatted(
+                    trimmedFragment,
+                    openSnapshot.title(),
+                    openSnapshot.items().stream()
+                        .map(candidate -> "'" + candidate.displayName() + "'")
+                        .toList()
+                )));
+        frameworkGateway.clickMenuSlot(player.uniqueId(), item.slot());
+        return this;
+    }
+
+    /**
+     * Performs a drag operation using a material over the provided slots, auto-waiting for an open menu first
+     * (bounded, default 10 seconds).
      *
      * @param materialKey
      *     Material identifier.
      * @param slots
      *     Target slot indices.
      * @return This handle.
+     * @throws IllegalStateException
+     *     When no menu opens within the wait bound.
      */
     public MenuHandle dragWithMaterial(String materialKey, int... slots)
     {
+        awaitOpenMenu();
         frameworkGateway.dragMenuSlots(player.uniqueId(), materialKey, slots);
         return this;
+    }
+
+    /**
+     * Waits for an open menu within the default bound and returns its snapshot.
+     *
+     * @return The open menu's snapshot.
+     * @throws IllegalStateException
+     *     When no menu opens within the wait bound.
+     */
+    private MenuSnapshot awaitOpenMenu()
+    {
+        try
+        {
+            frameworkGateway.waitUntil(() -> snapshot().open(), DEFAULT_MENU_WAIT_TIMEOUT);
+        }
+        catch (IllegalStateException exception)
+        {
+            final MenuSnapshot lastSnapshot = snapshot();
+            throw new IllegalStateException(
+                "No open menu for player '%s' within %s (open=%s, title='%s').".formatted(
+                    player.name(), DEFAULT_MENU_WAIT_TIMEOUT, lastSnapshot.open(), lastSnapshot.title()),
+                exception);
+        }
+        return snapshot();
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/MenuHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/MenuHandle.java
@@ -15,8 +15,9 @@ import java.util.Optional;
  * Menu actions ({@link #clickAtIndex(int)}, {@link #clickItem(String)}, {@link #dragWithMaterial}) auto-wait for
  * an open menu (bounded, default 10 seconds) before acting. This is the one deliberate implicit wait in the
  * framework API: waiting for the menu is the only correct behavior before interacting with it. Probes and
- * verifications ({@link #isOpen()}, {@link #snapshot()}, {@link #verifyMenuName}, {@link #hasTitle},
- * {@link #hasItemAt}) never wait.
+ * verifications (e.g. {@link #isOpen()}, {@link #snapshot()}, {@link #verifyMenuName}, {@link #verifyMenuClosed},
+ * {@link #hasTitle}, {@link #hasItemAt}) never wait; the explicit {@link #andWaitForMenuClose()} waits for the
+ * opposite transition.
  */
 public final class MenuHandle
 {
@@ -112,6 +113,23 @@ public final class MenuHandle
     }
 
     /**
+     * Retrieves the open menu's snapshot after {@link #awaitOpenMenu()}, distinguishing a menu that closed again
+     * mid-flight from a menu that simply lacks the requested item.
+     *
+     * @return The open menu's snapshot.
+     * @throws IllegalStateException
+     *     When the menu closed between the wait passing and the snapshot.
+     */
+    private MenuSnapshot openSnapshotAfterWait()
+    {
+        final MenuSnapshot openSnapshot = snapshot();
+        if (!openSnapshot.open())
+            throw new IllegalStateException(
+                "The menu for player '%s' closed while it was being interacted with.".formatted(player.name()));
+        return openSnapshot;
+    }
+
+    /**
      * Clicks the first menu item whose display name contains the given fragment, auto-waiting for an open menu
      * first (bounded, default 10 seconds).
      *
@@ -128,7 +146,8 @@ public final class MenuHandle
         if (trimmedFragment.isEmpty())
             throw new IllegalArgumentException("displayNameFragment may not be blank.");
 
-        final MenuSnapshot openSnapshot = awaitOpenMenu();
+        awaitOpenMenu();
+        final MenuSnapshot openSnapshot = openSnapshotAfterWait();
         final MenuItemSnapshot item = openSnapshot.items().stream()
             .filter(candidate -> candidate.displayName().contains(trimmedFragment))
             .findFirst()
@@ -164,13 +183,12 @@ public final class MenuHandle
     }
 
     /**
-     * Waits for an open menu within the default bound and returns its snapshot.
+     * Waits for an open menu within the default bound.
      *
-     * @return The open menu's snapshot.
      * @throws IllegalStateException
      *     When no menu opens within the wait bound.
      */
-    private MenuSnapshot awaitOpenMenu()
+    private void awaitOpenMenu()
     {
         try
         {
@@ -184,7 +202,6 @@ public final class MenuHandle
                     player.name(), DEFAULT_MENU_WAIT_TIMEOUT, lastSnapshot.open(), lastSnapshot.title()),
                 exception);
         }
-        return snapshot();
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework;
 
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import org.bukkit.block.BlockFace;
 import org.jspecify.annotations.Nullable;
 
@@ -16,8 +17,6 @@ import java.util.UUID;
  */
 public final class PlayerHandle
 {
-    private static final Duration DEFAULT_MENU_WAIT_TIMEOUT = Duration.ofSeconds(10);
-
     private final IFrameworkGatewayView frameworkGateway;
     private final UUID uniqueId;
     private final String name;
@@ -125,9 +124,9 @@ public final class PlayerHandle
      *     Y coordinate.
      * @param z
      *     Z coordinate.
-     * @return This handle for fluent chaining.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public PlayerHandle leftClickBlock(int x, int y, int z)
+    public InteractionResult leftClickBlock(int x, int y, int z)
     {
         return leftClickBlock(new Vector3Di(x, y, z));
     }
@@ -137,9 +136,9 @@ public final class PlayerHandle
      *
      * @param position
      *     Block coordinates.
-     * @return This handle for fluent chaining.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public PlayerHandle leftClickBlock(Vector3Di position)
+    public InteractionResult leftClickBlock(Vector3Di position)
     {
         return leftClickBlock(position, BlockFace.UP);
     }
@@ -151,16 +150,16 @@ public final class PlayerHandle
      *     Block coordinates.
      * @param blockFace
      *     Clicked block face.
-     * @return This handle for fluent chaining.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public PlayerHandle leftClickBlock(Vector3Di position, BlockFace blockFace)
+    public InteractionResult leftClickBlock(Vector3Di position, BlockFace blockFace)
     {
-        frameworkGateway.leftClickBlock(
+        final boolean cancelled = frameworkGateway.leftClickBlock(
             uniqueId,
             Objects.requireNonNull(position, "position may not be null."),
             Objects.requireNonNull(blockFace, "blockFace may not be null.").name()
         );
-        return this;
+        return new InteractionResult(true, cancelled);
     }
 
     /**
@@ -172,9 +171,9 @@ public final class PlayerHandle
      *     Y coordinate.
      * @param z
      *     Z coordinate.
-     * @return This handle for fluent chaining.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public PlayerHandle rightClickBlock(int x, int y, int z)
+    public InteractionResult rightClickBlock(int x, int y, int z)
     {
         return rightClickBlock(new Vector3Di(x, y, z));
     }
@@ -184,9 +183,9 @@ public final class PlayerHandle
      *
      * @param position
      *     Block coordinates.
-     * @return This handle for fluent chaining.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public PlayerHandle rightClickBlock(Vector3Di position)
+    public InteractionResult rightClickBlock(Vector3Di position)
     {
         return rightClickBlock(position, BlockFace.UP);
     }
@@ -198,16 +197,16 @@ public final class PlayerHandle
      *     Block coordinates.
      * @param blockFace
      *     Clicked block face.
-     * @return This handle for fluent chaining.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public PlayerHandle rightClickBlock(Vector3Di position, BlockFace blockFace)
+    public InteractionResult rightClickBlock(Vector3Di position, BlockFace blockFace)
     {
-        frameworkGateway.rightClickBlock(
+        final boolean cancelled = frameworkGateway.rightClickBlock(
             uniqueId,
             Objects.requireNonNull(position, "position may not be null."),
             Objects.requireNonNull(blockFace, "blockFace may not be null.").name()
         );
-        return this;
+        return new InteractionResult(true, cancelled);
     }
 
     /**
@@ -236,11 +235,14 @@ public final class PlayerHandle
     /**
      * Simulates the player dropping their main hand item.
      *
-     * @return {@code true} when no plugin cancelled the drop event (i.e., the item would have been dropped
-     *     in production). Note: the item entity is always created and removed to satisfy the Bukkit API
-     *     constraint; this return value reflects whether a plugin would have allowed the drop.
+     * <p>An empty main hand ({@link DropResult#EMPTY_HAND}) is reported distinctly from a plugin cancelling the
+     * drop event ({@link DropResult#CANCELLED}); no event is fired at all for an empty hand. On a cancelled
+     * drop, the item entity is created and removed again to satisfy the Bukkit event contract, and the
+     * inventory is unchanged.
+     *
+     * @return The drop outcome.
      */
-    public boolean dropMainHandItem()
+    public DropResult dropMainHandItem()
     {
         return frameworkGateway.dropItem(uniqueId);
     }
@@ -285,7 +287,7 @@ public final class PlayerHandle
         final MenuHandle menuHandle = FrameworkHandleFactory.menuHandle(frameworkGateway, this);
         frameworkGateway.waitUntil(
             () -> menuHandle.snapshot().open(),
-            DEFAULT_MENU_WAIT_TIMEOUT
+            MenuHandle.DEFAULT_MENU_WAIT_TIMEOUT
         );
         return menuHandle;
     }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -19,6 +19,7 @@ import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
@@ -163,6 +164,34 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         LOG.log(
             System.Logger.Level.INFO,
             () -> "LK_FRAMEWORK: Created world '" + worldName + "'."
+        );
+        return FrameworkHandleFactory.worldHandle(this, worldName);
+    }
+
+    @Override
+    public WorldHandle newWorldFromTemplate(String templateName)
+    {
+        ensureOpen();
+        final String trimmedTemplateName =
+            Objects.requireNonNull(templateName, "templateName may not be null.").trim();
+        if (trimmedTemplateName.isEmpty())
+            throw new IllegalArgumentException("templateName may not be blank.");
+        if (!runtimeManifest.provisionedWorldNames().contains(trimmedTemplateName))
+            throw new IllegalArgumentException(
+                "No world template named '%s' was provisioned. Provisioned templates: %s".formatted(
+                    trimmedTemplateName, runtimeManifest.provisionedWorldNames()));
+
+        // The world folder already exists on disk, so the server loads it from its own data; the spec's
+        // type/environment/seed only apply to genuinely new worlds and are ignored here.
+        final String worldName = agentClient.newWorld(new WorldSpec(
+            trimmedTemplateName,
+            DEFAULT_WORLD_TYPE,
+            DEFAULT_WORLD_ENVIRONMENT,
+            DEFAULT_WORLD_SEED
+        ));
+        LOG.log(
+            System.Logger.Level.INFO,
+            () -> "LK_FRAMEWORK: Loaded world '" + worldName + "' from a provisioned template."
         );
         return FrameworkHandleFactory.worldHandle(this, worldName);
     }
@@ -374,15 +403,15 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
-    public void leftClickBlock(UUID playerId, Vector3Di position, String blockFace)
+    public boolean leftClickBlock(UUID playerId, Vector3Di position, String blockFace)
     {
-        clickBlock(playerId, position, blockFace, agentClient::leftClickBlock);
+        return clickBlock(playerId, position, blockFace, agentClient::leftClickBlock);
     }
 
     @Override
-    public void rightClickBlock(UUID playerId, Vector3Di position, String blockFace)
+    public boolean rightClickBlock(UUID playerId, Vector3Di position, String blockFace)
     {
-        clickBlock(playerId, position, blockFace, agentClient::rightClickBlock);
+        return clickBlock(playerId, position, blockFace, agentClient::rightClickBlock);
     }
 
     @Override
@@ -480,7 +509,7 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
-    public boolean dropItem(UUID playerId)
+    public DropResult dropItem(UUID playerId)
     {
         ensureOpen();
         Objects.requireNonNull(playerId, "playerId may not be null.");
@@ -703,7 +732,7 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         startServer();
     }
 
-    private void clickBlock(UUID playerId, Vector3Di position, String blockFace, BlockClickOperation operation)
+    private boolean clickBlock(UUID playerId, Vector3Di position, String blockFace, BlockClickOperation operation)
     {
         ensureOpen();
         Objects.requireNonNull(playerId, "playerId may not be null.");
@@ -711,13 +740,13 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         final String trimmedBlockFace = Objects.requireNonNull(blockFace, "blockFace may not be null.").trim();
         if (trimmedBlockFace.isEmpty())
             throw new IllegalArgumentException("blockFace may not be blank.");
-        operation.clickBlock(playerId, position, trimmedBlockFace);
+        return operation.clickBlock(playerId, position, trimmedBlockFace);
     }
 
     @FunctionalInterface
     private interface BlockClickOperation
     {
-        void clickBlock(UUID playerId, Vector3Di position, String blockFace);
+        boolean clickBlock(UUID playerId, Vector3Di position, String blockFace);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -176,24 +176,34 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
             Objects.requireNonNull(templateName, "templateName may not be null.").trim();
         if (trimmedTemplateName.isEmpty())
             throw new IllegalArgumentException("templateName may not be blank.");
-        if (!runtimeManifest.provisionedWorldNames().contains(trimmedTemplateName))
-            throw new IllegalArgumentException(
+        final RuntimeManifest.ProvisionedWorld template = runtimeManifest.provisionedWorlds().stream()
+            .filter(provisionedWorld -> provisionedWorld.name().equals(trimmedTemplateName))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(
                 "No world template named '%s' was provisioned. Provisioned templates: %s".formatted(
-                    trimmedTemplateName, runtimeManifest.provisionedWorldNames()));
+                    trimmedTemplateName,
+                    runtimeManifest.provisionedWorlds().stream()
+                        .map(RuntimeManifest.ProvisionedWorld::name)
+                        .toList())));
 
-        // The world folder already exists on disk, so the server loads it from its own data; the spec's
-        // type/environment/seed only apply to genuinely new worlds and are ignored here.
-        final String worldName = agentClient.newWorld(new WorldSpec(
-            trimmedTemplateName,
-            DEFAULT_WORLD_TYPE,
-            DEFAULT_WORLD_ENVIRONMENT,
-            DEFAULT_WORLD_SEED
-        ));
+        // Pass the template's own provisioned spec: folders that lack complete world data are generated with
+        // the configured settings, while folders with real world data load from their own files and ignore it.
+        final String worldName = agentClient.newWorld(toWorldSpec(template));
         LOG.log(
             System.Logger.Level.INFO,
             () -> "LK_FRAMEWORK: Loaded world '" + worldName + "' from a provisioned template."
         );
         return FrameworkHandleFactory.worldHandle(this, worldName);
+    }
+
+    private static WorldSpec toWorldSpec(RuntimeManifest.ProvisionedWorld provisionedWorld)
+    {
+        return new WorldSpec(
+            provisionedWorld.name(),
+            WorldSpec.WorldType.valueOf(provisionedWorld.worldType()),
+            WorldSpec.WorldEnvironment.valueOf(provisionedWorld.environment()),
+            provisionedWorld.seed()
+        );
     }
 
     @Override
@@ -798,15 +808,11 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
 
     private void preloadConfiguredWorlds()
     {
-        for (final RuntimeManifest.PreloadedWorld preloadedWorld : runtimeManifest.preloadedWorlds())
+        for (final RuntimeManifest.ProvisionedWorld provisionedWorld : runtimeManifest.provisionedWorlds())
         {
-            final WorldSpec worldSpec = new WorldSpec(
-                preloadedWorld.name(),
-                WorldSpec.WorldType.valueOf(preloadedWorld.worldType()),
-                WorldSpec.WorldEnvironment.valueOf(preloadedWorld.environment()),
-                preloadedWorld.seed()
-            );
-            final String worldName = agentClient.newWorld(worldSpec);
+            if (!provisionedWorld.loadOnStartup())
+                continue;
+            final String worldName = agentClient.newWorld(toWorldSpec(provisionedWorld));
             LOG.log(
                 System.Logger.Level.INFO,
                 () -> "LK_FRAMEWORK: Preloaded world '%s' from runtime manifest.".formatted(worldName)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -14,6 +14,7 @@ import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.CreatePlayer;
 import nl.pim16aap2.lightkeeper.protocol.DragMenuSlots;
 import nl.pim16aap2.lightkeeper.protocol.DropItem;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.ExecuteCommand;
 import nl.pim16aap2.lightkeeper.protocol.ExecutePlayerCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
@@ -218,7 +219,7 @@ final class UdsAgentClient implements AutoCloseable
         send(command);
     }
 
-    void leftClickBlock(UUID uuid, Vector3Di position, String blockFace)
+    boolean leftClickBlock(UUID uuid, Vector3Di position, String blockFace)
     {
         final LeftClickBlock.Command command = new LeftClickBlock.Command(
             nextRequestId(),
@@ -228,10 +229,10 @@ final class UdsAgentClient implements AutoCloseable
             position.z(),
             blockFace
         );
-        send(command);
+        return send(command).cancelled();
     }
 
-    void rightClickBlock(UUID uuid, Vector3Di position, String blockFace)
+    boolean rightClickBlock(UUID uuid, Vector3Di position, String blockFace)
     {
         final RightClickBlock.Command command = new RightClickBlock.Command(
             nextRequestId(),
@@ -241,7 +242,7 @@ final class UdsAgentClient implements AutoCloseable
             position.z(),
             blockFace
         );
-        send(command);
+        return send(command).cancelled();
     }
 
     MenuSnapshot menuSnapshot(UUID uuid)
@@ -340,10 +341,10 @@ final class UdsAgentClient implements AutoCloseable
         return send(command).items();
     }
 
-    boolean dropItem(UUID uuid)
+    DropResult dropItem(UUID uuid)
     {
         final DropItem.Command command = new DropItem.Command(nextRequestId(), uuid);
-        return send(command).dropped();
+        return send(command).result();
     }
 
     void registerEventListener(String eventClassName)

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/MenuHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/MenuHandleTest.java
@@ -4,6 +4,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
 import java.util.List;
@@ -14,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,6 +58,34 @@ class MenuHandleTest
 
         // verify
         assertThat(result).isSameAs(snapshot);
+    }
+
+    @Test
+    void isOpen_shouldReturnTrueWhenSnapshotIsOpen()
+    {
+        // setup
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(true, "Main Menu", List.of()));
+
+        // execute
+        final boolean result = menuHandle.isOpen();
+
+        // verify
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isOpen_shouldReturnFalseWhenSnapshotIsClosed()
+    {
+        // setup
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(false, "", List.of()));
+
+        // execute
+        final boolean result = menuHandle.isOpen();
+
+        // verify
+        assertThat(result).isFalse();
     }
 
     @Test
@@ -110,6 +140,108 @@ class MenuHandleTest
     }
 
     @Test
+    void clickAtIndex_shouldAutoWaitForOpenMenuUsingDefaultTimeout()
+        throws Exception
+    {
+        // setup
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(true, "Main Menu", List.of()));
+        final ArgumentCaptor<Condition> conditionCaptor = ArgumentCaptor.forClass(Condition.class);
+
+        // execute
+        menuHandle.clickAtIndex(4);
+
+        // verify
+        verify(frameworkGateway).waitUntil(conditionCaptor.capture(), eq(Duration.ofSeconds(10)));
+        assertThat(conditionCaptor.getValue().evaluate()).isEqualTo(menuHandle.snapshot().open());
+    }
+
+    @Test
+    void clickAtIndex_shouldRethrowWithPlayerNameWhenMenuNeverOpensWithinTimeout()
+    {
+        // setup
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(false, "", List.of()));
+        doThrow(new IllegalStateException("Condition did not pass within timeout PT10S."))
+            .when(frameworkGateway).waitUntil(any(Condition.class), eq(Duration.ofSeconds(10)));
+
+        // execute + verify
+        assertThatThrownBy(() -> menuHandle.clickAtIndex(4))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(playerHandle.name());
+    }
+
+    @Test
+    void clickItem_shouldClickFirstMatchingItemAndReturnSelf()
+    {
+        // setup
+        final MenuItemSnapshot first = new MenuItemSnapshot(1, "minecraft:stone", "Stone Block", List.of());
+        final MenuItemSnapshot second = new MenuItemSnapshot(2, "minecraft:diamond", "Shiny Diamond", List.of());
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(true, "Main Menu", List.of(first, second)));
+
+        // execute
+        final MenuHandle result = menuHandle.clickItem("Diamond");
+
+        // verify
+        assertThat(result).isSameAs(menuHandle);
+        verify(frameworkGateway).clickMenuSlot(PLAYER_UUID, second.slot());
+    }
+
+    @Test
+    void clickItem_shouldThrowExceptionWhenNoItemMatches()
+    {
+        // setup
+        final MenuItemSnapshot first = new MenuItemSnapshot(1, "minecraft:stone", "Stone Block", List.of());
+        final MenuItemSnapshot second = new MenuItemSnapshot(2, "minecraft:diamond", "Shiny Diamond", List.of());
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(true, "Main Menu", List.of(first, second)));
+
+        // execute + verify
+        assertThatThrownBy(() -> menuHandle.clickItem("Emerald"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Emerald")
+            .hasMessageContaining("Stone Block")
+            .hasMessageContaining("Shiny Diamond");
+    }
+
+    @Test
+    void clickItem_shouldThrowExceptionWhenFragmentIsBlank()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> menuHandle.clickItem("   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("blank");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void clickItem_shouldThrowNullPointerExceptionWhenFragmentIsNull()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> menuHandle.clickItem(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void clickItem_shouldAutoWaitForOpenMenuUsingDefaultTimeout()
+        throws Exception
+    {
+        // setup
+        final MenuItemSnapshot item = new MenuItemSnapshot(1, "minecraft:stone", "Stone Block", List.of());
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(true, "Main Menu", List.of(item)));
+        final ArgumentCaptor<Condition> conditionCaptor = ArgumentCaptor.forClass(Condition.class);
+
+        // execute
+        menuHandle.clickItem("Stone");
+
+        // verify
+        verify(frameworkGateway).waitUntil(conditionCaptor.capture(), eq(Duration.ofSeconds(10)));
+        assertThat(conditionCaptor.getValue().evaluate()).isEqualTo(menuHandle.snapshot().open());
+    }
+
+    @Test
     void dragWithMaterial_shouldDelegateAndReturnSelf()
     {
         // execute
@@ -118,6 +250,23 @@ class MenuHandleTest
         // verify
         assertThat(result).isSameAs(menuHandle);
         verify(frameworkGateway).dragMenuSlots(PLAYER_UUID, "minecraft:stone", 2, 3, 4);
+    }
+
+    @Test
+    void dragWithMaterial_shouldAutoWaitForOpenMenuUsingDefaultTimeout()
+        throws Exception
+    {
+        // setup
+        when(frameworkGateway.menuSnapshot(PLAYER_UUID))
+            .thenReturn(new MenuSnapshot(true, "Main Menu", List.of()));
+        final ArgumentCaptor<Condition> conditionCaptor = ArgumentCaptor.forClass(Condition.class);
+
+        // execute
+        menuHandle.dragWithMaterial("minecraft:stone", 2, 3, 4);
+
+        // verify
+        verify(frameworkGateway).waitUntil(conditionCaptor.capture(), eq(Duration.ofSeconds(10)));
+        assertThat(conditionCaptor.getValue().evaluate()).isEqualTo(menuHandle.snapshot().open());
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework;
 
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import org.bukkit.block.BlockFace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -165,14 +166,14 @@ class PlayerHandleTest
     @Test
     void dropMainHandItem_shouldDelegateToGatewayAndReturnDroppedState()
     {
-        // setup — gateway returns true when the drop was not cancelled by any plugin
-        when(frameworkGateway.dropItem(PLAYER_UUID)).thenReturn(true);
+        // setup
+        when(frameworkGateway.dropItem(PLAYER_UUID)).thenReturn(DropResult.DROPPED);
 
         // execute
-        final boolean result = playerHandle.dropMainHandItem();
+        final DropResult result = playerHandle.dropMainHandItem();
 
         // verify
-        assertThat(result).isTrue();
+        assertThat(result).isEqualTo(DropResult.DROPPED);
         verify(frameworkGateway).dropItem(PLAYER_UUID);
     }
 
@@ -202,30 +203,32 @@ class PlayerHandleTest
     }
 
     @Test
-    void leftClickBlock_shouldDelegateToGatewayAndReturnSelf()
+    void leftClickBlock_shouldDelegateToGatewayAndReturnInteractionResult()
     {
         // setup
         final Vector3Di position = new Vector3Di(1, 64, 2);
+        when(frameworkGateway.leftClickBlock(PLAYER_UUID, position, "NORTH")).thenReturn(true);
 
         // execute
-        final PlayerHandle result = playerHandle.leftClickBlock(position, BlockFace.NORTH);
+        final InteractionResult result = playerHandle.leftClickBlock(position, BlockFace.NORTH);
 
         // verify
-        assertThat(result).isSameAs(playerHandle);
+        assertThat(result).isEqualTo(new InteractionResult(true, true));
         verify(frameworkGateway).leftClickBlock(PLAYER_UUID, position, "NORTH");
     }
 
     @Test
-    void rightClickBlock_shouldDelegateToGatewayAndReturnSelf()
+    void rightClickBlock_shouldDelegateToGatewayAndReturnInteractionResult()
     {
         // setup
         final Vector3Di position = new Vector3Di(1, 64, 2);
+        when(frameworkGateway.rightClickBlock(PLAYER_UUID, position, "SOUTH")).thenReturn(false);
 
         // execute
-        final PlayerHandle result = playerHandle.rightClickBlock(position, BlockFace.SOUTH);
+        final InteractionResult result = playerHandle.rightClickBlock(position, BlockFace.SOUTH);
 
         // verify
-        assertThat(result).isSameAs(playerHandle);
+        assertThat(result).isEqualTo(new InteractionResult(true, false));
         verify(frameworkGateway).rightClickBlock(PLAYER_UUID, position, "SOUTH");
     }
 
@@ -365,10 +368,10 @@ class PlayerHandleTest
         final Vector3Di position = new Vector3Di(3, 70, 4);
 
         // execute
-        final PlayerHandle result = playerHandle.leftClickBlock(position);
+        final InteractionResult result = playerHandle.leftClickBlock(position);
 
         // verify
-        assertThat(result).isSameAs(playerHandle);
+        assertThat(result).isEqualTo(new InteractionResult(true, false));
         verify(frameworkGateway).leftClickBlock(PLAYER_UUID, position, "UP");
     }
 
@@ -376,10 +379,10 @@ class PlayerHandleTest
     void leftClickBlock_shouldDelegateWithCoordinatesUsingDefaultBlockFace()
     {
         // execute
-        final PlayerHandle result = playerHandle.leftClickBlock(5, 64, 6);
+        final InteractionResult result = playerHandle.leftClickBlock(5, 64, 6);
 
         // verify
-        assertThat(result).isSameAs(playerHandle);
+        assertThat(result).isEqualTo(new InteractionResult(true, false));
         verify(frameworkGateway).leftClickBlock(eq(PLAYER_UUID), any(Vector3Di.class), eq("UP"));
     }
 
@@ -390,10 +393,10 @@ class PlayerHandleTest
         final Vector3Di position = new Vector3Di(7, 70, 8);
 
         // execute
-        final PlayerHandle result = playerHandle.rightClickBlock(position);
+        final InteractionResult result = playerHandle.rightClickBlock(position);
 
         // verify
-        assertThat(result).isSameAs(playerHandle);
+        assertThat(result).isEqualTo(new InteractionResult(true, false));
         verify(frameworkGateway).rightClickBlock(PLAYER_UUID, position, "UP");
     }
 
@@ -401,10 +404,10 @@ class PlayerHandleTest
     void rightClickBlock_shouldDelegateWithCoordinatesUsingDefaultBlockFace()
     {
         // execute
-        final PlayerHandle result = playerHandle.rightClickBlock(9, 64, 10);
+        final InteractionResult result = playerHandle.rightClickBlock(9, 64, 10);
 
         // verify
-        assertThat(result).isSameAs(playerHandle);
+        assertThat(result).isEqualTo(new InteractionResult(true, false));
         verify(frameworkGateway).rightClickBlock(eq(PLAYER_UUID), any(Vector3Di.class), eq("UP"));
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
@@ -227,10 +227,12 @@ class DefaultLightkeeperFrameworkGatewayTest
         // setup
         final UdsAgentClient agentClient = mock(UdsAgentClient.class);
         when(agentClient.newWorld(new WorldSpec(
-            "template-a", WorldSpec.WorldType.NORMAL, WorldSpec.WorldEnvironment.NORMAL, 0L)))
+            "template-a", WorldSpec.WorldType.FLAT, WorldSpec.WorldEnvironment.NETHER, 7L)))
             .thenReturn("template-a-instance");
         final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
-            runtimeManifestWithProvisionedWorlds(List.of("template-a")),
+            runtimeManifestWithProvisionedWorlds(List.of(
+                new RuntimeManifest.ProvisionedWorld("template-a", "NETHER", "FLAT", 7L, false)
+            )),
             mock(MinecraftServerProcess.class),
             agentClient,
             new PlayerScopeRegistry()
@@ -242,7 +244,7 @@ class DefaultLightkeeperFrameworkGatewayTest
         // verify
         assertThat(result.name()).isEqualTo("template-a-instance");
         verify(agentClient).newWorld(new WorldSpec(
-            "template-a", WorldSpec.WorldType.NORMAL, WorldSpec.WorldEnvironment.NORMAL, 0L));
+            "template-a", WorldSpec.WorldType.FLAT, WorldSpec.WorldEnvironment.NETHER, 7L));
     }
 
     @Test
@@ -250,7 +252,10 @@ class DefaultLightkeeperFrameworkGatewayTest
     {
         // setup
         final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
-            runtimeManifestWithProvisionedWorlds(List.of("template-a", "template-b")),
+            runtimeManifestWithProvisionedWorlds(List.of(
+                new RuntimeManifest.ProvisionedWorld("template-a", "NORMAL", "NORMAL", 0L, false),
+                new RuntimeManifest.ProvisionedWorld("template-b", "NORMAL", "NORMAL", 0L, false)
+            )),
             mock(MinecraftServerProcess.class),
             mock(UdsAgentClient.class),
             new PlayerScopeRegistry()
@@ -423,12 +428,12 @@ class DefaultLightkeeperFrameworkGatewayTest
             1,
             "agent-cache-identity",
             null,
-            List.of(),
             List.of()
         );
     }
 
-    private static RuntimeManifest runtimeManifestWithProvisionedWorlds(List<String> provisionedWorldNames)
+    private static RuntimeManifest runtimeManifestWithProvisionedWorlds(
+        List<RuntimeManifest.ProvisionedWorld> provisionedWorlds)
     {
         return new RuntimeManifest(
             "paper",
@@ -445,8 +450,7 @@ class DefaultLightkeeperFrameworkGatewayTest
             1,
             "agent-cache-identity",
             null,
-            List.of(),
-            provisionedWorldNames
+            provisionedWorlds
         );
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
@@ -1,5 +1,9 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import nl.pim16aap2.lightkeeper.framework.Vector3Di;
+import nl.pim16aap2.lightkeeper.framework.WorldHandle;
+import nl.pim16aap2.lightkeeper.framework.WorldSpec;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 import org.junit.jupiter.api.Test;
@@ -217,6 +221,191 @@ class DefaultLightkeeperFrameworkGatewayTest
             .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void newWorldFromTemplate_shouldCreateWorldFromProvisionedTemplate()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        when(agentClient.newWorld(new WorldSpec(
+            "template-a", WorldSpec.WorldType.NORMAL, WorldSpec.WorldEnvironment.NORMAL, 0L)))
+            .thenReturn("template-a-instance");
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifestWithProvisionedWorlds(List.of("template-a")),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final WorldHandle result = framework.newWorldFromTemplate("template-a");
+
+        // verify
+        assertThat(result.name()).isEqualTo("template-a-instance");
+        verify(agentClient).newWorld(new WorldSpec(
+            "template-a", WorldSpec.WorldType.NORMAL, WorldSpec.WorldEnvironment.NORMAL, 0L));
+    }
+
+    @Test
+    void newWorldFromTemplate_shouldThrowExceptionWhenTemplateIsNotProvisioned()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifestWithProvisionedWorlds(List.of("template-a", "template-b")),
+            mock(MinecraftServerProcess.class),
+            mock(UdsAgentClient.class),
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.newWorldFromTemplate("template-x"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("template-a")
+            .hasMessageContaining("template-b");
+    }
+
+    @Test
+    void newWorldFromTemplate_shouldThrowExceptionWhenTemplateNameIsBlank()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            mock(UdsAgentClient.class),
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.newWorldFromTemplate("   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("blank");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void newWorldFromTemplate_shouldThrowNullPointerExceptionWhenTemplateNameIsNull()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            mock(UdsAgentClient.class),
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.newWorldFromTemplate(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void leftClickBlock_shouldReturnTrueWhenAgentClientReportsCancelled()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final UUID playerId = UUID.randomUUID();
+        final Vector3Di position = new Vector3Di(1, 64, 1);
+        when(agentClient.leftClickBlock(playerId, position, "UP")).thenReturn(true);
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final boolean result = framework.leftClickBlock(playerId, position, "UP");
+
+        // verify
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void leftClickBlock_shouldReturnFalseWhenAgentClientReportsNotCancelled()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final UUID playerId = UUID.randomUUID();
+        final Vector3Di position = new Vector3Di(1, 64, 1);
+        when(agentClient.leftClickBlock(playerId, position, "UP")).thenReturn(false);
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final boolean result = framework.leftClickBlock(playerId, position, "UP");
+
+        // verify
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void rightClickBlock_shouldReturnTrueWhenAgentClientReportsCancelled()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final UUID playerId = UUID.randomUUID();
+        final Vector3Di position = new Vector3Di(1, 64, 1);
+        when(agentClient.rightClickBlock(playerId, position, "UP")).thenReturn(true);
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final boolean result = framework.rightClickBlock(playerId, position, "UP");
+
+        // verify
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void rightClickBlock_shouldReturnFalseWhenAgentClientReportsNotCancelled()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final UUID playerId = UUID.randomUUID();
+        final Vector3Di position = new Vector3Di(1, 64, 1);
+        when(agentClient.rightClickBlock(playerId, position, "UP")).thenReturn(false);
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final boolean result = framework.rightClickBlock(playerId, position, "UP");
+
+        // verify
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void dropItem_shouldReturnDropResultFromAgentClient()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final UUID playerId = UUID.randomUUID();
+        when(agentClient.dropItem(playerId)).thenReturn(DropResult.EMPTY_HAND);
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final DropResult result = framework.dropItem(playerId);
+
+        // verify
+        assertThat(result).isEqualTo(DropResult.EMPTY_HAND);
+    }
+
     private static RuntimeManifest runtimeManifest()
     {
         return new RuntimeManifest(
@@ -234,7 +423,30 @@ class DefaultLightkeeperFrameworkGatewayTest
             1,
             "agent-cache-identity",
             null,
+            List.of(),
             List.of()
+        );
+    }
+
+    private static RuntimeManifest runtimeManifestWithProvisionedWorlds(List<String> provisionedWorldNames)
+    {
+        return new RuntimeManifest(
+            "paper",
+            "1.21.11",
+            1L,
+            "cache-key",
+            "/tmp/lightkeeper/server",
+            "/tmp/lightkeeper/server/server.jar",
+            1024,
+            "/tmp/lightkeeper/agent.sock",
+            "auth-token",
+            "/tmp/lightkeeper/agent.jar",
+            "agent-sha256",
+            1,
+            "agent-cache-identity",
+            null,
+            List.of(),
+            provisionedWorldNames
         );
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkLifecycleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkLifecycleTest.java
@@ -447,6 +447,7 @@ class DefaultLightkeeperFrameworkLifecycleTest
             1,
             "agent-cache-identity",
             null,
+            List.of(),
             List.of()
         );
     }
@@ -468,7 +469,8 @@ class DefaultLightkeeperFrameworkLifecycleTest
             1,
             "agent-cache-identity",
             null,
-            List.of(new RuntimeManifest.PreloadedWorld("preload_world", "NORMAL", "NORMAL", 42L))
+            List.of(new RuntimeManifest.PreloadedWorld("preload_world", "NORMAL", "NORMAL", 42L)),
+            List.of("preload_world")
         );
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkLifecycleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkLifecycleTest.java
@@ -245,6 +245,8 @@ class DefaultLightkeeperFrameworkLifecycleTest
             WorldSpec.WorldEnvironment.NORMAL,
             42L
         ));
+        // Only the loadOnStartup=true world is preloaded; the template world in the fixture must be skipped.
+        verify(agentClient, times(1)).newWorld(any());
 
         framework.beginMethodScope("method-after-restart");
         verify(playerScopeRegistry, times(1)).beginMethodScope("method-after-restart");
@@ -447,7 +449,6 @@ class DefaultLightkeeperFrameworkLifecycleTest
             1,
             "agent-cache-identity",
             null,
-            List.of(),
             List.of()
         );
     }
@@ -469,8 +470,10 @@ class DefaultLightkeeperFrameworkLifecycleTest
             1,
             "agent-cache-identity",
             null,
-            List.of(new RuntimeManifest.PreloadedWorld("preload_world", "NORMAL", "NORMAL", 42L)),
-            List.of("preload_world")
+            List.of(
+                new RuntimeManifest.ProvisionedWorld("preload_world", "NORMAL", "NORMAL", 42L, true),
+                new RuntimeManifest.ProvisionedWorld("template_world", "NETHER", "FLAT", 7L, false)
+            )
         );
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkServerErrorsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkServerErrorsTest.java
@@ -210,7 +210,6 @@ class DefaultLightkeeperFrameworkServerErrorsTest
             1,
             "agent-cache-identity",
             null,
-            List.of(),
             List.of()
         );
     }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkServerErrorsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkServerErrorsTest.java
@@ -210,6 +210,7 @@ class DefaultLightkeeperFrameworkServerErrorsTest
             1,
             "agent-cache-identity",
             null,
+            List.of(),
             List.of()
         );
     }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
@@ -474,7 +474,6 @@ class MinecraftServerProcessTest
             RuntimeProtocol.VERSION,
             "agent-cache",
             null,
-            List.of(),
             List.of()
         );
     }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/MinecraftServerProcessTest.java
@@ -474,6 +474,7 @@ class MinecraftServerProcessTest
             RuntimeProtocol.VERSION,
             "agent-cache",
             null,
+            List.of(),
             List.of()
         );
     }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -2,7 +2,9 @@ package nl.pim16aap2.lightkeeper.framework.internal;
 
 import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
+import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.ItemSnapshot;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicks;
@@ -244,38 +246,94 @@ class UdsAgentClientTest
     }
 
     @Test
-    void dropItem_shouldReturnTrueWhenEventWasNotCancelled(@TempDir Path tempDirectory)
+    void dropItem_shouldReturnDroppedWhenEventWasNotCancelled(@TempDir Path tempDirectory)
         throws Exception
     {
         // setup
         final Path socketPath = tempDirectory.resolve("drop-item.sock");
-        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"dropped\":true}";
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"result\":\"DROPPED\"}";
         try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final boolean dropped = client.dropItem(UUID.randomUUID());
+            final DropResult result = client.dropItem(UUID.randomUUID());
 
             // verify
-            assertThat(dropped).isTrue();
+            assertThat(result).isEqualTo(DropResult.DROPPED);
         }
     }
 
     @Test
-    void dropItem_shouldReturnFalseWhenEventWasCancelled(@TempDir Path tempDirectory)
+    void dropItem_shouldReturnCancelledWhenEventWasCancelled(@TempDir Path tempDirectory)
         throws Exception
     {
         // setup
         final Path socketPath = tempDirectory.resolve("drop-item-cancel.sock");
-        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"dropped\":false}";
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"result\":\"CANCELLED\"}";
         try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final boolean dropped = client.dropItem(UUID.randomUUID());
+            final DropResult result = client.dropItem(UUID.randomUUID());
 
             // verify
-            assertThat(dropped).isFalse();
+            assertThat(result).isEqualTo(DropResult.CANCELLED);
+        }
+    }
+
+    @Test
+    void dropItem_shouldReturnEmptyHandWhenMainHandIsEmpty(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("drop-item-empty-hand.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"result\":\"EMPTY_HAND\"}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final DropResult result = client.dropItem(UUID.randomUUID());
+
+            // verify
+            assertThat(result).isEqualTo(DropResult.EMPTY_HAND);
+        }
+    }
+
+    @Test
+    void leftClickBlock_shouldReturnCancelledFlagFromResponse(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("left-click-block.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"cancelled\":true}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean cancelled = client.leftClickBlock(PLAYER_ID, new Vector3Di(1, 64, 1), "UP");
+
+            // verify
+            assertThat(cancelled).isTrue();
+            assertThat(server.capturedRequest()).contains("\"action\":\"LEFT_CLICK_BLOCK\"");
+        }
+    }
+
+    @Test
+    void rightClickBlock_shouldReturnCancelledFlagFromResponse(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("right-click-block.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"cancelled\":false}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final boolean cancelled = client.rightClickBlock(PLAYER_ID, new Vector3Di(1, 64, 1), "UP");
+
+            // verify
+            assertThat(cancelled).isFalse();
+            assertThat(server.capturedRequest()).contains("\"action\":\"RIGHT_CLICK_BLOCK\"");
         }
     }
 

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
@@ -1,10 +1,12 @@
 package nl.pim16aap2.lightkeeper.maven.test;
 
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.InteractionResult;
 import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
@@ -51,7 +53,7 @@ class LightkeeperBotIT
         secondPlayer.executeCommand("lktestgui")
             .andWaitForMenuOpen(10)
             .verifyMenuName("Main Menu")
-            .clickAtIndex(0)
+            .clickItem("Button 1")
             .andWaitTicks(5)
             .verifyMenuName("Sub Menu")
             .dragWithMaterial("minecraft:stone", 3, 4, 5)
@@ -73,11 +75,15 @@ class LightkeeperBotIT
         player.placeBlock("minecraft:stone", 1, 100, 0)
             .andWaitTicks(1);
         world.setBlockAt(new Vector3Di(3, 100, 0), "minecraft:gold_block");
-        player.leftClickBlock(new Vector3Di(3, 100, 0), BlockFace.NORTH)
-            .rightClickBlock(new Vector3Di(3, 100, 0), BlockFace.SOUTH)
-            .andWaitTicks(1);
+        final InteractionResult leftClickResult = player.leftClickBlock(new Vector3Di(3, 100, 0), BlockFace.NORTH);
+        final InteractionResult rightClickResult = player.rightClickBlock(new Vector3Di(3, 100, 0), BlockFace.SOUTH);
+        player.andWaitTicks(1);
+        final DropResult emptyHandDropResult = player.dropMainHandItem();
 
         // verify
+        assertThat(leftClickResult).isEqualTo(new InteractionResult(true, false));
+        assertThat(rightClickResult).isEqualTo(new InteractionResult(true, false));
+        assertThat(emptyHandDropResult).isEqualTo(DropResult.EMPTY_HAND);
         assertThat(world)
             .hasBlockAt(1, 100, 0)
             .ofType(Material.STONE);

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperProvisioningIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperProvisioningIT.java
@@ -34,7 +34,7 @@ class LightkeeperProvisioningIT
         assertThat(serverDirectory.resolve("plugins/lightkeeper-spigot-test-plugin/test-overlay.yml"))
             .isRegularFile()
             .hasContent("overlay: true\n");
-        assertThat(runtimeManifest.preloadedWorlds()).isEmpty();
+        assertThat(runtimeManifest.provisionedWorlds()).noneMatch(RuntimeManifest.ProvisionedWorld::loadOnStartup);
         assertThat(runtimeManifest.serverType()).isEqualTo(expectedServerType);
     }
 }

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperWorldTemplateIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperWorldTemplateIT.java
@@ -1,0 +1,50 @@
+package nl.pim16aap2.lightkeeper.maven.test;
+
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
+import nl.pim16aap2.lightkeeper.framework.WorldHandle;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.catchThrowable;
+
+@ExtendWith(LightkeeperExtension.class)
+class LightkeeperWorldTemplateIT
+{
+    private static final String TEMPLATE_NAME = "lightkeeper-fixture-world";
+
+    @Test
+    void newWorldFromTemplate_shouldLoadProvisionedTemplateWorld(ILightkeeperFramework framework)
+    {
+        // setup
+        final Path templateDirectory = framework.serverDirectory().resolve(TEMPLATE_NAME);
+
+        // execute
+        final WorldHandle templateWorld = framework.newWorldFromTemplate(TEMPLATE_NAME);
+
+        // verify
+        assertThat(templateWorld).hasNonBlankName();
+        assertThat(templateWorld.name()).isEqualTo(TEMPLATE_NAME);
+        // The provisioned folder is the loaded world's directory: the fixture marker must still be in place.
+        assertThat(templateDirectory.resolve("fixtures").resolve("marker.txt")).exists();
+    }
+
+    @Test
+    void newWorldFromTemplate_shouldRejectUnknownTemplateName(ILightkeeperFramework framework)
+    {
+        // setup
+        final String unknownTemplate = "lightkeeper-no-such-template";
+
+        // execute
+        final Throwable thrown = catchThrowable(() -> framework.newWorldFromTemplate(unknownTemplate));
+
+        // verify
+        assertThat(thrown)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(unknownTemplate)
+            .hasMessageContaining(TEMPLATE_NAME);
+    }
+}

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
@@ -472,6 +472,10 @@ public class PrepareServerMojo extends AbstractMojo
             ))
             .toList();
 
+        final List<String> provisionedWorldNames = worldInputSpecs.stream()
+            .map(WorldInputSpec::name)
+            .toList();
+
         return new RuntimeManifest(
             normalizedServerType,
             resolvedManifestServerVersion,
@@ -488,7 +492,8 @@ public class PrepareServerMojo extends AbstractMojo
             runtimeProtocolVersion,
             agentMetadata.cacheIdentity(),
             PrepareServerInputResolver.normalizeOptionalString(extraJvmArgs),
-            preloadedWorlds
+            preloadedWorlds,
+            provisionedWorldNames
         );
     }
 

--- a/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
+++ b/lightkeeper-maven-plugin/src/main/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerMojo.java
@@ -462,18 +462,14 @@ public class PrepareServerMojo extends AbstractMojo
         int runtimeProtocolVersion,
         List<WorldInputSpec> worldInputSpecs)
     {
-        final List<RuntimeManifest.PreloadedWorld> preloadedWorlds = worldInputSpecs.stream()
-            .filter(WorldInputSpec::loadOnStartup)
-            .map(worldInput -> new RuntimeManifest.PreloadedWorld(
+        final List<RuntimeManifest.ProvisionedWorld> provisionedWorlds = worldInputSpecs.stream()
+            .map(worldInput -> new RuntimeManifest.ProvisionedWorld(
                 worldInput.name(),
                 worldInput.environment(),
                 worldInput.worldType(),
-                worldInput.seed()
+                worldInput.seed(),
+                worldInput.loadOnStartup()
             ))
-            .toList();
-
-        final List<String> provisionedWorldNames = worldInputSpecs.stream()
-            .map(WorldInputSpec::name)
             .toList();
 
         return new RuntimeManifest(
@@ -492,8 +488,7 @@ public class PrepareServerMojo extends AbstractMojo
             runtimeProtocolVersion,
             agentMetadata.cacheIdentity(),
             PrepareServerInputResolver.normalizeOptionalString(extraJvmArgs),
-            preloadedWorlds,
-            provisionedWorldNames
+            provisionedWorlds
         );
     }
 

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerRuntimeSupportTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerRuntimeSupportTest.java
@@ -304,7 +304,6 @@ class PrepareServerRuntimeSupportTest
             1,
             "no-agent",
             null,
-            List.of(),
             List.of()
         );
 
@@ -315,8 +314,7 @@ class PrepareServerRuntimeSupportTest
     }
 
     @Test
-    void createRuntimeManifest_shouldIncludeAllWorldsInProvisionedNamesAndOnlyStartupWorldsInPreloaded(
-        @TempDir Path tempDirectory)
+    void createRuntimeManifest_shouldMapAllWorldInputSpecsToProvisionedWorlds(@TempDir Path tempDirectory)
     {
         // setup
         final PrepareServerMojo mojo = new PrepareServerMojo();
@@ -336,9 +334,9 @@ class PrepareServerRuntimeSupportTest
             tempDirectory.resolve("template-world"),
             true,
             false,
-            "NORMAL",
-            "NORMAL",
-            0L
+            "NETHER",
+            "FLAT",
+            99L
         );
         final ServerProvider serverProvider = mock(ServerProvider.class);
         when(serverProvider.targetJarFilePath()).thenReturn(tempDirectory.resolve("paper.jar"));
@@ -361,9 +359,18 @@ class PrepareServerRuntimeSupportTest
         );
 
         // verify
-        assertThat(runtimeManifest.provisionedWorldNames())
-            .containsExactlyInAnyOrder("startup-world", "template-world");
-        assertThat(runtimeManifest.preloadedWorlds()).hasSize(1);
-        assertThat(runtimeManifest.preloadedWorlds().getFirst().name()).isEqualTo("startup-world");
+        assertThat(runtimeManifest.provisionedWorlds()).hasSize(2);
+        final RuntimeManifest.ProvisionedWorld provisionedStartupWorld = runtimeManifest.provisionedWorlds().get(0);
+        assertThat(provisionedStartupWorld.name()).isEqualTo("startup-world");
+        assertThat(provisionedStartupWorld.environment()).isEqualTo("NORMAL");
+        assertThat(provisionedStartupWorld.worldType()).isEqualTo("NORMAL");
+        assertThat(provisionedStartupWorld.seed()).isEqualTo(0L);
+        assertThat(provisionedStartupWorld.loadOnStartup()).isTrue();
+        final RuntimeManifest.ProvisionedWorld provisionedTemplateWorld = runtimeManifest.provisionedWorlds().get(1);
+        assertThat(provisionedTemplateWorld.name()).isEqualTo("template-world");
+        assertThat(provisionedTemplateWorld.environment()).isEqualTo("NETHER");
+        assertThat(provisionedTemplateWorld.worldType()).isEqualTo("FLAT");
+        assertThat(provisionedTemplateWorld.seed()).isEqualTo(99L);
+        assertThat(provisionedTemplateWorld.loadOnStartup()).isFalse();
     }
 }

--- a/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerRuntimeSupportTest.java
+++ b/lightkeeper-maven-plugin/src/test/java/nl/pim16aap2/lightkeeper/maven/mojo/prepareserver/PrepareServerRuntimeSupportTest.java
@@ -1,5 +1,7 @@
 package nl.pim16aap2.lightkeeper.maven.mojo.prepareserver;
 
+import nl.pim16aap2.lightkeeper.maven.provisioning.WorldInputSpec;
+import nl.pim16aap2.lightkeeper.maven.serverprovider.ServerProvider;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -21,6 +23,7 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class PrepareServerRuntimeSupportTest
 {
@@ -301,6 +304,7 @@ class PrepareServerRuntimeSupportTest
             1,
             "no-agent",
             null,
+            List.of(),
             List.of()
         );
 
@@ -308,5 +312,58 @@ class PrepareServerRuntimeSupportTest
         assertThatThrownBy(() -> PrepareServerRuntimeSupport.writeRuntimeManifest(runtimeManifest, manifestPath))
             .isInstanceOf(MojoExecutionException.class)
             .hasMessageContaining("not a directory");
+    }
+
+    @Test
+    void createRuntimeManifest_shouldIncludeAllWorldsInProvisionedNamesAndOnlyStartupWorldsInPreloaded(
+        @TempDir Path tempDirectory)
+    {
+        // setup
+        final PrepareServerMojo mojo = new PrepareServerMojo();
+        final WorldInputSpec startupWorld = new WorldInputSpec(
+            "startup-world",
+            WorldInputSpec.SourceType.FOLDER,
+            tempDirectory.resolve("startup-world"),
+            true,
+            true,
+            "NORMAL",
+            "NORMAL",
+            0L
+        );
+        final WorldInputSpec templateWorld = new WorldInputSpec(
+            "template-world",
+            WorldInputSpec.SourceType.FOLDER,
+            tempDirectory.resolve("template-world"),
+            true,
+            false,
+            "NORMAL",
+            "NORMAL",
+            0L
+        );
+        final ServerProvider serverProvider = mock(ServerProvider.class);
+        when(serverProvider.targetJarFilePath()).thenReturn(tempDirectory.resolve("paper.jar"));
+        final PrepareServerAgentMetadata agentMetadata = new PrepareServerAgentMetadata("abc123", "agent-cache-id");
+
+        // execute
+        final RuntimeManifest runtimeManifest = mojo.createRuntimeManifest(
+            "paper",
+            "1.21.11",
+            116L,
+            "cache-key",
+            tempDirectory.resolve("server"),
+            serverProvider,
+            768,
+            tempDirectory.resolve("socket.sock"),
+            "auth-token",
+            agentMetadata,
+            1,
+            List.of(startupWorld, templateWorld)
+        );
+
+        // verify
+        assertThat(runtimeManifest.provisionedWorldNames())
+            .containsExactlyInAnyOrder("startup-world", "template-world");
+        assertThat(runtimeManifest.preloadedWorlds()).hasSize(1);
+        assertThat(runtimeManifest.preloadedWorlds().getFirst().name()).isEqualTo("startup-world");
     }
 }

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/DropItem.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/DropItem.java
@@ -47,13 +47,19 @@ public final class DropItem
     /**
      * Response record for {@code DROP_ITEM}.
      *
-     * @param dropped
-     *     {@code true} when the drop materialised (item entity created, inventory slot consumed);
-     *     {@code false} when the player had nothing in hand, or the {@code PlayerDropItemEvent} was cancelled.
+     * @param result
+     *     The drop outcome, distinguishing a successful drop from a cancelled event and an empty main hand.
      */
     public record Response(
-        boolean dropped
+        DropResult result
     ) implements IAgentResponse
     {
+        /**
+         * Validates response inputs.
+         */
+        public Response
+        {
+            ProtocolPreconditions.requireNonNull(result, "result");
+        }
     }
 }

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/DropResult.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/DropResult.java
@@ -1,0 +1,24 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+/**
+ * Outcome of a main-hand item drop, distinguishing the two reasons a drop can fail to materialize.
+ */
+public enum DropResult
+{
+    /**
+     * The drop materialized: a {@code PlayerDropItemEvent} fired uncancelled, the item entity stays in the
+     * world, and one item was consumed from the player's main hand.
+     */
+    DROPPED,
+
+    /**
+     * A plugin cancelled the {@code PlayerDropItemEvent}: the item entity was removed again and the player's
+     * inventory is unchanged.
+     */
+    CANCELLED,
+
+    /**
+     * The player had nothing in their main hand; no event was fired at all.
+     */
+    EMPTY_HAND,
+}

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
@@ -492,14 +492,44 @@ class AgentCommandSerializationTest
     {
         // setup
         final ObjectMapper mapper = AgentProtocolMapper.create();
-        final DropItem.Response original = new DropItem.Response(true);
+        final DropItem.Response original = new DropItem.Response(DropResult.DROPPED);
 
         // execute
         final String json = mapper.writeValueAsString(original);
         final DropItem.Response result = mapper.readValue(json, DropItem.Response.class);
 
         // verify
-        assertThat(result.dropped()).isTrue();
+        assertThat(result.result()).isEqualTo(DropResult.DROPPED);
+    }
+
+    @Test
+    void serialize_dropItemResponse_withCancelledResult_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final DropItem.Response original = new DropItem.Response(DropResult.CANCELLED);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final DropItem.Response result = mapper.readValue(json, DropItem.Response.class);
+
+        // verify
+        assertThat(result.result()).isEqualTo(DropResult.CANCELLED);
+    }
+
+    @Test
+    void serialize_dropItemResponse_withEmptyHandResult_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final DropItem.Response original = new DropItem.Response(DropResult.EMPTY_HAND);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final DropItem.Response result = mapper.readValue(json, DropItem.Response.class);
+
+        // verify
+        assertThat(result.result()).isEqualTo(DropResult.EMPTY_HAND);
     }
 
     // -----------------------------------------------------------------------

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
@@ -143,6 +143,16 @@ class AgentCommandValidationTest
             .hasMessageContaining("permission");
     }
 
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void dropItemResponse_shouldRejectNullResult()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new DropItem.Response(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("result");
+    }
+
     private static Object validDefault(Class<?> type)
     {
         if (type == String.class)

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifest.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifest.java
@@ -35,11 +35,10 @@ import java.util.List;
  *     The cache identity for the resolved agent artifact.
  * @param extraJvmArgs
  *     Optional extra JVM arguments that must be applied when launching the test server runtime.
- * @param preloadedWorlds
- *     Worlds that should be loaded by the framework before test execution.
- * @param provisionedWorldNames
- *     Names of all world folders provisioned into the server directory, including templates that are not
- *     loaded on startup. Used by the framework to validate template names before loading.
+ * @param provisionedWorlds
+ *     All worlds provisioned into the server directory by {@code prepare-server}, including templates that
+ *     are not loaded on startup. The framework preloads the {@code loadOnStartup} entries before test
+ *     execution and validates template names against the full list.
  */
 public record RuntimeManifest(
     String serverType,
@@ -56,18 +55,16 @@ public record RuntimeManifest(
     int runtimeProtocolVersion,
     String agentCacheIdentity,
     @Nullable String extraJvmArgs,
-    List<PreloadedWorld> preloadedWorlds,
-    List<String> provisionedWorldNames
+    List<ProvisionedWorld> provisionedWorlds
 )
 {
     public RuntimeManifest
     {
-        preloadedWorlds = preloadedWorlds == null ? List.of() : List.copyOf(preloadedWorlds);
-        provisionedWorldNames = provisionedWorldNames == null ? List.of() : List.copyOf(provisionedWorldNames);
+        provisionedWorlds = provisionedWorlds == null ? List.of() : List.copyOf(provisionedWorlds);
     }
 
     /**
-     * World metadata for framework preloading.
+     * Metadata of a world provisioned into the server directory.
      *
      * @param name
      *     World name.
@@ -77,12 +74,15 @@ public record RuntimeManifest(
      *     World type enum name.
      * @param seed
      *     World seed.
+     * @param loadOnStartup
+     *     Whether the framework loads this world before test execution.
      */
-    public record PreloadedWorld(
+    public record ProvisionedWorld(
         String name,
         String environment,
         String worldType,
-        long seed
+        long seed,
+        boolean loadOnStartup
     )
     {
     }

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifest.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifest.java
@@ -37,6 +37,9 @@ import java.util.List;
  *     Optional extra JVM arguments that must be applied when launching the test server runtime.
  * @param preloadedWorlds
  *     Worlds that should be loaded by the framework before test execution.
+ * @param provisionedWorldNames
+ *     Names of all world folders provisioned into the server directory, including templates that are not
+ *     loaded on startup. Used by the framework to validate template names before loading.
  */
 public record RuntimeManifest(
     String serverType,
@@ -53,12 +56,14 @@ public record RuntimeManifest(
     int runtimeProtocolVersion,
     String agentCacheIdentity,
     @Nullable String extraJvmArgs,
-    List<PreloadedWorld> preloadedWorlds
+    List<PreloadedWorld> preloadedWorlds,
+    List<String> provisionedWorldNames
 )
 {
     public RuntimeManifest
     {
         preloadedWorlds = preloadedWorlds == null ? List.of() : List.copyOf(preloadedWorlds);
+        provisionedWorldNames = provisionedWorldNames == null ? List.of() : List.copyOf(provisionedWorldNames);
     }
 
     /**

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReader.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReader.java
@@ -66,24 +66,16 @@ public final class RuntimeManifestReader
         if (manifest.agentCacheIdentity() == null || manifest.agentCacheIdentity().isBlank())
             throw new IOException("Runtime manifest field 'agentCacheIdentity' is missing or blank.");
 
-        for (final RuntimeManifest.PreloadedWorld preloadedWorld : manifest.preloadedWorlds())
+        for (final RuntimeManifest.ProvisionedWorld provisionedWorld : manifest.provisionedWorlds())
         {
-            if (preloadedWorld.name() == null || preloadedWorld.name().isBlank())
-                throw new IOException("Runtime manifest contains preloaded world with missing name.");
-            if (preloadedWorld.environment() == null || preloadedWorld.environment().isBlank())
-                throw new IOException("Runtime manifest preloaded world '%s' is missing environment."
-                    .formatted(preloadedWorld.name()));
-            if (preloadedWorld.worldType() == null || preloadedWorld.worldType().isBlank())
-                throw new IOException("Runtime manifest preloaded world '%s' is missing worldType."
-                    .formatted(preloadedWorld.name()));
-        }
-
-        // Null elements cannot reach this point: the record's compact constructor copies the list via
-        // List.copyOf, which rejects them during deserialization.
-        for (final String provisionedWorldName : manifest.provisionedWorldNames())
-        {
-            if (provisionedWorldName.isBlank())
+            if (provisionedWorld.name() == null || provisionedWorld.name().isBlank())
                 throw new IOException("Runtime manifest contains a provisioned world with a missing name.");
+            if (provisionedWorld.environment() == null || provisionedWorld.environment().isBlank())
+                throw new IOException("Runtime manifest provisioned world '%s' is missing environment."
+                    .formatted(provisionedWorld.name()));
+            if (provisionedWorld.worldType() == null || provisionedWorld.worldType().isBlank())
+                throw new IOException("Runtime manifest provisioned world '%s' is missing worldType."
+                    .formatted(provisionedWorld.name()));
         }
     }
 }

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReader.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReader.java
@@ -77,5 +77,11 @@ public final class RuntimeManifestReader
                 throw new IOException("Runtime manifest preloaded world '%s' is missing worldType."
                     .formatted(preloadedWorld.name()));
         }
+
+        for (final String provisionedWorldName : manifest.provisionedWorldNames())
+        {
+            if (provisionedWorldName == null || provisionedWorldName.isBlank())
+                throw new IOException("Runtime manifest contains a provisioned world with a missing name.");
+        }
     }
 }

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReader.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReader.java
@@ -78,9 +78,11 @@ public final class RuntimeManifestReader
                     .formatted(preloadedWorld.name()));
         }
 
+        // Null elements cannot reach this point: the record's compact constructor copies the list via
+        // List.copyOf, which rejects them during deserialization.
         for (final String provisionedWorldName : manifest.provisionedWorldNames())
         {
-            if (provisionedWorldName == null || provisionedWorldName.isBlank())
+            if (provisionedWorldName.isBlank())
                 throw new IOException("Runtime manifest contains a provisioned world with a missing name.");
         }
     }

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -20,7 +20,7 @@ public final class RuntimeProtocol
      * in a backward-incompatible way. Both the framework and the agent must agree on this value;
      * a mismatch causes an {@code HANDSHAKE} failure.
      */
-    public static final int VERSION = 4;
+    public static final int VERSION = 5;
 
     /**
      * Minecraft server version supported by this LightKeeper build.

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class RuntimeManifestReaderTest
 {
@@ -148,12 +149,13 @@ class RuntimeManifestReaderTest
               "agentAuthToken": "token",
               "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
-              "preloadedWorlds": [
+              "provisionedWorlds": [
                 {
                   "name": "",
                   "environment": "NORMAL",
                   "worldType": "FLAT",
-                  "seed": 42
+                  "seed": 42,
+                  "loadOnStartup": true
                 }
               ]
             }
@@ -185,12 +187,13 @@ class RuntimeManifestReaderTest
               "agentAuthToken": "token",
               "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
-              "preloadedWorlds": [
+              "provisionedWorlds": [
                 {
                   "name": "fixture",
                   "environment": "",
                   "worldType": "FLAT",
-                  "seed": 42
+                  "seed": 42,
+                  "loadOnStartup": true
                 }
               ]
             }
@@ -222,12 +225,13 @@ class RuntimeManifestReaderTest
               "agentAuthToken": "token",
               "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
-              "preloadedWorlds": [
+              "provisionedWorlds": [
                 {
                   "name": "fixture",
                   "environment": "NORMAL",
                   "worldType": "",
-                  "seed": 42
+                  "seed": 42,
+                  "loadOnStartup": true
                 }
               ]
             }
@@ -301,7 +305,7 @@ class RuntimeManifestReaderTest
         assertThat(runtimeManifest.serverType()).isEqualTo("paper");
         assertThat(runtimeManifest.udsSocketPath()).isEqualTo("/tmp/lightkeeper.sock");
         assertThat(runtimeManifest.memoryMb()).isEqualTo(2048);
-        assertThat(runtimeManifest.preloadedWorlds()).isEmpty();
+        assertThat(runtimeManifest.provisionedWorlds()).isEmpty();
     }
 
     @Test
@@ -323,12 +327,13 @@ class RuntimeManifestReaderTest
               "agentAuthToken": "token",
               "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
-              "preloadedWorlds": [
+              "provisionedWorlds": [
                 {
                   "name": "fixture-world",
                   "environment": "NORMAL",
                   "worldType": "FLAT",
-                  "seed": 42
+                  "seed": 42,
+                  "loadOnStartup": true
                 }
               ]
             }
@@ -339,13 +344,13 @@ class RuntimeManifestReaderTest
         final RuntimeManifest runtimeManifest = new RuntimeManifestReader().read(manifestPath);
 
         // verify
-        assertThat(runtimeManifest.preloadedWorlds()).hasSize(1);
-        assertThat(runtimeManifest.preloadedWorlds().getFirst().name()).isEqualTo("fixture-world");
-        assertThat(runtimeManifest.preloadedWorlds().getFirst().worldType()).isEqualTo("FLAT");
+        assertThat(runtimeManifest.provisionedWorlds()).hasSize(1);
+        assertThat(runtimeManifest.provisionedWorlds().getFirst().name()).isEqualTo("fixture-world");
+        assertThat(runtimeManifest.provisionedWorlds().getFirst().worldType()).isEqualTo("FLAT");
     }
 
     @Test
-    void read_shouldParseProvisionedWorldNamesWhenPresent(@TempDir Path tempDirectory)
+    void read_shouldParseProvisionedWorldsWhenPresent(@TempDir Path tempDirectory)
         throws IOException
     {
         // setup
@@ -363,7 +368,22 @@ class RuntimeManifestReaderTest
               "agentAuthToken": "token",
               "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
-              "provisionedWorldNames": ["template-a", "world-b"]
+              "provisionedWorlds": [
+                {
+                  "name": "template-a",
+                  "environment": "NORMAL",
+                  "worldType": "NORMAL",
+                  "seed": 0,
+                  "loadOnStartup": true
+                },
+                {
+                  "name": "world-b",
+                  "environment": "NETHER",
+                  "worldType": "FLAT",
+                  "seed": 7,
+                  "loadOnStartup": false
+                }
+              ]
             }
             """.formatted(RuntimeProtocol.VERSION)
         );
@@ -372,11 +392,15 @@ class RuntimeManifestReaderTest
         final RuntimeManifest runtimeManifest = new RuntimeManifestReader().read(manifestPath);
 
         // verify
-        assertThat(runtimeManifest.provisionedWorldNames()).containsExactly("template-a", "world-b");
+        assertThat(runtimeManifest.provisionedWorlds()).hasSize(2);
+        assertThat(runtimeManifest.provisionedWorlds().get(0).name()).isEqualTo("template-a");
+        assertThat(runtimeManifest.provisionedWorlds().get(0).loadOnStartup()).isTrue();
+        assertThat(runtimeManifest.provisionedWorlds().get(1).name()).isEqualTo("world-b");
+        assertThat(runtimeManifest.provisionedWorlds().get(1).loadOnStartup()).isFalse();
     }
 
     @Test
-    void read_shouldDefaultProvisionedWorldNamesToEmptyListWhenAbsent(@TempDir Path tempDirectory)
+    void read_shouldDefaultProvisionedWorldsToEmptyListWhenAbsent(@TempDir Path tempDirectory)
         throws IOException
     {
         // setup
@@ -402,7 +426,7 @@ class RuntimeManifestReaderTest
         final RuntimeManifest runtimeManifest = new RuntimeManifestReader().read(manifestPath);
 
         // verify
-        assertThat(runtimeManifest.provisionedWorldNames()).isEmpty();
+        assertThat(runtimeManifest.provisionedWorlds()).isEmpty();
     }
 
     @Test
@@ -424,22 +448,37 @@ class RuntimeManifestReaderTest
               "agentAuthToken": "token",
               "runtimeProtocolVersion": %d,
               "agentCacheIdentity": "no-agent",
-              "provisionedWorldNames": [""]
+              "provisionedWorlds": [
+                {
+                  "name": "",
+                  "environment": "NORMAL",
+                  "worldType": "NORMAL",
+                  "seed": 0,
+                  "loadOnStartup": true
+                }
+              ]
             }
             """.formatted(RuntimeProtocol.VERSION)
         );
+        final RuntimeManifestReader runtimeManifestReader = new RuntimeManifestReader();
 
-        // execute + verify
-        assertThatThrownBy(() -> new RuntimeManifestReader().read(manifestPath))
+        // execute
+        final Throwable thrown = catchThrowable(() -> runtimeManifestReader.read(manifestPath));
+
+        // verify
+        assertThat(thrown)
             .isInstanceOf(IOException.class)
             .hasMessageContaining("Runtime manifest contains a provisioned world with a missing name.");
     }
 
     @Test
     @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
-    void runtimeManifest_shouldDefaultProvisionedWorldNamesToEmptyListWhenConstructedWithNull()
+    void runtimeManifest_shouldDefaultProvisionedWorldsToEmptyListWhenConstructedWithNull()
     {
-        // setup + execute
+        // setup
+        final List<RuntimeManifest.ProvisionedWorld> nullProvisionedWorlds = null;
+
+        // execute
         final RuntimeManifest runtimeManifest = new RuntimeManifest(
             "paper",
             "1.21.11",
@@ -455,12 +494,11 @@ class RuntimeManifestReaderTest
             RuntimeProtocol.VERSION,
             "no-agent",
             null,
-            List.of(),
-            null
+            nullProvisionedWorlds
         );
 
         // verify
-        assertThat(runtimeManifest.provisionedWorldNames()).isEmpty();
+        assertThat(runtimeManifest.provisionedWorlds()).isEmpty();
     }
 
     private static String defaultValueFor(String fieldName)

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestReaderTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -341,6 +342,125 @@ class RuntimeManifestReaderTest
         assertThat(runtimeManifest.preloadedWorlds()).hasSize(1);
         assertThat(runtimeManifest.preloadedWorlds().getFirst().name()).isEqualTo("fixture-world");
         assertThat(runtimeManifest.preloadedWorlds().getFirst().worldType()).isEqualTo("FLAT");
+    }
+
+    @Test
+    void read_shouldParseProvisionedWorldNamesWhenPresent(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final Path manifestPath = tempDirectory.resolve("runtime-manifest.json");
+        Files.writeString(manifestPath, """
+            {
+              "serverType": "paper",
+              "serverVersion": "1.21.11",
+              "paperBuildId": 113,
+              "cacheKey": "cache-key",
+              "serverDirectory": "/tmp/server",
+              "serverJar": "/tmp/server/paper.jar",
+              "memoryMb": 2048,
+              "udsSocketPath": "/tmp/lightkeeper.sock",
+              "agentAuthToken": "token",
+              "runtimeProtocolVersion": %d,
+              "agentCacheIdentity": "no-agent",
+              "provisionedWorldNames": ["template-a", "world-b"]
+            }
+            """.formatted(RuntimeProtocol.VERSION)
+        );
+
+        // execute
+        final RuntimeManifest runtimeManifest = new RuntimeManifestReader().read(manifestPath);
+
+        // verify
+        assertThat(runtimeManifest.provisionedWorldNames()).containsExactly("template-a", "world-b");
+    }
+
+    @Test
+    void read_shouldDefaultProvisionedWorldNamesToEmptyListWhenAbsent(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final Path manifestPath = tempDirectory.resolve("runtime-manifest.json");
+        Files.writeString(manifestPath, """
+            {
+              "serverType": "paper",
+              "serverVersion": "1.21.11",
+              "paperBuildId": 113,
+              "cacheKey": "cache-key",
+              "serverDirectory": "/tmp/server",
+              "serverJar": "/tmp/server/paper.jar",
+              "memoryMb": 2048,
+              "udsSocketPath": "/tmp/lightkeeper.sock",
+              "agentAuthToken": "token",
+              "runtimeProtocolVersion": %d,
+              "agentCacheIdentity": "no-agent"
+            }
+            """.formatted(RuntimeProtocol.VERSION)
+        );
+
+        // execute
+        final RuntimeManifest runtimeManifest = new RuntimeManifestReader().read(manifestPath);
+
+        // verify
+        assertThat(runtimeManifest.provisionedWorldNames()).isEmpty();
+    }
+
+    @Test
+    void read_shouldThrowExceptionWhenProvisionedWorldNameIsBlank(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final Path manifestPath = tempDirectory.resolve("runtime-manifest.json");
+        Files.writeString(manifestPath, """
+            {
+              "serverType": "paper",
+              "serverVersion": "1.21.11",
+              "paperBuildId": 113,
+              "cacheKey": "cache-key",
+              "serverDirectory": "/tmp/server",
+              "serverJar": "/tmp/server/paper.jar",
+              "memoryMb": 2048,
+              "udsSocketPath": "/tmp/lightkeeper.sock",
+              "agentAuthToken": "token",
+              "runtimeProtocolVersion": %d,
+              "agentCacheIdentity": "no-agent",
+              "provisionedWorldNames": [""]
+            }
+            """.formatted(RuntimeProtocol.VERSION)
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> new RuntimeManifestReader().read(manifestPath))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("Runtime manifest contains a provisioned world with a missing name.");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void runtimeManifest_shouldDefaultProvisionedWorldNamesToEmptyListWhenConstructedWithNull()
+    {
+        // setup + execute
+        final RuntimeManifest runtimeManifest = new RuntimeManifest(
+            "paper",
+            "1.21.11",
+            113,
+            "cache-key",
+            "/tmp/server",
+            "/tmp/server/paper.jar",
+            2048,
+            "/tmp/lightkeeper.sock",
+            "token",
+            null,
+            null,
+            RuntimeProtocol.VERSION,
+            "no-agent",
+            null,
+            List.of(),
+            null
+        );
+
+        // verify
+        assertThat(runtimeManifest.provisionedWorldNames()).isEmpty();
     }
 
     private static String defaultValueFor(String fieldName)

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestValidatorTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestValidatorTest.java
@@ -88,7 +88,6 @@ class RuntimeManifestValidatorTest
             protocolVersion,
             "agent-cache-id",
             null,
-            List.of(),
             List.of()
         );
     }

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestValidatorTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestValidatorTest.java
@@ -88,6 +88,7 @@ class RuntimeManifestValidatorTest
             protocolVersion,
             "agent-cache-id",
             null,
+            List.of(),
             List.of()
         );
     }

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
@@ -46,5 +46,6 @@ class RuntimeManifestWriterTest
         assertThat(parsedManifest.extraJvmArgs()).isEqualTo("-Dfoo=bar");
         assertThat(parsedManifest.preloadedWorlds()).hasSize(1);
         assertThat(parsedManifest.preloadedWorlds().getFirst().name()).isEqualTo("fixture-world");
+        assertThat(parsedManifest.provisionedWorldNames()).containsExactly("fixture-world", "template-world");
     }
 }

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
@@ -30,7 +30,8 @@ class RuntimeManifestWriterTest
             RuntimeProtocol.VERSION,
             "agent-cache-id",
             "-Dfoo=bar",
-            List.of(new RuntimeManifest.PreloadedWorld("fixture-world", "NORMAL", "FLAT", 42L))
+            List.of(new RuntimeManifest.PreloadedWorld("fixture-world", "NORMAL", "FLAT", 42L)),
+            List.of("fixture-world", "template-world")
         );
         final Path manifestPath = tempDirectory.resolve("runtime-manifest.json");
 

--- a/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
+++ b/lightkeeper-runtime-core/src/test/java/nl/pim16aap2/lightkeeper/runtime/RuntimeManifestWriterTest.java
@@ -30,8 +30,10 @@ class RuntimeManifestWriterTest
             RuntimeProtocol.VERSION,
             "agent-cache-id",
             "-Dfoo=bar",
-            List.of(new RuntimeManifest.PreloadedWorld("fixture-world", "NORMAL", "FLAT", 42L)),
-            List.of("fixture-world", "template-world")
+            List.of(
+                new RuntimeManifest.ProvisionedWorld("fixture-world", "NORMAL", "FLAT", 42L, true),
+                new RuntimeManifest.ProvisionedWorld("template-world", "NORMAL", "NORMAL", 0L, false)
+            )
         );
         final Path manifestPath = tempDirectory.resolve("runtime-manifest.json");
 
@@ -44,8 +46,11 @@ class RuntimeManifestWriterTest
         assertThat(parsedManifest.serverVersion()).isEqualTo("1.21.11");
         assertThat(parsedManifest.paperBuildId()).isEqualTo(116L);
         assertThat(parsedManifest.extraJvmArgs()).isEqualTo("-Dfoo=bar");
-        assertThat(parsedManifest.preloadedWorlds()).hasSize(1);
-        assertThat(parsedManifest.preloadedWorlds().getFirst().name()).isEqualTo("fixture-world");
-        assertThat(parsedManifest.provisionedWorldNames()).containsExactly("fixture-world", "template-world");
+        assertThat(parsedManifest.provisionedWorlds()).hasSize(2);
+        assertThat(parsedManifest.provisionedWorlds().get(0).name()).isEqualTo("fixture-world");
+        assertThat(parsedManifest.provisionedWorlds().get(0).worldType()).isEqualTo("FLAT");
+        assertThat(parsedManifest.provisionedWorlds().get(0).loadOnStartup()).isTrue();
+        assertThat(parsedManifest.provisionedWorlds().get(1).name()).isEqualTo("template-world");
+        assertThat(parsedManifest.provisionedWorlds().get(1).loadOnStartup()).isFalse();
     }
 }

--- a/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/GuiMenuService.java
+++ b/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/GuiMenuService.java
@@ -5,6 +5,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Builds and opens deterministic test menus for the standalone integration plugin.
@@ -13,6 +14,7 @@ final class GuiMenuService
 {
     static final String MAIN_MENU_TITLE = "Main Menu";
     static final String SUB_MENU_TITLE = "Sub Menu";
+    static final String BUTTON_NAME = "Button 1";
     static final String BUTTON_CLICK_MESSAGE = "You clicked Button 1";
 
     /**
@@ -24,9 +26,29 @@ final class GuiMenuService
     void openMainMenu(Player player)
     {
         final Inventory inventory = Bukkit.createInventory(player, 9, MAIN_MENU_TITLE);
-        inventory.setItem(0, new ItemStack(Material.STONE));
+        inventory.setItem(0, namedItem(new ItemStack(Material.STONE), BUTTON_NAME));
         inventory.setItem(2, new ItemStack(Material.DIAMOND_SWORD));
         player.openInventory(inventory);
+    }
+
+    /**
+     * Applies a display name to an item so display-name-based menu interactions can be integration-tested.
+     *
+     * @param item
+     *     Item to name.
+     * @param displayName
+     *     Display name to apply.
+     * @return The same item, with the display name applied when item meta is available.
+     */
+    private static ItemStack namedItem(ItemStack item, String displayName)
+    {
+        final ItemMeta itemMeta = item.getItemMeta();
+        if (itemMeta != null)
+        {
+            itemMeta.setDisplayName(displayName);
+            item.setItemMeta(itemMeta);
+        }
+        return item;
     }
 
     /**


### PR DESCRIPTION
## Why
- Completes roadmap slice S1: template worlds for fixture-based tests (AA's LIF/RED lanes), menu ergonomics (GUI test ergonomics), and observable interaction outcomes (CRE-7/18; kills trap #6 — empty-hand drops were indistinguishable from cancelled drops).
- A typo'd template name used to silently create a fresh world; click cancellation was computed agent-side but discarded by the client.

## How
- **Templates**: the manifest gains `provisionedWorldNames` (all `<worlds>` entries, incl. `loadOnStartup=false`); `newWorldFromTemplate(name)` validates against it before touching the server and fails loudly listing the available templates.
- **Menus**: actions (`clickAtIndex`, new `clickItem(displayNameFragment)`, `dragWithMaterial`) auto-wait for an open menu (bounded 10s — the one deliberate implicit wait); new `isOpen()` probe.
- **Results** (⚠ breaking): `leftClickBlock`/`rightClickBlock` return `InteractionResult(eventFired, cancelled)` instead of the fluent handle; `dropMainHandItem` returns `DropResult` (`DROPPED`/`CANCELLED`/`EMPTY_HAND`). Protocol v5 for the changed `DROP_ITEM` response shape. `eventFired` is always true for clicks today by design — it is the blueprint contract; `placeBlock` gains real (bypassable) events in a later slice.

## Tests
- `mvn -Perrorprone clean install checkstyle:checkstyle pmd:check`: BUILD SUCCESS, 0 checkstyle/PMD violations (updated + 33 new unit tests across protocol/runtime-core/maven-plugin/agent/framework).
- `mvn clean verify -pl lightkeeper-integration-tests`: 26/26 on both Paper and Spigot lanes, including new `LightkeeperWorldTemplateIT` (template round-trip via the provisioned folder's marker file + typo rejection) and `LightkeeperBotIT` now clicking by display name and asserting `InteractionResult`/`DropResult` (incl. `EMPTY_HAND`) live.
- Pre-PR deep review (Opus agent): MERGE-WITH-FIXES; all findings addressed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P15FjGQzyNmX9T6Qmyq8Dn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added world creation from provisioned templates, with clear errors for unknown or invalid template names.
  * Menu interactions now wait for menus to open automatically and support clicking items by display name.
  * Added instant menu-open checks.
  * Block interactions now report event and cancellation outcomes.
  * Item drops now distinguish successful, cancelled, and empty-hand results.

* **Documentation**
  * Expanded feature documentation with interaction results, menu behavior, and world templates.

* **Bug Fixes**
  * Improved error messages when menus fail to open or matching items cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->