### PR TITLE
feat: diagnostics-on-failure bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ class MyPluginIT
 - World templates: provision world folders via `<worlds>` and load them with
   `newWorldFromTemplate("name")` — typos fail loudly instead of silently creating a fresh world
 - Received-message assertions with AssertJ string chaining
+- Diagnostics-on-failure: failed tests automatically get a bundle (test outcome, captured server errors,
+  server console output) under `target/lightkeeper-reports/`
 - Graceful server lifecycle control from tests (`stopServer()`, `startServer()`, `restartServer()`), plus
   `crashServer()` for hard-kill scenarios
 - Server directory access (`serverDirectory()`, `pluginDataDirectory(name)`) for seeding files while the
@@ -383,6 +385,11 @@ GitHub Actions can cache URL and Modrinth plugin downloads separately from the n
 
 - Failsafe reports:
     - `lightkeeper-integration-tests/target/failsafe-reports/`
+- Diagnostics bundles (written by the JUnit extension when a test fails):
+    - `target/lightkeeper-reports/<TestClass>/<testMethod>-<timestamp>/` with `outcome.txt`,
+      `server-errors.txt`, and `server-output.log`
+    - Control via system properties: `lightkeeper.diagnostics` = `on-failure` (default) | `always` | `off`,
+      and `lightkeeper.diagnosticsDirectory` to relocate the report root
 - Runtime manifests:
     - `lightkeeper-integration-tests/target/lightkeeper/*-runtime-manifest.json`
 - Prepared server directories:

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtension.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtension.java
@@ -32,6 +32,8 @@ public final class LightkeeperExtension implements
     AfterAllCallback,
     ParameterResolver
 {
+    private static final System.Logger LOG = System.getLogger(LightkeeperExtension.class.getName());
+
     private static final ExtensionContext.Namespace NAMESPACE =
         ExtensionContext.Namespace.create(LightkeeperExtension.class);
     private static final String KEY_SHARED_FRAMEWORK = "shared-framework";
@@ -41,10 +43,14 @@ public final class LightkeeperExtension implements
 
     /**
      * Starts a shared framework when tests are not configured for per-method fresh servers.
+     *
+     * <p>Also validates the diagnostics configuration up front: a typo in {@code lightkeeper.diagnostics} must
+     * fail loudly here, before any server is provisioned — not during cleanup.
      */
     @Override
     public void beforeAll(ExtensionContext context)
     {
+        diagnosticsMode();
         if (usesFreshLifecycleForClass(context) || hasMethodLevelFreshServers(context))
             return;
         getClassStore(context).put(KEY_SHARED_FRAMEWORK, startFramework());
@@ -236,29 +242,57 @@ public final class LightkeeperExtension implements
 
     /**
      * Writes a diagnostics bundle when the configured mode calls for one and a live framework exists for the
-     * current test. Never starts a framework and never throws: diagnostics are best-effort by contract.
+     * current test. Never starts a framework and never throws — this runs before the cleanup in
+     * {@link #afterEach}, and a diagnostics problem (including a mode value changed to garbage mid-run) must
+     * not prevent that cleanup from running.
      */
     private static void maybeWriteDiagnostics(ExtensionContext context)
     {
-        final DiagnosticsMode mode = diagnosticsMode();
+        try
+        {
+            final DiagnosticsMode mode = diagnosticsMode();
+            if (mode == DiagnosticsMode.OFF)
+                return;
+
+            final @Nullable Throwable failure = context.getExecutionException().orElse(null);
+            if (!shouldWriteBundle(mode, failure))
+                return;
+
+            final @Nullable ILightkeeperFramework framework = findExistingFramework(context);
+            if (framework == null)
+                return;
+
+            FailureDiagnosticsWriter.write(
+                framework,
+                diagnosticsDirectory(),
+                context.getRequiredTestClass().getSimpleName(),
+                context.getRequiredTestMethod().getName(),
+                failure
+            );
+        }
+        catch (RuntimeException exception)
+        {
+            LOG.log(
+                System.Logger.Level.WARNING,
+                "LK_DIAGNOSTICS: Skipping the diagnostics bundle because of an unexpected error.",
+                exception
+            );
+        }
+    }
+
+    /**
+     * Decides whether a bundle should be written for the given mode and collected throwable.
+     *
+     * <p>An assumption abort ({@link org.opentest4j.TestAbortedException}) means the test was skipped, not
+     * failed: it never triggers an {@code on-failure} bundle, though {@code always} mode still records it.
+     */
+    static boolean shouldWriteBundle(DiagnosticsMode mode, @Nullable Throwable failure)
+    {
+        if (mode == DiagnosticsMode.ALWAYS)
+            return true;
         if (mode == DiagnosticsMode.OFF)
-            return;
-
-        final @Nullable Throwable failure = context.getExecutionException().orElse(null);
-        if (failure == null && mode != DiagnosticsMode.ALWAYS)
-            return;
-
-        final @Nullable ILightkeeperFramework framework = findExistingFramework(context);
-        if (framework == null)
-            return;
-
-        FailureDiagnosticsWriter.write(
-            framework,
-            diagnosticsDirectory(),
-            context.getRequiredTestClass().getSimpleName(),
-            context.getTestMethod().map(java.lang.reflect.Method::getName).orElse("unknown-method"),
-            failure
-        );
+            return false;
+        return failure != null && !(failure instanceof org.opentest4j.TestAbortedException);
     }
 
     /**
@@ -275,12 +309,13 @@ public final class LightkeeperExtension implements
         return getClassStore(context).get(KEY_SHARED_FRAMEWORK, ILightkeeperFramework.class);
     }
 
-    private static DiagnosticsMode diagnosticsMode()
+    static DiagnosticsMode diagnosticsMode()
     {
         final String configuredMode = System.getProperty("lightkeeper.diagnostics", "on-failure").trim();
         return switch (configuredMode.toLowerCase(Locale.ROOT))
         {
-            case "on-failure" -> DiagnosticsMode.ON_FAILURE;
+            // An empty value (e.g. a bare -Dlightkeeper.diagnostics=) means "use the default".
+            case "", "on-failure" -> DiagnosticsMode.ON_FAILURE;
             case "always" -> DiagnosticsMode.ALWAYS;
             case "off" -> DiagnosticsMode.OFF;
             default -> throw new IllegalStateException(
@@ -297,7 +332,7 @@ public final class LightkeeperExtension implements
     /**
      * When the extension captures a diagnostics bundle.
      */
-    private enum DiagnosticsMode
+    enum DiagnosticsMode
     {
         /**
          * Never write bundles.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtension.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtension.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.lightkeeper.framework;
 
 import nl.pim16aap2.lightkeeper.framework.internal.DefaultLightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.internal.FailureDiagnosticsWriter;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -9,12 +10,20 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import org.jspecify.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * JUnit extension for framework lifecycle management.
+ *
+ * <p>On test failure the extension writes a diagnostics bundle (test outcome, captured server errors, server
+ * console output) before any cleanup runs — see {@link FailureDiagnosticsWriter}. Two system properties control
+ * this: {@code lightkeeper.diagnostics} ({@code on-failure} (default) | {@code always} | {@code off}) and
+ * {@code lightkeeper.diagnosticsDirectory} (default {@code target/lightkeeper-reports}, resolved against the
+ * test JVM's working directory).
  */
 public final class LightkeeperExtension implements
     BeforeAllCallback,
@@ -61,10 +70,16 @@ public final class LightkeeperExtension implements
 
     /**
      * Cleans up method-scoped framework resources after each test method.
+     *
+     * <p>Diagnostics are captured first: JUnit's {@code TestWatcher} hooks only run after all
+     * {@code afterEach} callbacks, by which point the framework is closed (fresh mode) or its error capture
+     * cleared (shared mode) — so this is the last moment the failing test's state is still observable.
      */
     @Override
     public void afterEach(ExtensionContext context)
     {
+        maybeWriteDiagnostics(context);
+
         if (!usesFreshLifecycleForMethod(context))
         {
             final ILightkeeperFramework sharedFramework = getClassStore(context).get(
@@ -217,5 +232,86 @@ public final class LightkeeperExtension implements
         if (runtimeManifestPath.isBlank())
             throw new IllegalStateException("System property 'lightkeeper.runtimeManifestPath' is not set.");
         return Lightkeeper.start(Path.of(runtimeManifestPath));
+    }
+
+    /**
+     * Writes a diagnostics bundle when the configured mode calls for one and a live framework exists for the
+     * current test. Never starts a framework and never throws: diagnostics are best-effort by contract.
+     */
+    private static void maybeWriteDiagnostics(ExtensionContext context)
+    {
+        final DiagnosticsMode mode = diagnosticsMode();
+        if (mode == DiagnosticsMode.OFF)
+            return;
+
+        final @Nullable Throwable failure = context.getExecutionException().orElse(null);
+        if (failure == null && mode != DiagnosticsMode.ALWAYS)
+            return;
+
+        final @Nullable ILightkeeperFramework framework = findExistingFramework(context);
+        if (framework == null)
+            return;
+
+        FailureDiagnosticsWriter.write(
+            framework,
+            diagnosticsDirectory(),
+            context.getRequiredTestClass().getSimpleName(),
+            context.getTestMethod().map(java.lang.reflect.Method::getName).orElse("unknown-method"),
+            failure
+        );
+    }
+
+    /**
+     * Finds the framework bound to the current test, if any, without ever starting one.
+     */
+    private static @Nullable ILightkeeperFramework findExistingFramework(ExtensionContext context)
+    {
+        final ILightkeeperFramework methodFramework = getMethodStore(context).get(
+            KEY_METHOD_FRAMEWORK,
+            ILightkeeperFramework.class
+        );
+        if (methodFramework != null)
+            return methodFramework;
+        return getClassStore(context).get(KEY_SHARED_FRAMEWORK, ILightkeeperFramework.class);
+    }
+
+    private static DiagnosticsMode diagnosticsMode()
+    {
+        final String configuredMode = System.getProperty("lightkeeper.diagnostics", "on-failure").trim();
+        return switch (configuredMode.toLowerCase(Locale.ROOT))
+        {
+            case "on-failure" -> DiagnosticsMode.ON_FAILURE;
+            case "always" -> DiagnosticsMode.ALWAYS;
+            case "off" -> DiagnosticsMode.OFF;
+            default -> throw new IllegalStateException(
+                ("Unknown value '%s' for system property 'lightkeeper.diagnostics'; expected 'on-failure', "
+                    + "'always', or 'off'.").formatted(configuredMode));
+        };
+    }
+
+    private static Path diagnosticsDirectory()
+    {
+        return Path.of(System.getProperty("lightkeeper.diagnosticsDirectory", "target/lightkeeper-reports"));
+    }
+
+    /**
+     * When the extension captures a diagnostics bundle.
+     */
+    private enum DiagnosticsMode
+    {
+        /**
+         * Never write bundles.
+         */
+        OFF,
+
+        /**
+         * Write a bundle only for failed tests (default).
+         */
+        ON_FAILURE,
+
+        /**
+         * Write a bundle for every test, passed or failed.
+         */
+        ALWAYS,
     }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshot.java
@@ -83,4 +83,36 @@ public record ServerErrorSnapshot(
         Objects.requireNonNull(message, "message may not be null.");
         stackTrace = stackTrace == null ? List.of() : List.copyOf(stackTrace);
     }
+
+    /**
+     * Renders this entry as human-readable text: one header line plus indented stack-trace lines, capped at the
+     * given limit with a {@code "... (N more stack trace lines)"} tail when truncated.
+     *
+     * @param maxStackTraceLines
+     *     Maximum number of stack-trace lines to render; use {@link Integer#MAX_VALUE} for the full trace.
+     * @return The rendered entry, ending with a line separator.
+     */
+    public String toDisplayString(int maxStackTraceLines)
+    {
+        if (maxStackTraceLines < 0)
+            throw new IllegalArgumentException("maxStackTraceLines must be >= 0.");
+
+        final StringBuilder rendered = new StringBuilder(128);
+        rendered
+            .append("[%s] %s (thread: %s): %s".formatted(
+                levelName,
+                loggerName,
+                threadName.isEmpty() ? "?" : threadName,
+                message))
+            .append(System.lineSeparator());
+
+        stackTrace.stream()
+            .limit(maxStackTraceLines)
+            .forEach(line -> rendered.append("    ").append(line).append(System.lineSeparator()));
+        if (stackTrace.size() > maxStackTraceLines)
+            rendered
+                .append("    ... (%d more stack trace lines)".formatted(stackTrace.size() - maxStackTraceLines))
+                .append(System.lineSeparator());
+        return rendered.toString();
+    }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperFrameworkAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperFrameworkAssert.java
@@ -114,25 +114,7 @@ public final class LightkeeperFrameworkAssert
         final int maxRenderedStackTraceLines = 15;
         final StringBuilder rendered = new StringBuilder(256);
         for (final ServerErrorSnapshot error : errors)
-        {
-            rendered
-                .append("[%s] %s (thread: %s): %s".formatted(
-                    error.levelName(),
-                    error.loggerName(),
-                    error.threadName().isEmpty() ? "?" : error.threadName(),
-                    error.message()))
-                .append(System.lineSeparator());
-
-            final List<String> stackTrace = error.stackTrace();
-            stackTrace.stream()
-                .limit(maxRenderedStackTraceLines)
-                .forEach(line -> rendered.append("    ").append(line).append(System.lineSeparator()));
-            if (stackTrace.size() > maxRenderedStackTraceLines)
-                rendered
-                    .append("    ... (%d more stack trace lines)"
-                        .formatted(stackTrace.size() - maxRenderedStackTraceLines))
-                    .append(System.lineSeparator());
-        }
+            rendered.append(error.toDisplayString(maxRenderedStackTraceLines));
         return rendered.toString();
     }
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriter.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriter.java
@@ -18,7 +18,10 @@ import java.util.List;
  * <p>A bundle is a directory of plain-text files under the configured reports root:
  * {@code <root>/<TestClass>/<testMethod>-<timestamp>/} containing the test outcome and failure
  * ({@code outcome.txt}), all captured server errors ({@code server-errors.txt}), and the captured server
- * console output ({@code server-output.log}).
+ * console output ({@code server-output.log}). The timestamp suffix keeps repeated runs (and repeated
+ * invocations of parameterized tests) from colliding; in shared-server mode the console output is the full
+ * bounded buffer for the server, not just the failing test's own window (unlike the server errors, which are
+ * cleared per method).
  *
  * <p>Writing is strictly best-effort: diagnostics must never fail (or further fail) a test run. Every data
  * source is captured independently, so one broken source (e.g. a dead agent connection) still leaves the other
@@ -67,7 +70,7 @@ public final class FailureDiagnosticsWriter
             writeSection(bundleDirectory, "server-output.log", () -> renderServerOutput(framework));
 
             LOG.log(
-                System.Logger.Level.WARNING,
+                System.Logger.Level.INFO,
                 () -> "LK_DIAGNOSTICS: Wrote diagnostics bundle for %s.%s to '%s'."
                     .formatted(testClassName, testMethodName, bundleDirectory)
             );
@@ -92,10 +95,18 @@ public final class FailureDiagnosticsWriter
         @Nullable Throwable failure)
         throws IOException
     {
+        final String outcomeLabel;
+        if (failure == null)
+            outcomeLabel = "PASSED";
+        else if (failure instanceof org.opentest4j.TestAbortedException)
+            outcomeLabel = "ABORTED";
+        else
+            outcomeLabel = "FAILED";
+
         final StringBuilder outcome = new StringBuilder(256)
             .append("test: ").append(testClassName).append('.').append(testMethodName)
             .append(System.lineSeparator())
-            .append("outcome: ").append(failure == null ? "PASSED" : "FAILED")
+            .append("outcome: ").append(outcomeLabel)
             .append(System.lineSeparator());
         if (failure != null)
         {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriter.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriter.java
@@ -1,0 +1,171 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Writes per-test diagnostics bundles for LightKeeper-managed tests.
+ *
+ * <p>A bundle is a directory of plain-text files under the configured reports root:
+ * {@code <root>/<TestClass>/<testMethod>-<timestamp>/} containing the test outcome and failure
+ * ({@code outcome.txt}), all captured server errors ({@code server-errors.txt}), and the captured server
+ * console output ({@code server-output.log}).
+ *
+ * <p>Writing is strictly best-effort: diagnostics must never fail (or further fail) a test run. Every data
+ * source is captured independently, so one broken source (e.g. a dead agent connection) still leaves the other
+ * files intact, with the failure recorded in place of the missing content.
+ */
+public final class FailureDiagnosticsWriter
+{
+    private static final System.Logger LOG = System.getLogger(FailureDiagnosticsWriter.class.getName());
+
+    private FailureDiagnosticsWriter()
+    {
+    }
+
+    /**
+     * Writes a diagnostics bundle for a single test.
+     *
+     * @param framework
+     *     The framework whose state to capture; must still be open.
+     * @param reportsRoot
+     *     Root directory for diagnostics bundles; created when missing.
+     * @param testClassName
+     *     Simple name of the test class, used as the bundle's parent directory.
+     * @param testMethodName
+     *     Name of the test method, used in the bundle directory's name.
+     * @param failure
+     *     The test's execution failure, or {@code null} when the test passed (e.g. in {@code always} mode).
+     * @return The bundle directory, or {@code null} when nothing could be written.
+     */
+    public static @Nullable Path write(
+        ILightkeeperFramework framework,
+        Path reportsRoot,
+        String testClassName,
+        String testMethodName,
+        @Nullable Throwable failure)
+    {
+        try
+        {
+            final String timestamp = Instant.now().toString().replace(':', '-');
+            final Path bundleDirectory = reportsRoot
+                .resolve(sanitizeFileName(testClassName))
+                .resolve(sanitizeFileName(testMethodName) + "-" + timestamp);
+            Files.createDirectories(bundleDirectory);
+
+            writeOutcome(bundleDirectory, testClassName, testMethodName, failure);
+            writeSection(bundleDirectory, "server-errors.txt", () -> renderServerErrors(framework));
+            writeSection(bundleDirectory, "server-output.log", () -> renderServerOutput(framework));
+
+            LOG.log(
+                System.Logger.Level.WARNING,
+                () -> "LK_DIAGNOSTICS: Wrote diagnostics bundle for %s.%s to '%s'."
+                    .formatted(testClassName, testMethodName, bundleDirectory)
+            );
+            return bundleDirectory;
+        }
+        catch (Exception exception)
+        {
+            LOG.log(
+                System.Logger.Level.WARNING,
+                "LK_DIAGNOSTICS: Failed to write a diagnostics bundle for %s.%s."
+                    .formatted(testClassName, testMethodName),
+                exception
+            );
+            return null;
+        }
+    }
+
+    private static void writeOutcome(
+        Path bundleDirectory,
+        String testClassName,
+        String testMethodName,
+        @Nullable Throwable failure)
+        throws IOException
+    {
+        final StringBuilder outcome = new StringBuilder(256)
+            .append("test: ").append(testClassName).append('.').append(testMethodName)
+            .append(System.lineSeparator())
+            .append("outcome: ").append(failure == null ? "PASSED" : "FAILED")
+            .append(System.lineSeparator());
+        if (failure != null)
+        {
+            final StringWriter stackTrace = new StringWriter();
+            failure.printStackTrace(new PrintWriter(stackTrace));
+            outcome.append(System.lineSeparator()).append(stackTrace);
+        }
+        Files.writeString(bundleDirectory.resolve("outcome.txt"), outcome.toString());
+    }
+
+    /**
+     * Captures one data source into a file, recording the capture failure in the file itself when the source
+     * throws — one broken source must not take down the rest of the bundle.
+     */
+    private static void writeSection(Path bundleDirectory, String fileName, ContentSupplier contentSupplier)
+        throws IOException
+    {
+        String content;
+        try
+        {
+            content = contentSupplier.get();
+        }
+        catch (Exception exception)
+        {
+            final StringWriter stackTrace = new StringWriter();
+            exception.printStackTrace(new PrintWriter(stackTrace));
+            content = "Failed to capture this section: " + stackTrace;
+        }
+        Files.writeString(bundleDirectory.resolve(fileName), content);
+    }
+
+    private static String renderServerErrors(ILightkeeperFramework framework)
+    {
+        final List<ServerErrorSnapshot> capturedErrors = framework.serverErrors().getCaptured();
+        if (capturedErrors.isEmpty())
+            return "No captured server errors." + System.lineSeparator();
+
+        final StringBuilder rendered = new StringBuilder(1024);
+        for (final ServerErrorSnapshot error : capturedErrors)
+            rendered.append(error.toDisplayString(Integer.MAX_VALUE));
+        return rendered.toString();
+    }
+
+    private static String renderServerOutput(ILightkeeperFramework framework)
+    {
+        return String.join(System.lineSeparator(), framework.serverOutput()) + System.lineSeparator();
+    }
+
+    /**
+     * Replaces every character that is not safe in a file name across platforms with an underscore.
+     */
+    private static String sanitizeFileName(String name)
+    {
+        final StringBuilder sanitized = new StringBuilder(name.length());
+        for (int i = 0; i < name.length(); i++)
+        {
+            final char character = name.charAt(i);
+            final boolean safe = (character >= 'a' && character <= 'z')
+                || (character >= 'A' && character <= 'Z')
+                || (character >= '0' && character <= '9')
+                || character == '.' || character == '-' || character == '_';
+            sanitized.append(safe ? character : '_');
+        }
+        final String result = sanitized.toString();
+        return result.isEmpty() ? "unnamed" : result;
+    }
+
+    @FunctionalInterface
+    private interface ContentSupplier
+    {
+        String get();
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtensionDiagnosticsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtensionDiagnosticsTest.java
@@ -1,0 +1,108 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LightkeeperExtensionDiagnosticsTest
+{
+    private static final String MODE_PROPERTY = "lightkeeper.diagnostics";
+
+    @Test
+    void diagnosticsMode_shouldParseAllKnownValuesAndDefaultBlankToOnFailure()
+    {
+        // setup
+        final String previousValue = System.getProperty(MODE_PROPERTY);
+        try
+        {
+            // execute + verify
+            System.clearProperty(MODE_PROPERTY);
+            assertThat(LightkeeperExtension.diagnosticsMode())
+                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ON_FAILURE);
+
+            System.setProperty(MODE_PROPERTY, "");
+            assertThat(LightkeeperExtension.diagnosticsMode())
+                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ON_FAILURE);
+
+            System.setProperty(MODE_PROPERTY, "on-failure");
+            assertThat(LightkeeperExtension.diagnosticsMode())
+                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ON_FAILURE);
+
+            System.setProperty(MODE_PROPERTY, "ALWAYS");
+            assertThat(LightkeeperExtension.diagnosticsMode())
+                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ALWAYS);
+
+            System.setProperty(MODE_PROPERTY, "off");
+            assertThat(LightkeeperExtension.diagnosticsMode())
+                .isEqualTo(LightkeeperExtension.DiagnosticsMode.OFF);
+        }
+        finally
+        {
+            restore(previousValue);
+        }
+    }
+
+    @Test
+    void diagnosticsMode_shouldRejectUnknownValues()
+    {
+        // setup
+        final String previousValue = System.getProperty(MODE_PROPERTY);
+        try
+        {
+            System.setProperty(MODE_PROPERTY, "on_failure");
+
+            // execute + verify
+            assertThatThrownBy(LightkeeperExtension::diagnosticsMode)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("on_failure")
+                .hasMessageContaining("lightkeeper.diagnostics");
+        }
+        finally
+        {
+            restore(previousValue);
+        }
+    }
+
+    @Test
+    void shouldWriteBundle_shouldWriteOnlyRealFailuresInOnFailureMode()
+    {
+        // setup
+        final Throwable realFailure = new AssertionError("boom");
+        final Throwable assumptionAbort = new TestAbortedException("skipped on this platform");
+
+        // execute + verify
+        assertThat(LightkeeperExtension.shouldWriteBundle(
+            LightkeeperExtension.DiagnosticsMode.ON_FAILURE, realFailure)).isTrue();
+        assertThat(LightkeeperExtension.shouldWriteBundle(
+            LightkeeperExtension.DiagnosticsMode.ON_FAILURE, null)).isFalse();
+        assertThat(LightkeeperExtension.shouldWriteBundle(
+            LightkeeperExtension.DiagnosticsMode.ON_FAILURE, assumptionAbort)).isFalse();
+    }
+
+    @Test
+    void shouldWriteBundle_shouldFollowModeForAlwaysAndOff()
+    {
+        // setup
+        final Throwable realFailure = new AssertionError("boom");
+
+        // execute + verify
+        assertThat(LightkeeperExtension.shouldWriteBundle(
+            LightkeeperExtension.DiagnosticsMode.ALWAYS, null)).isTrue();
+        assertThat(LightkeeperExtension.shouldWriteBundle(
+            LightkeeperExtension.DiagnosticsMode.ALWAYS, realFailure)).isTrue();
+        assertThat(LightkeeperExtension.shouldWriteBundle(
+            LightkeeperExtension.DiagnosticsMode.OFF, realFailure)).isFalse();
+        assertThat(LightkeeperExtension.shouldWriteBundle(
+            LightkeeperExtension.DiagnosticsMode.OFF, null)).isFalse();
+    }
+
+    private static void restore(String previousValue)
+    {
+        if (previousValue == null)
+            System.clearProperty(MODE_PROPERTY);
+        else
+            System.setProperty(MODE_PROPERTY, previousValue);
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtensionDiagnosticsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/LightkeeperExtensionDiagnosticsTest.java
@@ -1,10 +1,11 @@
 package nl.pim16aap2.lightkeeper.framework;
 
+import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension.DiagnosticsMode;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class LightkeeperExtensionDiagnosticsTest
 {
@@ -17,26 +18,24 @@ class LightkeeperExtensionDiagnosticsTest
         final String previousValue = System.getProperty(MODE_PROPERTY);
         try
         {
-            // execute + verify
+            // execute
             System.clearProperty(MODE_PROPERTY);
-            assertThat(LightkeeperExtension.diagnosticsMode())
-                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ON_FAILURE);
-
+            final DiagnosticsMode whenAbsent = LightkeeperExtension.diagnosticsMode();
             System.setProperty(MODE_PROPERTY, "");
-            assertThat(LightkeeperExtension.diagnosticsMode())
-                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ON_FAILURE);
-
+            final DiagnosticsMode whenBlank = LightkeeperExtension.diagnosticsMode();
             System.setProperty(MODE_PROPERTY, "on-failure");
-            assertThat(LightkeeperExtension.diagnosticsMode())
-                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ON_FAILURE);
-
+            final DiagnosticsMode whenOnFailure = LightkeeperExtension.diagnosticsMode();
             System.setProperty(MODE_PROPERTY, "ALWAYS");
-            assertThat(LightkeeperExtension.diagnosticsMode())
-                .isEqualTo(LightkeeperExtension.DiagnosticsMode.ALWAYS);
-
+            final DiagnosticsMode whenAlwaysUpperCase = LightkeeperExtension.diagnosticsMode();
             System.setProperty(MODE_PROPERTY, "off");
-            assertThat(LightkeeperExtension.diagnosticsMode())
-                .isEqualTo(LightkeeperExtension.DiagnosticsMode.OFF);
+            final DiagnosticsMode whenOff = LightkeeperExtension.diagnosticsMode();
+
+            // verify
+            assertThat(whenAbsent).isEqualTo(DiagnosticsMode.ON_FAILURE);
+            assertThat(whenBlank).isEqualTo(DiagnosticsMode.ON_FAILURE);
+            assertThat(whenOnFailure).isEqualTo(DiagnosticsMode.ON_FAILURE);
+            assertThat(whenAlwaysUpperCase).isEqualTo(DiagnosticsMode.ALWAYS);
+            assertThat(whenOff).isEqualTo(DiagnosticsMode.OFF);
         }
         finally
         {
@@ -53,8 +52,11 @@ class LightkeeperExtensionDiagnosticsTest
         {
             System.setProperty(MODE_PROPERTY, "on_failure");
 
-            // execute + verify
-            assertThatThrownBy(LightkeeperExtension::diagnosticsMode)
+            // execute
+            final Throwable thrown = catchThrowable(LightkeeperExtension::diagnosticsMode);
+
+            // verify
+            assertThat(thrown)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("on_failure")
                 .hasMessageContaining("lightkeeper.diagnostics");
@@ -72,13 +74,17 @@ class LightkeeperExtensionDiagnosticsTest
         final Throwable realFailure = new AssertionError("boom");
         final Throwable assumptionAbort = new TestAbortedException("skipped on this platform");
 
-        // execute + verify
-        assertThat(LightkeeperExtension.shouldWriteBundle(
-            LightkeeperExtension.DiagnosticsMode.ON_FAILURE, realFailure)).isTrue();
-        assertThat(LightkeeperExtension.shouldWriteBundle(
-            LightkeeperExtension.DiagnosticsMode.ON_FAILURE, null)).isFalse();
-        assertThat(LightkeeperExtension.shouldWriteBundle(
-            LightkeeperExtension.DiagnosticsMode.ON_FAILURE, assumptionAbort)).isFalse();
+        // execute
+        final boolean writesRealFailure =
+            LightkeeperExtension.shouldWriteBundle(DiagnosticsMode.ON_FAILURE, realFailure);
+        final boolean writesOnPass = LightkeeperExtension.shouldWriteBundle(DiagnosticsMode.ON_FAILURE, null);
+        final boolean writesOnAbort =
+            LightkeeperExtension.shouldWriteBundle(DiagnosticsMode.ON_FAILURE, assumptionAbort);
+
+        // verify
+        assertThat(writesRealFailure).isTrue();
+        assertThat(writesOnPass).isFalse();
+        assertThat(writesOnAbort).isFalse();
     }
 
     @Test
@@ -87,15 +93,18 @@ class LightkeeperExtensionDiagnosticsTest
         // setup
         final Throwable realFailure = new AssertionError("boom");
 
-        // execute + verify
-        assertThat(LightkeeperExtension.shouldWriteBundle(
-            LightkeeperExtension.DiagnosticsMode.ALWAYS, null)).isTrue();
-        assertThat(LightkeeperExtension.shouldWriteBundle(
-            LightkeeperExtension.DiagnosticsMode.ALWAYS, realFailure)).isTrue();
-        assertThat(LightkeeperExtension.shouldWriteBundle(
-            LightkeeperExtension.DiagnosticsMode.OFF, realFailure)).isFalse();
-        assertThat(LightkeeperExtension.shouldWriteBundle(
-            LightkeeperExtension.DiagnosticsMode.OFF, null)).isFalse();
+        // execute
+        final boolean alwaysWritesOnPass = LightkeeperExtension.shouldWriteBundle(DiagnosticsMode.ALWAYS, null);
+        final boolean alwaysWritesOnFailure =
+            LightkeeperExtension.shouldWriteBundle(DiagnosticsMode.ALWAYS, realFailure);
+        final boolean offWritesOnFailure = LightkeeperExtension.shouldWriteBundle(DiagnosticsMode.OFF, realFailure);
+        final boolean offWritesOnPass = LightkeeperExtension.shouldWriteBundle(DiagnosticsMode.OFF, null);
+
+        // verify
+        assertThat(alwaysWritesOnPass).isTrue();
+        assertThat(alwaysWritesOnFailure).isTrue();
+        assertThat(offWritesOnFailure).isFalse();
+        assertThat(offWritesOnPass).isFalse();
     }
 
     private static void restore(String previousValue)

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshotTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/ServerErrorSnapshotTest.java
@@ -2,7 +2,10 @@ package nl.pim16aap2.lightkeeper.framework;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ServerErrorSnapshotTest
 {
@@ -25,5 +28,80 @@ class ServerErrorSnapshotTest
 
         // verify
         assertThat(snapshot.stackTrace()).isEmpty();
+    }
+
+    @Test
+    void toDisplayString_shouldRenderHeaderAndFullStackTrace()
+    {
+        // setup
+        final ServerErrorSnapshot snapshot = snapshot(
+            "ERROR", "Server thread", List.of("at a.B.c(B.java:1)", "at d.E.f(E.java:2)"));
+
+        // execute
+        final String rendered = snapshot.toDisplayString(Integer.MAX_VALUE);
+
+        // verify
+        assertThat(rendered)
+            .contains("[ERROR] net.example.SomePlugin (thread: Server thread): boom")
+            .contains("    at a.B.c(B.java:1)")
+            .contains("    at d.E.f(E.java:2)")
+            .doesNotContain("more stack trace lines");
+    }
+
+    @Test
+    void toDisplayString_shouldCapStackTraceAndReportOmittedLineCount()
+    {
+        // setup
+        final ServerErrorSnapshot snapshot = snapshot(
+            "ERROR", "Server thread", List.of("line1", "line2", "line3"));
+
+        // execute
+        final String rendered = snapshot.toDisplayString(1);
+
+        // verify
+        assertThat(rendered)
+            .contains("    line1")
+            .doesNotContain("line2")
+            .contains("... (2 more stack trace lines)");
+    }
+
+    @Test
+    void toDisplayString_shouldRenderQuestionMarkWhenThreadNameIsEmpty()
+    {
+        // setup
+        final ServerErrorSnapshot snapshot = snapshot("WARN", "", List.of());
+
+        // execute
+        final String rendered = snapshot.toDisplayString(Integer.MAX_VALUE);
+
+        // verify
+        assertThat(rendered).contains("(thread: ?)");
+    }
+
+    @Test
+    void toDisplayString_shouldRejectNegativeMaxStackTraceLines()
+    {
+        // setup
+        final ServerErrorSnapshot snapshot = snapshot("ERROR", "Server thread", List.of());
+
+        // execute + verify
+        assertThatThrownBy(() -> snapshot.toDisplayString(-1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("maxStackTraceLines");
+    }
+
+    private static ServerErrorSnapshot snapshot(String levelName, String threadName, List<String> stackTrace)
+    {
+        return new ServerErrorSnapshot(
+            1L,
+            "WARN".equals(levelName) ? ServerErrorSnapshot.Severity.WARNING : ServerErrorSnapshot.Severity.ERROR,
+            levelName,
+            "net.example.SomePlugin",
+            threadName,
+            "boom",
+            null,
+            null,
+            stackTrace
+        );
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriterTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriterTest.java
@@ -88,6 +88,33 @@ class FailureDiagnosticsWriterTest
     }
 
     @Test
+    void write_shouldReportAbortedOutcomeForAssumptionAborts(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of());
+        when(framework.serverOutput()).thenReturn(List.of());
+
+        // execute
+        final Path writtenDirectory = FailureDiagnosticsWriter.write(
+            framework,
+            tempDirectory,
+            "MyTestClass",
+            "myAbortedMethod",
+            new org.opentest4j.TestAbortedException("skipped on this platform"));
+
+        // verify
+        assertThat(writtenDirectory).isNotNull();
+        final Path bundleDirectory = java.util.Objects.requireNonNull(writtenDirectory);
+        assertThat(Files.readString(bundleDirectory.resolve("outcome.txt")))
+            .contains("outcome: ABORTED")
+            .contains("skipped on this platform");
+    }
+
+    @Test
     void write_shouldRecordSectionFailureWithoutLosingOtherSections(@TempDir Path tempDirectory)
         throws IOException
     {

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriterTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/FailureDiagnosticsWriterTest.java
@@ -1,0 +1,152 @@
+package nl.pim16aap2.lightkeeper.framework.internal;
+
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FailureDiagnosticsWriterTest
+{
+    @Test
+    void write_shouldCreateBundleWithOutcomeErrorsAndOutput(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of(new ServerErrorSnapshot(
+            123L,
+            ServerErrorSnapshot.Severity.ERROR,
+            "ERROR",
+            "test.logger",
+            "main",
+            "boom happened",
+            "java.lang.IllegalStateException",
+            "boom",
+            List.of("at example.Foo.bar(Foo.java:1)")
+        )));
+        when(framework.serverOutput()).thenReturn(List.of("line one", "line two"));
+        final RuntimeException failure = new RuntimeException("test assertion failed");
+
+        // execute
+        final Path writtenDirectory = FailureDiagnosticsWriter.write(
+            framework, tempDirectory, "MyTestClass", "myTestMethod", failure);
+
+        // verify
+        assertThat(writtenDirectory).isNotNull();
+        final Path bundleDirectory = java.util.Objects.requireNonNull(writtenDirectory);
+        assertThat(bundleDirectory).isDirectory();
+        assertThat(java.util.Objects.requireNonNull(bundleDirectory.getParent()).getFileName().toString())
+            .isEqualTo("MyTestClass");
+        assertThat(bundleDirectory.getFileName().toString()).startsWith("myTestMethod-");
+        assertThat(Files.readString(bundleDirectory.resolve("outcome.txt")))
+            .contains("test: MyTestClass.myTestMethod")
+            .contains("outcome: FAILED")
+            .contains("test assertion failed");
+        assertThat(Files.readString(bundleDirectory.resolve("server-errors.txt")))
+            .contains("[ERROR] test.logger (thread: main): boom happened")
+            .contains("at example.Foo.bar(Foo.java:1)");
+        assertThat(Files.readString(bundleDirectory.resolve("server-output.log")))
+            .contains("line one")
+            .contains("line two");
+    }
+
+    @Test
+    void write_shouldReportPassedOutcomeWhenNoFailureGiven(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of());
+        when(framework.serverOutput()).thenReturn(List.of());
+
+        // execute
+        final Path writtenDirectory = FailureDiagnosticsWriter.write(
+            framework, tempDirectory, "MyTestClass", "myPassingMethod", null);
+
+        // verify
+        assertThat(writtenDirectory).isNotNull();
+        final Path bundleDirectory = java.util.Objects.requireNonNull(writtenDirectory);
+        assertThat(Files.readString(bundleDirectory.resolve("outcome.txt")))
+            .contains("outcome: PASSED")
+            .doesNotContain("FAILED");
+        assertThat(Files.readString(bundleDirectory.resolve("server-errors.txt")))
+            .contains("No captured server errors.");
+    }
+
+    @Test
+    void write_shouldRecordSectionFailureWithoutLosingOtherSections(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        when(framework.serverErrors()).thenThrow(new IllegalStateException("agent connection is gone"));
+        when(framework.serverOutput()).thenReturn(List.of("still available"));
+
+        // execute
+        final Path writtenDirectory = FailureDiagnosticsWriter.write(
+            framework, tempDirectory, "MyTestClass", "myTestMethod", new RuntimeException("failed"));
+
+        // verify
+        assertThat(writtenDirectory).isNotNull();
+        final Path bundleDirectory = java.util.Objects.requireNonNull(writtenDirectory);
+        assertThat(Files.readString(bundleDirectory.resolve("server-errors.txt")))
+            .contains("Failed to capture this section:")
+            .contains("agent connection is gone");
+        assertThat(Files.readString(bundleDirectory.resolve("server-output.log")))
+            .contains("still available");
+    }
+
+    @Test
+    void write_shouldReturnNullInsteadOfThrowingWhenRootIsNotWritable(@TempDir Path tempDirectory)
+        throws IOException
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        // A regular FILE at the reports-root path makes createDirectories fail on every platform.
+        final Path blockedRoot = tempDirectory.resolve("blocked");
+        Files.writeString(blockedRoot, "not a directory");
+
+        // execute
+        final Path bundleDirectory = FailureDiagnosticsWriter.write(
+            framework, blockedRoot, "MyTestClass", "myTestMethod", new RuntimeException("failed"));
+
+        // verify
+        assertThat(bundleDirectory).isNull();
+    }
+
+    @Test
+    void write_shouldSanitizeUnsafeCharactersInDirectoryNames(@TempDir Path tempDirectory)
+    {
+        // setup
+        final ILightkeeperFramework framework = mock(ILightkeeperFramework.class);
+        final ServerErrorsHandle serverErrorsHandle = mock(ServerErrorsHandle.class);
+        when(framework.serverErrors()).thenReturn(serverErrorsHandle);
+        when(serverErrorsHandle.getCaptured()).thenReturn(List.of());
+        when(framework.serverOutput()).thenReturn(List.of());
+
+        // execute
+        final Path writtenDirectory = FailureDiagnosticsWriter.write(
+            framework, tempDirectory, "My/Test:Class", "my method [1]", null);
+
+        // verify
+        assertThat(writtenDirectory).isNotNull();
+        final Path bundleDirectory = java.util.Objects.requireNonNull(writtenDirectory);
+        assertThat(java.util.Objects.requireNonNull(bundleDirectory.getParent()).getFileName().toString())
+            .isEqualTo("My_Test_Class");
+        assertThat(bundleDirectory.getFileName().toString()).startsWith("my_method__1_-");
+    }
+}

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperDiagnosticsIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperDiagnosticsIT.java
@@ -2,6 +2,8 @@ package nl.pim16aap2.lightkeeper.maven.test;
 
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -11,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.stream.Stream;
 
 import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
@@ -20,7 +23,9 @@ import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertion
  *
  * <p>The bundle is written by the extension's {@code afterEach}, so no test can observe its own bundle; the
  * first (ordered) test enables {@code always} mode into a dedicated directory, and the second test asserts the
- * first test's bundle content before restoring the default mode.
+ * first test's bundle content before restoring the previous configuration. An {@link AfterAll} hook restores
+ * the configuration even when the flow fails halfway, so {@code always} mode cannot leak into other IT classes
+ * in the same JVM.
  */
 @ExtendWith(LightkeeperExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -28,11 +33,18 @@ class LightkeeperDiagnosticsIT
 {
     private static final Path REPORTS_ROOT = Path.of("target", "lightkeeper-reports-it");
 
+    private static @Nullable String previousMode;
+    private static @Nullable String previousDirectory;
+    private static boolean propertiesModified;
+
     @Test
     @Order(1)
     void diagnostics_shouldEnableAlwaysModeForThisTest(ILightkeeperFramework framework)
     {
         // setup
+        previousMode = System.getProperty("lightkeeper.diagnostics");
+        previousDirectory = System.getProperty("lightkeeper.diagnosticsDirectory");
+        propertiesModified = true;
         System.setProperty("lightkeeper.diagnostics", "always");
         System.setProperty("lightkeeper.diagnosticsDirectory", REPORTS_ROOT.toString());
 
@@ -45,18 +57,18 @@ class LightkeeperDiagnosticsIT
     void diagnostics_shouldHaveWrittenBundleForPreviousTest(ILightkeeperFramework framework)
         throws IOException
     {
-        // setup: restore the default mode first so THIS test's afterEach writes nothing
-        System.clearProperty("lightkeeper.diagnostics");
-        System.clearProperty("lightkeeper.diagnosticsDirectory");
+        // setup: restore the previous configuration first so THIS test's afterEach writes nothing
+        restoreDiagnosticsProperties();
         final Path classDirectory = REPORTS_ROOT.resolve(getClass().getSimpleName());
 
-        // execute
+        // execute: pick the newest matching bundle (ISO timestamps sort lexicographically), so stale bundles
+        // from earlier non-clean runs cannot be selected.
         final Path bundleDirectory;
         try (Stream<Path> bundles = Files.list(classDirectory))
         {
             bundleDirectory = bundles
                 .filter(path -> path.getFileName().toString().startsWith("diagnostics_shouldEnableAlwaysMode"))
-                .findFirst()
+                .max(Comparator.comparing(path -> path.getFileName().toString()))
                 .orElseThrow(() -> new AssertionError(
                     "No diagnostics bundle found under " + classDirectory));
         }
@@ -68,5 +80,27 @@ class LightkeeperDiagnosticsIT
         assertThat(bundleDirectory.resolve("server-errors.txt")).exists();
         assertThat(Files.readString(bundleDirectory.resolve("server-output.log")))
             .contains("Done");
+    }
+
+    @AfterAll
+    static void restoreDiagnosticsConfiguration()
+    {
+        restoreDiagnosticsProperties();
+    }
+
+    private static void restoreDiagnosticsProperties()
+    {
+        if (!propertiesModified)
+            return;
+        restoreProperty("lightkeeper.diagnostics", previousMode);
+        restoreProperty("lightkeeper.diagnosticsDirectory", previousDirectory);
+    }
+
+    private static void restoreProperty(String key, @Nullable String previousValue)
+    {
+        if (previousValue == null)
+            System.clearProperty(key);
+        else
+            System.setProperty(key, previousValue);
     }
 }

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperDiagnosticsIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperDiagnosticsIT.java
@@ -1,0 +1,72 @@
+package nl.pim16aap2.lightkeeper.maven.test;
+
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
+
+/**
+ * Exercises the diagnostics-on-failure bundle writer end-to-end.
+ *
+ * <p>The bundle is written by the extension's {@code afterEach}, so no test can observe its own bundle; the
+ * first (ordered) test enables {@code always} mode into a dedicated directory, and the second test asserts the
+ * first test's bundle content before restoring the default mode.
+ */
+@ExtendWith(LightkeeperExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LightkeeperDiagnosticsIT
+{
+    private static final Path REPORTS_ROOT = Path.of("target", "lightkeeper-reports-it");
+
+    @Test
+    @Order(1)
+    void diagnostics_shouldEnableAlwaysModeForThisTest(ILightkeeperFramework framework)
+    {
+        // setup
+        System.setProperty("lightkeeper.diagnostics", "always");
+        System.setProperty("lightkeeper.diagnosticsDirectory", REPORTS_ROOT.toString());
+
+        // execute + verify: a trivially passing interaction; the bundle itself is written in afterEach
+        assertThat(framework.mainWorld()).hasNonBlankName();
+    }
+
+    @Test
+    @Order(2)
+    void diagnostics_shouldHaveWrittenBundleForPreviousTest(ILightkeeperFramework framework)
+        throws IOException
+    {
+        // setup: restore the default mode first so THIS test's afterEach writes nothing
+        System.clearProperty("lightkeeper.diagnostics");
+        System.clearProperty("lightkeeper.diagnosticsDirectory");
+        final Path classDirectory = REPORTS_ROOT.resolve(getClass().getSimpleName());
+
+        // execute
+        final Path bundleDirectory;
+        try (Stream<Path> bundles = Files.list(classDirectory))
+        {
+            bundleDirectory = bundles
+                .filter(path -> path.getFileName().toString().startsWith("diagnostics_shouldEnableAlwaysMode"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                    "No diagnostics bundle found under " + classDirectory));
+        }
+
+        // verify
+        assertThat(Files.readString(bundleDirectory.resolve("outcome.txt")))
+            .contains("outcome: PASSED")
+            .contains("diagnostics_shouldEnableAlwaysModeForThisTest");
+        assertThat(bundleDirectory.resolve("server-errors.txt")).exists();
+        assertThat(Files.readString(bundleDirectory.resolve("server-output.log")))
+            .contains("Done");
+    }
+}


### PR DESCRIPTION
## Why
- The S0 roadmap leftover and the single highest-leverage CI-triage feature in the API blueprint: a failed e2e test currently leaves you grepping raw CI logs; now it leaves a self-contained bundle.
- Bundles land in `target/lightkeeper-reports/<TestClass>/<method>-<timestamp>/`: `outcome.txt` (outcome + failure stack), `server-errors.txt` (all captured server errors, full traces), `server-output.log` (bounded console buffer).

## How
- Capture runs at the **top of `afterEach`**, gated on `getExecutionException()` — verified against the JUnit engine: `TestWatcher` hooks fire only after all `afterEach` callbacks, by which point the framework is closed (fresh mode) or its error window cleared (shared mode).
- Knobs: `lightkeeper.diagnostics` = `on-failure` (default) | `always` | `off` — validated in `beforeAll` so a typo fails loudly before any server is provisioned; `lightkeeper.diagnosticsDirectory` relocates the root. Assumption aborts are skips: never bundled in `on-failure`, labeled `ABORTED` in `always`.
- Writing is best-effort by contract: each data source is captured independently (a dead agent connection is recorded in place of its section), and no diagnostics error can reach — or skip — the `afterEach` cleanup.
- `ServerErrorSnapshot.toDisplayString(maxLines)` is the new single renderer shared by assertion messages and bundles.
- Deliberately deferred (need new API surface, belong to the facet slice): per-bot state, current tick, open event-capture contents.

## Tests
- `mvn -Perrorprone clean install checkstyle:checkstyle pmd:check`: BUILD SUCCESS, 0 violations; new unit tests pin the writer contract (per-section resilience, sanitization, PASSED/FAILED/ABORTED, unwritable root) and the decision logic (mode parsing incl. unknown-value ISE, the aborted-test gate).
- `mvn clean verify -pl lightkeeper-integration-tests`: green on both Paper and Spigot lanes incl. the new `LightkeeperDiagnosticsIT` (always-mode bundle asserted end-to-end, property restoration hardened against mid-flow failure).
- Pre-PR deep review (Opus agent): MERGE-WITH-FIXES; both MAJORs (cleanup-skip on mode typo, aborted-as-failed) and all MINORs addressed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P15FjGQzyNmX9T6Qmyq8Dn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed integration tests now automatically generate diagnostic bundles containing test results, server errors, and server output.
  * Diagnostics can be configured to run on failures, always, or never.
  * Report locations can be customized through system properties.
  * Server error details now support readable, length-limited formatting.

* **Documentation**
  * Added guidance on diagnostics bundle contents, directory structure, and configuration options.

* **Tests**
  * Added coverage for diagnostic generation, configuration handling, formatting, and end-to-end report creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->