### PR TITLE
feat: eventually() retrying assertions and BlockPos/Vec3 vocabulary (S2, part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ class MyPluginIT
 - World templates: provision world folders via `<worlds>` and load them with
   `newWorldFromTemplate("name")` — typos fail loudly instead of silently creating a fresh world
 - Received-message assertions with AssertJ string chaining
+- Explicit retrying assertions: `eventually(timeout, () -> assertThat(...))` re-runs a live probe until it
+  passes, and reports the attempt count, elapsed time, and last failure on timeout
 - Diagnostics-on-failure: failed tests automatically get a bundle (test outcome, captured server errors,
   server console output) under `target/lightkeeper-reports/`
 - Graceful server lifecycle control from tests (`stopServer()`, `startServer()`, `restartServer()`), plus

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/BlockPos.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/BlockPos.java
@@ -1,0 +1,22 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+/**
+ * Integer block coordinates in a world.
+ *
+ * <p>This is the canonical vocabulary for block positions across the framework API; the double-precision
+ * counterpart for entity positions is {@link Vec3}.
+ *
+ * @param x
+ *     X coordinate.
+ * @param y
+ *     Y coordinate.
+ * @param z
+ *     Z coordinate.
+ */
+public record BlockPos(
+    int x,
+    int y,
+    int z
+)
+{
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -17,12 +17,12 @@ public interface IFrameworkGatewayView
     /**
      * Gets block material at a position.
      */
-    String getBlock(String worldName, Vector3Di position);
+    String getBlock(String worldName, BlockPos position);
 
     /**
      * Sets block material at a position.
      */
-    void setBlock(String worldName, Vector3Di position, String material);
+    void setBlock(String worldName, BlockPos position, String material);
 
     /**
      * Executes a command as a synthetic player.
@@ -83,14 +83,14 @@ public interface IFrameworkGatewayView
      *
      * @return {@code true} when a plugin cancelled the fired {@code PlayerInteractEvent}.
      */
-    boolean leftClickBlock(UUID playerId, Vector3Di position, String blockFace);
+    boolean leftClickBlock(UUID playerId, BlockPos position, String blockFace);
 
     /**
      * Fires a right-click block interaction as a synthetic player.
      *
      * @return {@code true} when a plugin cancelled the fired {@code PlayerInteractEvent}.
      */
-    boolean rightClickBlock(UUID playerId, Vector3Di position, String blockFace);
+    boolean rightClickBlock(UUID playerId, BlockPos position, String blockFace);
 
     /**
      * Retrieves menu snapshot for a synthetic player.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -97,6 +97,23 @@ public final class PlayerHandle
     }
 
     /**
+     * Teleports this player to a target position in a world.
+     *
+     * @param world
+     *     Target world.
+     * @param position
+     *     Target position.
+     * @return This handle for fluent chaining.
+     * @throws IllegalStateException
+     *     If the server rejected the teleport (e.g. a plugin cancelled the teleport event).
+     */
+    public PlayerHandle teleport(WorldHandle world, Vec3 position)
+    {
+        Objects.requireNonNull(position, "position may not be null.");
+        return teleport(world, position.x(), position.y(), position.z());
+    }
+
+    /**
      * Places a block from this player perspective.
      *
      * @param materialKey
@@ -128,7 +145,7 @@ public final class PlayerHandle
      */
     public InteractionResult leftClickBlock(int x, int y, int z)
     {
-        return leftClickBlock(new Vector3Di(x, y, z));
+        return leftClickBlock(new BlockPos(x, y, z));
     }
 
     /**
@@ -138,9 +155,24 @@ public final class PlayerHandle
      *     Block coordinates.
      * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public InteractionResult leftClickBlock(Vector3Di position)
+    public InteractionResult leftClickBlock(BlockPos position)
     {
         return leftClickBlock(position, BlockFace.UP);
+    }
+
+    /**
+     * Fires a left-click block interaction at a position in this player's current world.
+     *
+     * @param position
+     *     Block coordinates.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
+     * @deprecated Use {@link #leftClickBlock(BlockPos)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public InteractionResult leftClickBlock(Vector3Di position)
+    {
+        Objects.requireNonNull(position, "position may not be null.");
+        return leftClickBlock(position.toBlockPos());
     }
 
     /**
@@ -152,7 +184,7 @@ public final class PlayerHandle
      *     Clicked block face.
      * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public InteractionResult leftClickBlock(Vector3Di position, BlockFace blockFace)
+    public InteractionResult leftClickBlock(BlockPos position, BlockFace blockFace)
     {
         final boolean cancelled = frameworkGateway.leftClickBlock(
             uniqueId,
@@ -160,6 +192,23 @@ public final class PlayerHandle
             Objects.requireNonNull(blockFace, "blockFace may not be null.").name()
         );
         return new InteractionResult(true, cancelled);
+    }
+
+    /**
+     * Fires a left-click block interaction at a position in this player's current world.
+     *
+     * @param position
+     *     Block coordinates.
+     * @param blockFace
+     *     Clicked block face.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
+     * @deprecated Use {@link #leftClickBlock(BlockPos, BlockFace)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public InteractionResult leftClickBlock(Vector3Di position, BlockFace blockFace)
+    {
+        Objects.requireNonNull(position, "position may not be null.");
+        return leftClickBlock(position.toBlockPos(), blockFace);
     }
 
     /**
@@ -175,7 +224,7 @@ public final class PlayerHandle
      */
     public InteractionResult rightClickBlock(int x, int y, int z)
     {
-        return rightClickBlock(new Vector3Di(x, y, z));
+        return rightClickBlock(new BlockPos(x, y, z));
     }
 
     /**
@@ -185,9 +234,24 @@ public final class PlayerHandle
      *     Block coordinates.
      * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public InteractionResult rightClickBlock(Vector3Di position)
+    public InteractionResult rightClickBlock(BlockPos position)
     {
         return rightClickBlock(position, BlockFace.UP);
+    }
+
+    /**
+     * Fires a right-click block interaction at a position in this player's current world.
+     *
+     * @param position
+     *     Block coordinates.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
+     * @deprecated Use {@link #rightClickBlock(BlockPos)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public InteractionResult rightClickBlock(Vector3Di position)
+    {
+        Objects.requireNonNull(position, "position may not be null.");
+        return rightClickBlock(position.toBlockPos());
     }
 
     /**
@@ -199,7 +263,7 @@ public final class PlayerHandle
      *     Clicked block face.
      * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
      */
-    public InteractionResult rightClickBlock(Vector3Di position, BlockFace blockFace)
+    public InteractionResult rightClickBlock(BlockPos position, BlockFace blockFace)
     {
         final boolean cancelled = frameworkGateway.rightClickBlock(
             uniqueId,
@@ -207,6 +271,23 @@ public final class PlayerHandle
             Objects.requireNonNull(blockFace, "blockFace may not be null.").name()
         );
         return new InteractionResult(true, cancelled);
+    }
+
+    /**
+     * Fires a right-click block interaction at a position in this player's current world.
+     *
+     * @param position
+     *     Block coordinates.
+     * @param blockFace
+     *     Clicked block face.
+     * @return The interaction result; a real {@code PlayerInteractEvent} is always fired.
+     * @deprecated Use {@link #rightClickBlock(BlockPos, BlockFace)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public InteractionResult rightClickBlock(Vector3Di position, BlockFace blockFace)
+    {
+        Objects.requireNonNull(position, "position may not be null.");
+        return rightClickBlock(position.toBlockPos(), blockFace);
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -109,6 +109,7 @@ public final class PlayerHandle
      */
     public PlayerHandle teleport(WorldHandle world, Vec3 position)
     {
+        Objects.requireNonNull(world, "world may not be null.");
         Objects.requireNonNull(position, "position may not be null.");
         return teleport(world, position.x(), position.y(), position.z());
     }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/Vec3.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/Vec3.java
@@ -1,0 +1,22 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+/**
+ * Double-precision 3D position in a world.
+ *
+ * <p>This is the canonical vocabulary for entity positions across the framework API; the integer counterpart
+ * for block coordinates is {@link BlockPos}.
+ *
+ * @param x
+ *     X coordinate.
+ * @param y
+ *     Y coordinate.
+ * @param z
+ *     Z coordinate.
+ */
+public record Vec3(
+    double x,
+    double y,
+    double z
+)
+{
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/Vector3Di.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/Vector3Di.java
@@ -9,11 +9,23 @@ package nl.pim16aap2.lightkeeper.framework;
  *     Y coordinate.
  * @param z
  *     Z coordinate.
+ * @deprecated Use {@link BlockPos} instead; this type only remains so existing tests keep compiling for one
+ *     release and will be removed together with the rest of the v1 vocabulary.
  */
+@Deprecated(forRemoval = true)
 public record Vector3Di(
     int x,
     int y,
     int z
 )
 {
+    /**
+     * Converts this vector to the canonical {@link BlockPos} vocabulary.
+     *
+     * @return The equivalent block position.
+     */
+    public BlockPos toBlockPos()
+    {
+        return new BlockPos(x, y, z);
+    }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
@@ -36,10 +36,25 @@ public final class WorldHandle
      *     Block coordinates.
      * @return The block material name.
      */
-    public String blockTypeAt(Vector3Di position)
+    public String blockTypeAt(BlockPos position)
     {
         Objects.requireNonNull(position, "position may not be null.");
         return frameworkGateway.getBlock(name, position);
+    }
+
+    /**
+     * Retrieves the block type at a position.
+     *
+     * @param position
+     *     Block coordinates.
+     * @return The block material name.
+     * @deprecated Use {@link #blockTypeAt(BlockPos)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public String blockTypeAt(Vector3Di position)
+    {
+        Objects.requireNonNull(position, "position may not be null.");
+        return blockTypeAt(position.toBlockPos());
     }
 
     /**
@@ -50,10 +65,26 @@ public final class WorldHandle
      * @param material
      *     Material name.
      */
-    public void setBlockAt(Vector3Di position, String material)
+    public void setBlockAt(BlockPos position, String material)
     {
         Objects.requireNonNull(position, "position may not be null.");
         frameworkGateway.setBlock(name, position, material);
+    }
+
+    /**
+     * Sets the block type at a position.
+     *
+     * @param position
+     *     Block coordinates.
+     * @param material
+     *     Material name.
+     * @deprecated Use {@link #setBlockAt(BlockPos, String)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public void setBlockAt(Vector3Di position, String material)
+    {
+        Objects.requireNonNull(position, "position may not be null.");
+        setBlockAt(position.toBlockPos(), material);
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperAssertions.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperAssertions.java
@@ -116,7 +116,9 @@ public final class LightkeeperAssertions extends Assertions
     private static void runWithRetries(Duration timeout, RetryingAssertion assertion)
     {
         final long startNanos = System.nanoTime();
-        final long deadlineNanos = startNanos + timeout.toNanos();
+        // Compare elapsed time rather than an absolute deadline: nanoTime() may take any long value, so a
+        // precomputed deadline could overflow and expire immediately.
+        final long timeoutNanos = timeout.toNanos();
         int attempts = 0;
         while (true)
         {
@@ -144,7 +146,7 @@ public final class LightkeeperAssertions extends Assertions
                     exception);
             }
 
-            if (System.nanoTime() >= deadlineNanos)
+            if (System.nanoTime() - startNanos >= timeoutNanos)
             {
                 final double elapsedSeconds = (System.nanoTime() - startNanos) / 1_000_000_000.0;
                 throw new AssertionError(

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperAssertions.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperAssertions.java
@@ -7,11 +7,21 @@ import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.Nullable;
 
+import java.time.Duration;
+import java.util.Objects;
+
 /**
  * AssertJ entrypoints for LightKeeper handles.
  */
 public final class LightkeeperAssertions extends Assertions
 {
+    /**
+     * Poll interval between retry attempts; matches the framework's {@code waitUntil} polling cadence.
+     */
+    private static final long RETRY_POLL_INTERVAL_MILLIS = 50L;
+
+    private static final ThreadLocal<Boolean> INSIDE_EVENTUALLY = new ThreadLocal<>();
+
     private LightkeeperAssertions()
     {
     }
@@ -62,5 +72,109 @@ public final class LightkeeperAssertions extends Assertions
     public static LightkeeperFrameworkAssert assertThat(@Nullable ILightkeeperFramework actual)
     {
         return new LightkeeperFrameworkAssert(actual);
+    }
+
+    /**
+     * Retries an assertion until it passes or the timeout expires.
+     *
+     * <p>Eager assertions never poll; this is the visible opt-in retry over the exact same assertion. The
+     * assertion is re-run in full — probe and matcher — every {@code 50 ms}, so it only makes sense over LIVE
+     * subjects that re-query the server per call (block types, inventories, menus, messages, server errors);
+     * retrying a frozen snapshot can never change the outcome and simply burns the timeout.
+     *
+     * <p>On timeout, the thrown {@link AssertionError} carries the retry history (attempt count and elapsed
+     * time) and the last attempt's failure as its cause — strictly more information than a generic
+     * "condition not met". A non-assertion exception (e.g. a closed framework) fails fast on the first
+     * occurrence instead of burning the timeout; nesting {@code eventually} inside {@code eventually} is
+     * detected and rejected.
+     *
+     * @param timeout
+     *     Maximum time to keep retrying; must be positive.
+     * @param assertion
+     *     The assertion to retry, typically a lambda re-running an eager {@code assertThat(...)} chain.
+     */
+    public static void eventually(Duration timeout, RetryingAssertion assertion)
+    {
+        Objects.requireNonNull(timeout, "timeout may not be null.");
+        Objects.requireNonNull(assertion, "assertion may not be null.");
+        if (timeout.isZero() || timeout.isNegative())
+            throw new IllegalArgumentException("timeout must be positive.");
+        if (Boolean.TRUE.equals(INSIDE_EVENTUALLY.get()))
+            throw new IllegalStateException(
+                "eventually(...) may not be nested inside another eventually(...); retry the whole assertion "
+                    + "in a single call instead.");
+
+        INSIDE_EVENTUALLY.set(Boolean.TRUE);
+        try
+        {
+            runWithRetries(timeout, assertion);
+        }
+        finally
+        {
+            INSIDE_EVENTUALLY.remove();
+        }
+    }
+
+    private static void runWithRetries(Duration timeout, RetryingAssertion assertion)
+    {
+        final long startNanos = System.nanoTime();
+        final long deadlineNanos = startNanos + timeout.toNanos();
+        int attempts = 0;
+        while (true)
+        {
+            attempts++;
+            final AssertionError lastFailure;
+            try
+            {
+                assertion.run();
+                return;
+            }
+            catch (AssertionError assertionError)
+            {
+                lastFailure = assertionError;
+            }
+            catch (Exception exception)
+            {
+                // Non-assertion failures (closed framework, protocol errors) will not heal by retrying.
+                throw new IllegalStateException(
+                    "Assertion evaluation failed with a non-assertion error on attempt %d.".formatted(attempts),
+                    exception);
+            }
+
+            if (System.nanoTime() >= deadlineNanos)
+            {
+                final double elapsedSeconds = (System.nanoTime() - startNanos) / 1_000_000_000.0;
+                throw new AssertionError(
+                    "Assertion did not pass within %s (%d attempts over %.1fs). Last failure: %s".formatted(
+                        timeout, attempts, elapsedSeconds, lastFailure.getMessage()),
+                    lastFailure);
+            }
+
+            try
+            {
+                Thread.sleep(RETRY_POLL_INTERVAL_MILLIS);
+            }
+            catch (InterruptedException interruptedException)
+            {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while retrying an assertion.", interruptedException);
+            }
+        }
+    }
+
+    /**
+     * An assertion that {@link #eventually(Duration, RetryingAssertion)} re-runs until it passes.
+     */
+    @FunctionalInterface
+    public interface RetryingAssertion
+    {
+        /**
+         * Runs the assertion once.
+         *
+         * @throws Exception
+         *     Propagates probe failures; assertion failures surface as {@link AssertionError}.
+         */
+        void run()
+            throws Exception;
     }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperAssertions.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/LightkeeperAssertions.java
@@ -100,9 +100,7 @@ public final class LightkeeperAssertions extends Assertions
         if (timeout.isZero() || timeout.isNegative())
             throw new IllegalArgumentException("timeout must be positive.");
         if (Boolean.TRUE.equals(INSIDE_EVENTUALLY.get()))
-            throw new IllegalStateException(
-                "eventually(...) may not be nested inside another eventually(...); retry the whole assertion "
-                    + "in a single call instead.");
+            throw new NestedEventuallyException();
 
         INSIDE_EVENTUALLY.set(Boolean.TRUE);
         try
@@ -132,6 +130,11 @@ public final class LightkeeperAssertions extends Assertions
             catch (AssertionError assertionError)
             {
                 lastFailure = assertionError;
+            }
+            catch (NestedEventuallyException nestedEventuallyException)
+            {
+                // A programmer error, not an evaluation failure: surface the nesting message directly.
+                throw nestedEventuallyException;
             }
             catch (Exception exception)
             {
@@ -172,9 +175,23 @@ public final class LightkeeperAssertions extends Assertions
          * Runs the assertion once.
          *
          * @throws Exception
-         *     Propagates probe failures; assertion failures surface as {@link AssertionError}.
+         *     Assertion failures surface as {@link AssertionError} and are retried; any other failure is
+         *     wrapped in an {@link IllegalStateException} (with the original as its cause) and fails fast.
          */
         void run()
             throws Exception;
+    }
+
+    /**
+     * Thrown when {@code eventually} is nested inside another {@code eventually}; a distinct type so the
+     * outer retry loop can surface the nesting message directly instead of wrapping it.
+     */
+    private static final class NestedEventuallyException extends IllegalStateException
+    {
+        NestedEventuallyException()
+        {
+            super("eventually(...) may not be nested inside another eventually(...); retry the whole "
+                + "assertion in a single call instead.");
+        }
     }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldBlockAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldBlockAssert.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework.assertions;
 
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import org.assertj.core.api.AbstractAssert;
 import org.bukkit.Material;
@@ -13,9 +13,9 @@ import java.util.Objects;
  */
 public final class WorldBlockAssert extends AbstractAssert<WorldBlockAssert, @Nullable WorldHandle>
 {
-    private final Vector3Di position;
+    private final BlockPos position;
 
-    WorldBlockAssert(WorldHandle worldHandle, Vector3Di position)
+    WorldBlockAssert(WorldHandle worldHandle, BlockPos position)
     {
         super(worldHandle, WorldBlockAssert.class);
         this.position = position;

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldHandleAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldHandleAssert.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework.assertions;
 
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import org.assertj.core.api.AbstractAssert;
@@ -30,7 +31,7 @@ public final class WorldHandleAssert extends AbstractAssert<WorldHandleAssert, @
     public WorldBlockAssert hasBlockAt(int x, int y, int z)
     {
         final var actual = nonNullActual();
-        return new WorldBlockAssert(actual, new Vector3Di(x, y, z));
+        return new WorldBlockAssert(actual, new BlockPos(x, y, z));
     }
 
     /**
@@ -40,13 +41,27 @@ public final class WorldHandleAssert extends AbstractAssert<WorldHandleAssert, @
      *     Block position.
      * @return Block assertion entrypoint.
      */
-    public WorldBlockAssert hasBlockAt(Vector3Di position)
+    public WorldBlockAssert hasBlockAt(BlockPos position)
     {
         return hasBlockAt(
             position.x(),
             position.y(),
             position.z()
         );
+    }
+
+    /**
+     * Starts an assertion chain for a block at the requested position.
+     *
+     * @param position
+     *     Block position.
+     * @return Block assertion entrypoint.
+     * @deprecated Use {@link #hasBlockAt(BlockPos)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public WorldBlockAssert hasBlockAt(Vector3Di position)
+    {
+        return hasBlockAt(position.toBlockPos());
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldHandleAssert.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/assertions/WorldHandleAssert.java
@@ -43,6 +43,7 @@ public final class WorldHandleAssert extends AbstractAssert<WorldHandleAssert, @
      */
     public WorldBlockAssert hasBlockAt(BlockPos position)
     {
+        java.util.Objects.requireNonNull(position, "position may not be null.");
         return hasBlockAt(
             position.x(),
             position.y(),

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot;
 import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.CommandResult;
@@ -15,7 +16,6 @@ import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
@@ -296,7 +296,7 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
-    public String getBlock(String worldName, Vector3Di position)
+    public String getBlock(String worldName, BlockPos position)
     {
         ensureOpen();
         Objects.requireNonNull(worldName, "worldName may not be null.");
@@ -305,7 +305,7 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
-    public void setBlock(String worldName, Vector3Di position, String material)
+    public void setBlock(String worldName, BlockPos position, String material)
     {
         ensureOpen();
         Objects.requireNonNull(worldName, "worldName may not be null.");
@@ -413,13 +413,13 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     }
 
     @Override
-    public boolean leftClickBlock(UUID playerId, Vector3Di position, String blockFace)
+    public boolean leftClickBlock(UUID playerId, BlockPos position, String blockFace)
     {
         return clickBlock(playerId, position, blockFace, agentClient::leftClickBlock);
     }
 
     @Override
-    public boolean rightClickBlock(UUID playerId, Vector3Di position, String blockFace)
+    public boolean rightClickBlock(UUID playerId, BlockPos position, String blockFace)
     {
         return clickBlock(playerId, position, blockFace, agentClient::rightClickBlock);
     }
@@ -742,7 +742,7 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         startServer();
     }
 
-    private boolean clickBlock(UUID playerId, Vector3Di position, String blockFace, BlockClickOperation operation)
+    private boolean clickBlock(UUID playerId, BlockPos position, String blockFace, BlockClickOperation operation)
     {
         ensureOpen();
         Objects.requireNonNull(playerId, "playerId may not be null.");
@@ -756,7 +756,7 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     @FunctionalInterface
     private interface BlockClickOperation
     {
-        boolean clickBlock(UUID playerId, Vector3Di position, String blockFace);
+        boolean clickBlock(UUID playerId, BlockPos position, String blockFace);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -1,10 +1,10 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
@@ -133,7 +133,7 @@ final class UdsAgentClient implements AutoCloseable
         return send(cmd).dispatched();
     }
 
-    String blockType(String worldName, Vector3Di position)
+    String blockType(String worldName, BlockPos position)
     {
         final BlockType.Command command = new BlockType.Command(
             nextRequestId(),
@@ -145,7 +145,7 @@ final class UdsAgentClient implements AutoCloseable
         return send(command).material();
     }
 
-    void setBlock(String worldName, Vector3Di position, String material)
+    void setBlock(String worldName, BlockPos position, String material)
     {
         final SetBlock.Command command = new SetBlock.Command(
             nextRequestId(),
@@ -219,7 +219,7 @@ final class UdsAgentClient implements AutoCloseable
         send(command);
     }
 
-    boolean leftClickBlock(UUID uuid, Vector3Di position, String blockFace)
+    boolean leftClickBlock(UUID uuid, BlockPos position, String blockFace)
     {
         final LeftClickBlock.Command command = new LeftClickBlock.Command(
             nextRequestId(),
@@ -232,7 +232,7 @@ final class UdsAgentClient implements AutoCloseable
         return send(command).cancelled();
     }
 
-    boolean rightClickBlock(UUID uuid, Vector3Di position, String blockFace)
+    boolean rightClickBlock(UUID uuid, BlockPos position, String blockFace)
     {
         final RightClickBlock.Command command = new RightClickBlock.Command(
             nextRequestId(),

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -415,7 +415,7 @@ class PlayerHandleTest
 
         // verify
         assertThat(result).isEqualTo(new InteractionResult(true, false));
-        verify(frameworkGateway).leftClickBlock(eq(PLAYER_UUID), any(BlockPos.class), eq("UP"));
+        verify(frameworkGateway).leftClickBlock(PLAYER_UUID, new BlockPos(5, 64, 6), "UP");
     }
 
     @Test
@@ -440,6 +440,6 @@ class PlayerHandleTest
 
         // verify
         assertThat(result).isEqualTo(new InteractionResult(true, false));
-        verify(frameworkGateway).rightClickBlock(eq(PLAYER_UUID), any(BlockPos.class), eq("UP"));
+        verify(frameworkGateway).rightClickBlock(PLAYER_UUID, new BlockPos(9, 64, 10), "UP");
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -81,6 +81,22 @@ class PlayerHandleTest
     }
 
     @Test
+    void teleport_shouldDelegateVec3OverloadToGatewayAndReturnSelf()
+    {
+        // setup
+        final WorldHandle world = mock(WorldHandle.class);
+        when(world.name()).thenReturn("world_nether");
+        when(frameworkGateway.teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5)).thenReturn(true);
+
+        // execute
+        final PlayerHandle result = playerHandle.teleport(world, new Vec3(10.5, 64.0, 20.5));
+
+        // verify
+        assertThat(result).isSameAs(playerHandle);
+        verify(frameworkGateway).teleportPlayer(PLAYER_UUID, "world_nether", 10.5, 64.0, 20.5);
+    }
+
+    @Test
     void permissions_shouldReturnNonNullPermissionControl()
     {
         // execute
@@ -206,7 +222,7 @@ class PlayerHandleTest
     void leftClickBlock_shouldDelegateToGatewayAndReturnInteractionResult()
     {
         // setup
-        final Vector3Di position = new Vector3Di(1, 64, 2);
+        final BlockPos position = new BlockPos(1, 64, 2);
         when(frameworkGateway.leftClickBlock(PLAYER_UUID, position, "NORTH")).thenReturn(true);
 
         // execute
@@ -218,10 +234,26 @@ class PlayerHandleTest
     }
 
     @Test
-    void rightClickBlock_shouldDelegateToGatewayAndReturnInteractionResult()
+    @SuppressWarnings("removal")
+    void leftClickBlock_shouldDelegateFromDeprecatedVector3DiOverload()
     {
         // setup
         final Vector3Di position = new Vector3Di(1, 64, 2);
+        when(frameworkGateway.leftClickBlock(PLAYER_UUID, position.toBlockPos(), "NORTH")).thenReturn(true);
+
+        // execute
+        final InteractionResult result = playerHandle.leftClickBlock(position, BlockFace.NORTH);
+
+        // verify
+        assertThat(result).isEqualTo(new InteractionResult(true, true));
+        verify(frameworkGateway).leftClickBlock(PLAYER_UUID, position.toBlockPos(), "NORTH");
+    }
+
+    @Test
+    void rightClickBlock_shouldDelegateToGatewayAndReturnInteractionResult()
+    {
+        // setup
+        final BlockPos position = new BlockPos(1, 64, 2);
         when(frameworkGateway.rightClickBlock(PLAYER_UUID, position, "SOUTH")).thenReturn(false);
 
         // execute
@@ -365,7 +397,7 @@ class PlayerHandleTest
     void leftClickBlock_shouldDelegateWithDefaultBlockFaceWhenOnlyPositionGiven()
     {
         // setup
-        final Vector3Di position = new Vector3Di(3, 70, 4);
+        final BlockPos position = new BlockPos(3, 70, 4);
 
         // execute
         final InteractionResult result = playerHandle.leftClickBlock(position);
@@ -383,14 +415,14 @@ class PlayerHandleTest
 
         // verify
         assertThat(result).isEqualTo(new InteractionResult(true, false));
-        verify(frameworkGateway).leftClickBlock(eq(PLAYER_UUID), any(Vector3Di.class), eq("UP"));
+        verify(frameworkGateway).leftClickBlock(eq(PLAYER_UUID), any(BlockPos.class), eq("UP"));
     }
 
     @Test
     void rightClickBlock_shouldDelegateWithDefaultBlockFaceWhenOnlyPositionGiven()
     {
         // setup
-        final Vector3Di position = new Vector3Di(7, 70, 8);
+        final BlockPos position = new BlockPos(7, 70, 8);
 
         // execute
         final InteractionResult result = playerHandle.rightClickBlock(position);
@@ -408,6 +440,6 @@ class PlayerHandleTest
 
         // verify
         assertThat(result).isEqualTo(new InteractionResult(true, false));
-        verify(frameworkGateway).rightClickBlock(eq(PLAYER_UUID), any(Vector3Di.class), eq("UP"));
+        verify(frameworkGateway).rightClickBlock(eq(PLAYER_UUID), any(BlockPos.class), eq("UP"));
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
@@ -35,7 +35,7 @@ class WorldHandleTest
     void blockTypeAt_shouldDelegateToGateway()
     {
         // setup
-        final Vector3Di position = new Vector3Di(1, 70, 2);
+        final BlockPos position = new BlockPos(1, 70, 2);
         when(frameworkGateway.getBlock("world", position)).thenReturn("STONE");
 
         // execute
@@ -47,7 +47,37 @@ class WorldHandleTest
     }
 
     @Test
+    @SuppressWarnings("removal")
+    void blockTypeAt_shouldDelegateFromDeprecatedVector3DiOverload()
+    {
+        // setup
+        final Vector3Di position = new Vector3Di(1, 70, 2);
+        when(frameworkGateway.getBlock("world", position.toBlockPos())).thenReturn("STONE");
+
+        // execute
+        final String blockType = worldHandle.blockTypeAt(position);
+
+        // verify
+        assertThat(blockType).isEqualTo("STONE");
+        verify(frameworkGateway).getBlock("world", position.toBlockPos());
+    }
+
+    @Test
     void setBlockAt_shouldDelegateToGateway()
+    {
+        // setup
+        final BlockPos position = new BlockPos(1, 70, 2);
+
+        // execute
+        worldHandle.setBlockAt(position, "STONE");
+
+        // verify
+        verify(frameworkGateway).setBlock("world", position, "STONE");
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void setBlockAt_shouldDelegateFromDeprecatedVector3DiOverload()
     {
         // setup
         final Vector3Di position = new Vector3Di(1, 70, 2);
@@ -56,7 +86,7 @@ class WorldHandleTest
         worldHandle.setBlockAt(position, "STONE");
 
         // verify
-        verify(frameworkGateway).setBlock("world", position, "STONE");
+        verify(frameworkGateway).setBlock("world", position.toBlockPos(), "STONE");
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/EventuallyTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/EventuallyTest.java
@@ -16,15 +16,12 @@ class EventuallyTest
     {
         // setup
         final AtomicInteger attempts = new AtomicInteger(0);
-        final long startNanos = System.nanoTime();
 
         // execute
         LightkeeperAssertions.eventually(Duration.ofSeconds(5), attempts::incrementAndGet);
-        final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
 
-        // verify — a first-attempt success must not burn the 50 ms retry poll interval
+        // verify — a first-attempt success runs the assertion exactly once, with no retry
         assertThat(attempts.get()).isEqualTo(1);
-        assertThat(elapsedMillis).isLessThan(50L);
     }
 
     @Test
@@ -93,9 +90,8 @@ class EventuallyTest
         final Throwable thrown = catchThrowable(() -> LightkeeperAssertions.eventually(
             Duration.ofSeconds(5), () -> LightkeeperAssertions.eventually(Duration.ofSeconds(5), () -> { })));
 
-        // verify — the nesting guard fires from the inner call and surfaces as the outer failure's cause
-        assertThat(thrown).isInstanceOf(IllegalStateException.class);
-        assertThat(thrown.getCause())
+        // verify — the nesting guard's own message surfaces directly instead of being wrapped
+        assertThat(thrown)
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("nested");
     }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/EventuallyTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/EventuallyTest.java
@@ -1,0 +1,136 @@
+package nl.pim16aap2.lightkeeper.framework.assertions;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+class EventuallyTest
+{
+    @Test
+    void eventually_shouldPassImmediatelyWhenAssertionSucceedsOnFirstAttempt()
+    {
+        // setup
+        final AtomicInteger attempts = new AtomicInteger(0);
+        final long startNanos = System.nanoTime();
+
+        // execute
+        LightkeeperAssertions.eventually(Duration.ofSeconds(5), attempts::incrementAndGet);
+        final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        // verify — a first-attempt success must not burn the 50 ms retry poll interval
+        assertThat(attempts.get()).isEqualTo(1);
+        assertThat(elapsedMillis).isLessThan(50L);
+    }
+
+    @Test
+    void eventually_shouldPassAfterRetryingFailedAttempts()
+    {
+        // setup
+        final AtomicInteger attempts = new AtomicInteger(0);
+
+        // execute
+        LightkeeperAssertions.eventually(Duration.ofSeconds(5), () ->
+        {
+            if (attempts.incrementAndGet() < 3)
+                throw new AssertionError("Not ready yet.");
+        });
+
+        // verify
+        assertThat(attempts.get()).isEqualTo(3);
+    }
+
+    @Test
+    void eventually_shouldThrowAssertionErrorWithLastFailureAsCauseWhenTimeoutIsExceeded()
+    {
+        // setup
+        final AtomicInteger attempts = new AtomicInteger(0);
+
+        // execute
+        final Throwable thrown = catchThrowable(() -> LightkeeperAssertions.eventually(
+            Duration.ofMillis(200), () ->
+            {
+                attempts.incrementAndGet();
+                throw new AssertionError("Still failing.");
+            }));
+
+        // verify
+        assertThat(thrown)
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("did not pass within")
+            .hasMessageContaining("attempts");
+        assertThat(thrown.getCause())
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("Still failing.");
+        assertThat(attempts.get()).isGreaterThan(0);
+    }
+
+    @Test
+    void eventually_shouldThrowIllegalStateExceptionImmediatelyWhenNonAssertionExceptionIsThrown()
+    {
+        // setup
+        final AtomicInteger attempts = new AtomicInteger(0);
+
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.eventually(Duration.ofSeconds(5), () ->
+        {
+            attempts.incrementAndGet();
+            throw new IllegalStateException("Framework is closed.");
+        }))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("non-assertion");
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void eventually_shouldThrowIllegalStateExceptionWhenNestedInsideAnotherEventually()
+    {
+        // execute
+        final Throwable thrown = catchThrowable(() -> LightkeeperAssertions.eventually(
+            Duration.ofSeconds(5), () -> LightkeeperAssertions.eventually(Duration.ofSeconds(5), () -> { })));
+
+        // verify — the nesting guard fires from the inner call and surfaces as the outer failure's cause
+        assertThat(thrown).isInstanceOf(IllegalStateException.class);
+        assertThat(thrown.getCause())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("nested");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void eventually_shouldThrowNullPointerExceptionWhenTimeoutIsNull()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.eventually(null, () -> { }))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void eventually_shouldThrowNullPointerExceptionWhenAssertionIsNull()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.eventually(Duration.ofSeconds(5), null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void eventually_shouldThrowIllegalArgumentExceptionWhenTimeoutIsZero()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.eventually(Duration.ZERO, () -> { }))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void eventually_shouldThrowIllegalArgumentExceptionWhenTimeoutIsNegative()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> LightkeeperAssertions.eventually(Duration.ofSeconds(-1), () -> { }))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
@@ -1,14 +1,14 @@
 package nl.pim16aap2.lightkeeper.framework.assertions;
 
-import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.InventorySnapshot;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
-import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import org.bukkit.Material;

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/assertions/HandleAssertionsTest.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import org.bukkit.Material;
@@ -279,8 +280,8 @@ class HandleAssertionsTest
     {
         // setup
         final WorldHandle handle = mock(WorldHandle.class);
-        when(handle.blockTypeAt(new Vector3Di(1, 2, 3))).thenReturn("stone");
-        when(handle.blockTypeAt(new Vector3Di(4, 5, 6))).thenReturn("minecraft:dirt");
+        when(handle.blockTypeAt(new BlockPos(1, 2, 3))).thenReturn("stone");
+        when(handle.blockTypeAt(new BlockPos(4, 5, 6))).thenReturn("minecraft:dirt");
 
         // execute + verify
         LightkeeperAssertions.assertThat(handle).hasBlockAt(1, 2, 3).ofType(Material.STONE);
@@ -292,12 +293,24 @@ class HandleAssertionsTest
     {
         // setup
         final WorldHandle handle = mock(WorldHandle.class);
-        when(handle.blockTypeAt(new Vector3Di(0, 0, 0))).thenReturn("minecraft:stone");
+        when(handle.blockTypeAt(new BlockPos(0, 0, 0))).thenReturn("minecraft:stone");
 
         // execute + verify
         assertThatThrownBy(() ->
             LightkeeperAssertions.assertThat(handle).hasBlockAt(0, 0, 0).ofType("minecraft:dirt"))
             .isInstanceOf(AssertionError.class)
             .hasMessageContaining("Expected block at (0,0,0)");
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void hasBlockAt_shouldDelegateFromDeprecatedVector3DiOverload()
+    {
+        // setup
+        final WorldHandle handle = mock(WorldHandle.class);
+        when(handle.blockTypeAt(new BlockPos(1, 2, 3))).thenReturn("minecraft:stone");
+
+        // execute + verify
+        LightkeeperAssertions.assertThat(handle).hasBlockAt(new Vector3Di(1, 2, 3)).ofType(Material.STONE);
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
@@ -308,7 +308,7 @@ class DefaultLightkeeperFrameworkGatewayTest
         // setup
         final UdsAgentClient agentClient = mock(UdsAgentClient.class);
         final UUID playerId = UUID.randomUUID();
-        final Vector3Di position = new Vector3Di(1, 64, 1);
+        final BlockPos position = new BlockPos(1, 64, 1);
         when(agentClient.leftClickBlock(playerId, position, "UP")).thenReturn(true);
         final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
             runtimeManifest(),
@@ -330,7 +330,7 @@ class DefaultLightkeeperFrameworkGatewayTest
         // setup
         final UdsAgentClient agentClient = mock(UdsAgentClient.class);
         final UUID playerId = UUID.randomUUID();
-        final Vector3Di position = new Vector3Di(1, 64, 1);
+        final BlockPos position = new BlockPos(1, 64, 1);
         when(agentClient.leftClickBlock(playerId, position, "UP")).thenReturn(false);
         final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
             runtimeManifest(),
@@ -352,7 +352,7 @@ class DefaultLightkeeperFrameworkGatewayTest
         // setup
         final UdsAgentClient agentClient = mock(UdsAgentClient.class);
         final UUID playerId = UUID.randomUUID();
-        final Vector3Di position = new Vector3Di(1, 64, 1);
+        final BlockPos position = new BlockPos(1, 64, 1);
         when(agentClient.rightClickBlock(playerId, position, "UP")).thenReturn(true);
         final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
             runtimeManifest(),
@@ -374,7 +374,7 @@ class DefaultLightkeeperFrameworkGatewayTest
         // setup
         final UdsAgentClient agentClient = mock(UdsAgentClient.class);
         final UUID playerId = UUID.randomUUID();
-        final Vector3Di position = new Vector3Di(1, 64, 1);
+        final BlockPos position = new BlockPos(1, 64, 1);
         when(agentClient.rightClickBlock(playerId, position, "UP")).thenReturn(false);
         final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
             runtimeManifest(),

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.ItemSnapshot;
@@ -310,7 +310,7 @@ class UdsAgentClientTest
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final boolean cancelled = client.leftClickBlock(PLAYER_ID, new Vector3Di(1, 64, 1), "UP");
+            final boolean cancelled = client.leftClickBlock(PLAYER_ID, new BlockPos(1, 64, 1), "UP");
 
             // verify
             assertThat(cancelled).isTrue();
@@ -329,7 +329,7 @@ class UdsAgentClientTest
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final boolean cancelled = client.rightClickBlock(PLAYER_ID, new Vector3Di(1, 64, 1), "UP");
+            final boolean cancelled = client.rightClickBlock(PLAYER_ID, new BlockPos(1, 64, 1), "UP");
 
             // verify
             assertThat(cancelled).isFalse();

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
@@ -141,10 +141,10 @@ class LightkeeperBotIT
         builtPlayer.andWaitTicks(1);
         final MenuHandle noLongerOpenMenu = builtPlayer.getMenu();
         explicitPlayer.placeBlock("STONE", 2, 100, 0);
-        eventually(Duration.ofSeconds(20), () ->
-            assertThat(buildWorldResult).hasBlockAt(new BlockPos(2, 100, 0)).ofType(Material.STONE));
 
         // verify
+        eventually(Duration.ofSeconds(20), () ->
+            assertThat(buildWorldResult).hasBlockAt(new BlockPos(2, 100, 0)).ofType(Material.STONE));
         assertThat(consoleCommandResult.success()).isTrue();
         assertThat(buildWorldResult.name()).isNotBlank();
         assertThat(menu.player()).isEqualTo(builtPlayer);

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
@@ -1,10 +1,10 @@
 package nl.pim16aap2.lightkeeper.maven.test;
 
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.InteractionResult;
 import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import org.bukkit.Material;
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.UUID;
 
 import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.eventually;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,9 +75,9 @@ class LightkeeperBotIT
 
         player.placeBlock("minecraft:stone", 1, 100, 0)
             .andWaitTicks(1);
-        world.setBlockAt(new Vector3Di(3, 100, 0), "minecraft:gold_block");
-        final InteractionResult leftClickResult = player.leftClickBlock(new Vector3Di(3, 100, 0), BlockFace.NORTH);
-        final InteractionResult rightClickResult = player.rightClickBlock(new Vector3Di(3, 100, 0), BlockFace.SOUTH);
+        world.setBlockAt(new BlockPos(3, 100, 0), "minecraft:gold_block");
+        final InteractionResult leftClickResult = player.leftClickBlock(new BlockPos(3, 100, 0), BlockFace.NORTH);
+        final InteractionResult rightClickResult = player.rightClickBlock(new BlockPos(3, 100, 0), BlockFace.SOUTH);
         player.andWaitTicks(1);
         final DropResult emptyHandDropResult = player.dropMainHandItem();
 
@@ -140,10 +141,8 @@ class LightkeeperBotIT
         builtPlayer.andWaitTicks(1);
         final MenuHandle noLongerOpenMenu = builtPlayer.getMenu();
         explicitPlayer.placeBlock("STONE", 2, 100, 0);
-        framework.waitUntil(
-            () -> "minecraft:stone".equals(buildWorldResult.blockTypeAt(new Vector3Di(2, 100, 0))),
-            Duration.ofSeconds(20)
-        );
+        eventually(Duration.ofSeconds(20), () ->
+            assertThat(buildWorldResult).hasBlockAt(new BlockPos(2, 100, 0)).ofType(Material.STONE));
 
         // verify
         assertThat(consoleCommandResult.success()).isTrue();

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperExtensionIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperExtensionIT.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.lightkeeper.maven.test;
 
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -28,7 +28,7 @@ class LightkeeperExtensionIT
     {
         // setup
         final var mainWorld = framework.mainWorld();
-        final Vector3Di position = new Vector3Di(2, 70, 2);
+        final BlockPos position = new BlockPos(2, 70, 2);
 
         // execute
         final var world = framework.newWorld();

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperFrameworkIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperFrameworkIT.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.lightkeeper.maven.test;
 
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.Lightkeeper;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
@@ -49,7 +49,7 @@ class LightkeeperFrameworkIT
         // setup
         final Path runtimeManifestPath = getRuntimeManifestPath();
         final String worldName = "lk_world_" + UUID.randomUUID().toString().replace("-", "");
-        final Vector3Di position = new Vector3Di(1, 70, 1);
+        final BlockPos position = new BlockPos(1, 70, 1);
         final WorldSpec worldSpec = new WorldSpec(
             worldName,
             WorldSpec.WorldType.FLAT,


### PR DESCRIPTION
## Why
- First half of roadmap slice S2: the assertion-model half (design decision D1) and the geometry-vocabulary rename (D6) — fixed now, while the API has a single consumer.
- Tests currently hand-roll block-wait polls whose failures say only "condition not met"; assertion failures could never ride `waitUntil` because `Condition`'s checked-`Exception` contract cannot catch `AssertionError`.

## How
- **`eventually(timeout, () -> assertThat(...))`** on `LightkeeperAssertions`: visible opt-in retry re-running the exact eager assertion (probe + matcher) every 50ms. Timeout failures carry attempt count, elapsed time, and the last failure as cause; non-assertion errors fail fast; nesting is rejected with a direct message. `OutOfMemoryError`/other `Error`s are never swallowed; opentest4j failures are retried (they subclass `AssertionError`).
- **`BlockPos` (int) / `Vec3` (double)** are the canonical geometry vocabulary. Public APIs gained `BlockPos` variants; the `Vector3Di` overloads remain for one release as `@Deprecated(forRemoval = true)` delegates (evolve-in-place, D3). Internal seams switched outright; `teleport` gained a `Vec3` overload. The wire protocol was already primitive-int-only — untouched, no version bump.
- BotIT's hand-rolled block poll is now the first real `eventually()` usage.

## Tests
- `mvn -Perrorprone clean install checkstyle:checkstyle pmd:check`: BUILD SUCCESS, 0 violations; 245+ framework unit tests incl. new `EventuallyTest` (retry-until-pass, timeout enrichment, fail-fast, nesting, validation) and deprecated-delegate tests.
- `mvn clean verify -pl lightkeeper-integration-tests`: 28/28 on both Paper and Spigot lanes.
- Pre-PR deep review (Opus agent): MERGE-WITH-FIXES — no blockers or majors; both minors and all nits addressed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P15FjGQzyNmX9T6Qmyq8Dn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added polling-based `eventually(Duration, ...)` retryable assertions with attempt/elapsed-time reporting.
  * Added a canonical `Vec3` type and a canonical `BlockPos` type for API coordinates.
  * Added a `teleport` overload that accepts `Vec3`.
* **API Updates**
  * Block interactions/queries/assertions now use `BlockPos` (with `Vector3Di` overloads deprecated and delegating via conversion).
* **Documentation**
  * Updated README with the new `eventually(timeout, ...)` behavior details.
* **Tests**
  * Expanded unit/integration coverage for the new retryable assertions and `BlockPos`-based block coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->