### PR TITLE
feat: IProtocolValue typed wire envelope (S2, part 2 — protocol v6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ class MyPluginIT
 - Received-message assertions with AssertJ string chaining
 - Explicit retrying assertions: `eventually(timeout, () -> assertThat(...))` re-runs a live probe until it
   passes, and reports the attempt count, elapsed time, and last failure on timeout
+- Typed event payloads: captured events carry real types (numbers, booleans, UUIDs, enums, entity/world
+  references, nested records) — values the agent cannot encode appear as explicit `DROPPED` markers instead
+  of being silently absent
 - Diagnostics-on-failure: failed tests automatically get a bundle (test outcome, captured server errors,
   server console output) under `target/lightkeeper-reports/`
 - Graceful server lifecycle control from tests (`stopServer()`, `startServer()`, `restartServer()`), plus

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListener;
 
@@ -73,7 +74,7 @@ final class AgentEventActions
     GetCapturedEvents.Response handleGetCapturedEvents(GetCapturedEvents.Command command)
     {
         final String eventClassName = command.eventClassName();
-        final List<Map<String, String>> events = eventCapture.getCapturedEvents(eventClassName);
+        final List<Map<String, IProtocolValue>> events = eventCapture.getCapturedEvents(eventClassName);
         return new GetCapturedEvents.Response(events);
     }
 

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
@@ -8,8 +9,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,11 +33,6 @@ final class AgentEventCapture
      * Prevents unbounded memory growth when a test forgets to close the capture handle.
      */
     private static final int MAX_CAPTURED_EVENTS_PER_CLASS = 10_000;
-    /**
-     * Maximum number of getter/isser methods inspected per event instance during capture.
-     * Bounds reflection overhead for events with very wide APIs.
-     */
-    private static final int MAX_CAPTURE_METHODS_PER_EVENT = 32;
 
     /**
      * Owning plugin used as registration context for Bukkit listeners.
@@ -49,18 +43,17 @@ final class AgentEventCapture
      */
     private final AgentMainThreadExecutor mainThreadExecutor;
     /**
+     * Encoder turning fired events into typed wire payloads; owns the drop markers and their WARN-once logging.
+     */
+    private final ProtocolValueEncoder protocolValueEncoder;
+    /**
      * Captured event payloads keyed by fully qualified event class name.
      */
-    private final Map<String, List<Map<String, String>>> capturedEvents = new ConcurrentHashMap<>();
+    private final Map<String, List<Map<String, IProtocolValue>>> capturedEvents = new ConcurrentHashMap<>();
     /**
      * Active marker listeners keyed by fully qualified event class name.
      */
     private final Map<String, Listener> activeListeners = new ConcurrentHashMap<>();
-    /**
-     * {@code eventClassName#methodName} keys whose capture failure has already been logged, so a getter that
-     * throws on every event is warned about once rather than flooding the log up to the capture cap.
-     */
-    private final Set<String> loggedCaptureFailures = ConcurrentHashMap.newKeySet();
     /**
      * Event class names whose capture cap has already been warned about, so hitting the cap is reported once
      * rather than silently discarding every subsequent event.
@@ -77,6 +70,7 @@ final class AgentEventCapture
     {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.mainThreadExecutor = Objects.requireNonNull(mainThreadExecutor, "mainThreadExecutor");
+        this.protocolValueEncoder = new ProtocolValueEncoder(plugin);
     }
 
     /**
@@ -106,7 +100,7 @@ final class AgentEventCapture
                 throw new IllegalArgumentException("Class '%s' is not a Bukkit Event.".formatted(eventClassName));
 
             final Class<? extends Event> eventClass = resolvedClass.asSubclass(Event.class);
-            final List<Map<String, String>> events =
+            final List<Map<String, IProtocolValue>> events =
                 capturedEvents.computeIfAbsent(eventClassName, ignored -> new CopyOnWriteArrayList<>());
 
             mainThreadExecutor.callOnMainThread(() ->
@@ -225,9 +219,9 @@ final class AgentEventCapture
      * @return
      *     Snapshot list of captured event payloads, or an empty list when nothing has been captured.
      */
-    List<Map<String, String>> getCapturedEvents(String eventClassName)
+    List<Map<String, IProtocolValue>> getCapturedEvents(String eventClassName)
     {
-        final List<Map<String, String>> events = capturedEvents.get(eventClassName);
+        final List<Map<String, IProtocolValue>> events = capturedEvents.get(eventClassName);
         if (events == null)
             throw new IllegalArgumentException(
                 ("No capture listener is registered for event class '%s'; register it before querying captured "
@@ -244,7 +238,7 @@ final class AgentEventCapture
      */
     void clearCapturedEvents(String eventClassName)
     {
-        final List<Map<String, String>> events = capturedEvents.get(eventClassName);
+        final List<Map<String, IProtocolValue>> events = capturedEvents.get(eventClassName);
         if (events == null)
             throw new IllegalArgumentException(
                 "No capture listener is registered for event class '%s'; register it before clearing events."
@@ -252,7 +246,7 @@ final class AgentEventCapture
         events.clear();
     }
 
-    private void captureEventForList(Event event, List<Map<String, String>> targetList)
+    private void captureEventForList(Event event, List<Map<String, IProtocolValue>> targetList)
     {
         if (targetList.size() >= MAX_CAPTURED_EVENTS_PER_CLASS)
         {
@@ -264,73 +258,6 @@ final class AgentEventCapture
             return;
         }
 
-        final Map<String, String> data = new ConcurrentHashMap<>();
-        int inspectedMethodCount = 0;
-        for (final Method method : event.getClass().getMethods())
-        {
-            if (inspectedMethodCount >= MAX_CAPTURE_METHODS_PER_EVENT)
-                break;
-
-            if (method.getParameterCount() == 0 &&
-                (method.getName().startsWith("get") || method.getName().startsWith("is")) &&
-                !method.getName().equals("getClass") &&
-                !method.getName().equals("getHandlers") &&
-                !method.getName().equals("getEventName"))
-            {
-                ++inspectedMethodCount;
-                try
-                {
-                    final Object value = method.invoke(event);
-                    if (isPrintable(value))
-                        data.put(method.getName(), String.valueOf(value));
-                }
-                catch (InvocationTargetException exception)
-                {
-                    recordCaptureFailure(
-                        data, event, method, exception.getCause() == null ? exception : exception.getCause());
-                }
-                catch (ReflectiveOperationException | RuntimeException exception)
-                {
-                    recordCaptureFailure(data, event, method, exception);
-                }
-            }
-        }
-        targetList.add(data);
-    }
-
-    /**
-     * Records a visible sentinel for a failed event getter and warns once per event-class/method, so a getter
-     * that throws is never dropped silently (an absent key would let a negative assertion pass on broken
-     * capture).
-     *
-     * @param data
-     *     Captured property map for the current event.
-     * @param event
-     *     The event whose property failed to capture.
-     * @param method
-     *     The getter that failed.
-     * @param cause
-     *     The underlying failure (already unwrapped from any {@link InvocationTargetException}).
-     */
-    private void recordCaptureFailure(Map<String, String> data, Event event, Method method, Throwable cause)
-    {
-        data.put(method.getName(), "<capture-failed: " + cause.getClass().getSimpleName() + ">");
-        if (loggedCaptureFailures.add(event.getClass().getName() + "#" + method.getName()))
-            plugin.getLogger().log(
-                Level.WARNING,
-                "Failed to capture property '%s' of event '%s'."
-                    .formatted(method.getName(), event.getClass().getName()),
-                cause
-            );
-    }
-
-    private boolean isPrintable(Object value)
-    {
-        if (value == null) return false;
-        return value instanceof String ||
-               value instanceof Number ||
-               value instanceof Boolean ||
-               value instanceof java.util.UUID ||
-               value.getClass().isEnum();
+        targetList.add(protocolValueEncoder.encodeAccessors(event, event.getClass().getName()));
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
@@ -57,6 +57,11 @@ final class ProtocolValueEncoder
      */
     static final int MAX_CONTAINER_ELEMENTS = 128;
 
+    /**
+     * Reserved field name for truncation markers in encoded records and maps.
+     */
+    static final String TRUNCATED_KEY = "<truncated>";
+
     private final JavaPlugin plugin;
     /**
      * WARN-once guard keyed by {@code context + "#" + accessorName}, so a noisy accessor logs a single warning
@@ -95,34 +100,45 @@ final class ProtocolValueEncoder
         final Map<String, IProtocolValue> encoded = new LinkedHashMap<>();
         if (subject.getClass().isRecord())
         {
-            for (final RecordComponent component : boundedRecordComponents(subject))
+            final RecordComponent[] components = subject.getClass().getRecordComponents();
+            for (int i = 0; i < Math.min(components.length, MAX_ACCESSORS_PER_OBJECT); i++)
             {
+                final RecordComponent component = components[i];
                 final IProtocolValue value =
                     encodeAccessorResult(subject, component.getAccessor(), component.getName(),
                         context, remainingDepth);
                 if (value != null)
                     encoded.put(component.getName(), value);
             }
+            markTruncatedAccessors(encoded, context, components.length);
             return encoded;
         }
 
-        for (final Method accessor : boundedAccessors(subject))
+        final List<Method> accessors = sortedInstanceAccessors(subject);
+        for (int i = 0; i < Math.min(accessors.size(), MAX_ACCESSORS_PER_OBJECT); i++)
         {
+            final Method accessor = accessors.get(i);
             final IProtocolValue value =
                 encodeAccessorResult(subject, accessor, accessor.getName(), context, remainingDepth);
             if (value != null)
                 encoded.put(accessor.getName(), value);
         }
+        markTruncatedAccessors(encoded, context, accessors.size());
         return encoded;
     }
 
-    private List<RecordComponent> boundedRecordComponents(Object subject)
+    /**
+     * Appends a loud truncation marker when an object exposed more accessors than the per-object cap, so the
+     * cap never silently discards fields.
+     */
+    private void markTruncatedAccessors(Map<String, IProtocolValue> encoded, String context, int totalAccessors)
     {
-        final RecordComponent[] components = subject.getClass().getRecordComponents();
-        return Arrays.asList(components).subList(0, Math.min(components.length, MAX_ACCESSORS_PER_OBJECT));
+        if (totalAccessors > MAX_ACCESSORS_PER_OBJECT)
+            encoded.put(TRUNCATED_KEY, dropped(context, TRUNCATED_KEY,
+                "truncated: %d more accessors".formatted(totalAccessors - MAX_ACCESSORS_PER_OBJECT)));
     }
 
-    private List<Method> boundedAccessors(Object subject)
+    private List<Method> sortedInstanceAccessors(Object subject)
     {
         return Arrays.stream(subject.getClass().getMethods())
             // Static methods are never instance state; without this, every Bukkit event's static
@@ -134,7 +150,6 @@ final class ProtocolValueEncoder
                 && !method.getName().equals("getHandlers")
                 && !method.getName().equals("getEventName"))
             .sorted(Comparator.comparing(Method::getName))
-            .limit(MAX_ACCESSORS_PER_OBJECT)
             .toList();
     }
 
@@ -257,11 +272,16 @@ final class ProtocolValueEncoder
                 continue;
             if (encodedCount >= MAX_CONTAINER_ELEMENTS)
             {
-                fields.put("<truncated>", truncated(context, accessorName, map.size() - encodedCount));
+                fields.put(TRUNCATED_KEY, truncated(context, accessorName, map.size() - encodedCount));
                 break;
             }
-            fields.put(String.valueOf(entry.getKey()),
-                encodeValue(entry.getValue(), accessorName, context, remainingDepth - 1));
+            final String key = String.valueOf(entry.getKey());
+            final IProtocolValue encodedEntry =
+                encodeValue(entry.getValue(), accessorName, context, remainingDepth - 1);
+            // Distinct map keys can stringify identically (1 vs "1"); overwriting would lose data silently,
+            // so a collision is reported as a loud marker instead.
+            if (fields.putIfAbsent(key, encodedEntry) != null)
+                fields.put(key, dropped(context, accessorName, "key-collision: '%s'".formatted(key)));
             encodedCount++;
         }
         return new IProtocolValue.PRecord(fields);

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
@@ -1,0 +1,247 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+/**
+ * Generic reflective encoder from live Java objects to the {@link IProtocolValue} wire envelope.
+ *
+ * <p>Simple values map to their leaves (text, numbers, booleans, UUIDs, enum constants); identifiable Bukkit
+ * objects travel as references ({@link IProtocolValue.PRef}: entities by UUID, worlds by name) instead of being
+ * walked; collections, maps, and other objects nest ({@link IProtocolValue.PList},
+ * {@link IProtocolValue.PRecord}) up to a bounded depth. Records are walked through their record components, all
+ * other objects through their public zero-arg {@code get*}/{@code is*} accessors (sorted by name for
+ * deterministic output, capped per object).
+ *
+ * <p>Nothing is skipped silently: a value the encoder cannot represent — depth exhausted, an unencodable type,
+ * or a throwing accessor — is reported as a {@link IProtocolValue.PDropped} marker, with a WARN logged once per
+ * (context, accessor) pair. Only {@code null} values are omitted entirely: an absent value is data, not data
+ * loss.
+ */
+final class ProtocolValueEncoder
+{
+    /**
+     * Maximum nesting depth for encoded object graphs; deeper values are reported as dropped.
+     */
+    static final int MAX_DEPTH = 3;
+
+    /**
+     * Maximum number of accessors encoded per object; prevents pathological types from bloating payloads.
+     */
+    static final int MAX_ACCESSORS_PER_OBJECT = 32;
+
+    private final JavaPlugin plugin;
+    /**
+     * WARN-once guard keyed by {@code context + "#" + accessorName}, so a noisy accessor logs a single warning
+     * regardless of how many times its value is dropped.
+     */
+    private final Set<String> loggedDrops = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Creates an encoder that logs drop warnings through the given plugin's logger.
+     *
+     * @param plugin
+     *     Owning plugin used for logging.
+     */
+    ProtocolValueEncoder(JavaPlugin plugin)
+    {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    /**
+     * Encodes an object's accessible state into named {@link IProtocolValue}s.
+     *
+     * @param subject
+     *     The object whose accessors to walk.
+     * @param context
+     *     Context label for drop warnings, e.g. the captured event's class name.
+     * @return Accessor name to encoded value, in sorted accessor order; {@code null}-valued accessors are
+     *     omitted.
+     */
+    Map<String, IProtocolValue> encodeAccessors(Object subject, String context)
+    {
+        return walkAccessors(subject, context, MAX_DEPTH);
+    }
+
+    private Map<String, IProtocolValue> walkAccessors(Object subject, String context, int remainingDepth)
+    {
+        final Map<String, IProtocolValue> encoded = new LinkedHashMap<>();
+        if (subject.getClass().isRecord())
+        {
+            for (final RecordComponent component : boundedRecordComponents(subject))
+            {
+                final IProtocolValue value =
+                    encodeAccessorResult(subject, component.getAccessor(), component.getName(),
+                        context, remainingDepth);
+                if (value != null)
+                    encoded.put(component.getName(), value);
+            }
+            return encoded;
+        }
+
+        for (final Method accessor : boundedAccessors(subject))
+        {
+            final IProtocolValue value =
+                encodeAccessorResult(subject, accessor, accessor.getName(), context, remainingDepth);
+            if (value != null)
+                encoded.put(accessor.getName(), value);
+        }
+        return encoded;
+    }
+
+    private List<RecordComponent> boundedRecordComponents(Object subject)
+    {
+        final RecordComponent[] components = subject.getClass().getRecordComponents();
+        return Arrays.asList(components).subList(0, Math.min(components.length, MAX_ACCESSORS_PER_OBJECT));
+    }
+
+    private List<Method> boundedAccessors(Object subject)
+    {
+        return Arrays.stream(subject.getClass().getMethods())
+            .filter(method -> method.getParameterCount() == 0)
+            .filter(method -> method.getName().startsWith("get") || method.getName().startsWith("is"))
+            .filter(method -> !method.getName().equals("getClass")
+                && !method.getName().equals("getHandlers")
+                && !method.getName().equals("getEventName"))
+            .sorted(Comparator.comparing(Method::getName))
+            .limit(MAX_ACCESSORS_PER_OBJECT)
+            .toList();
+    }
+
+    private @Nullable IProtocolValue encodeAccessorResult(
+        Object subject,
+        Method accessor,
+        String accessorName,
+        String context,
+        int remainingDepth)
+    {
+        final Object value;
+        try
+        {
+            value = accessor.invoke(subject);
+        }
+        catch (InvocationTargetException exception)
+        {
+            final Throwable cause = Objects.requireNonNullElse(exception.getCause(), exception);
+            return dropped(context, accessorName, "capture-failed: " + cause.getClass().getSimpleName());
+        }
+        catch (ReflectiveOperationException | RuntimeException exception)
+        {
+            return dropped(context, accessorName, "capture-failed: " + exception.getClass().getSimpleName());
+        }
+
+        if (value == null)
+            return null;
+        return encodeValue(value, accessorName, context, remainingDepth);
+    }
+
+    /**
+     * Encodes a single non-null value at the given remaining depth.
+     */
+    private IProtocolValue encodeValue(Object value, String accessorName, String context, int remainingDepth)
+    {
+        if (value instanceof String string)
+            return new IProtocolValue.PString(string);
+        if (value instanceof Number number)
+            return new IProtocolValue.PNumber(number);
+        if (value instanceof Boolean bool)
+            return new IProtocolValue.PBool(bool);
+        if (value instanceof UUID uuid)
+            return new IProtocolValue.PUuid(uuid);
+        if (value.getClass().isEnum())
+            return new IProtocolValue.PEnum(value.getClass().getName(), ((Enum<?>) value).name());
+        if (value instanceof Entity entity)
+            return new IProtocolValue.PRef(entity.getClass().getName(), entity.getUniqueId().toString());
+        if (value instanceof World world)
+            return new IProtocolValue.PRef(world.getClass().getName(), world.getName());
+
+        if (remainingDepth <= 0)
+            return dropped(context, accessorName, value.getClass().getName());
+
+        if (value instanceof Collection<?> collection)
+            return encodeList(collection, accessorName, context, remainingDepth);
+        if (value.getClass().isArray())
+            return encodeArray(value, accessorName, context, remainingDepth);
+        if (value instanceof Map<?, ?> map)
+            return encodeMap(map, accessorName, context, remainingDepth);
+
+        final Map<String, IProtocolValue> nested = walkAccessors(value, context, remainingDepth - 1);
+        if (nested.isEmpty())
+            return dropped(context, accessorName, value.getClass().getName());
+        return new IProtocolValue.PRecord(nested);
+    }
+
+    private IProtocolValue encodeList(
+        Collection<?> collection,
+        String accessorName,
+        String context,
+        int remainingDepth)
+    {
+        final List<IProtocolValue> elements = new ArrayList<>(collection.size());
+        for (final Object element : collection)
+        {
+            if (element == null)
+                continue;
+            elements.add(encodeValue(element, accessorName, context, remainingDepth - 1));
+        }
+        return new IProtocolValue.PList(elements);
+    }
+
+    private IProtocolValue encodeArray(Object array, String accessorName, String context, int remainingDepth)
+    {
+        final int length = Array.getLength(array);
+        final List<IProtocolValue> elements = new ArrayList<>(length);
+        for (int i = 0; i < length; i++)
+        {
+            final Object element = Array.get(array, i);
+            if (element == null)
+                continue;
+            elements.add(encodeValue(element, accessorName, context, remainingDepth - 1));
+        }
+        return new IProtocolValue.PList(elements);
+    }
+
+    private IProtocolValue encodeMap(Map<?, ?> map, String accessorName, String context, int remainingDepth)
+    {
+        final Map<String, IProtocolValue> fields = new LinkedHashMap<>();
+        for (final Map.Entry<?, ?> entry : map.entrySet())
+        {
+            if (entry.getValue() == null)
+                continue;
+            fields.put(String.valueOf(entry.getKey()),
+                encodeValue(entry.getValue(), accessorName, context, remainingDepth - 1));
+        }
+        return new IProtocolValue.PRecord(fields);
+    }
+
+    private IProtocolValue.PDropped dropped(String context, String accessorName, String runtimeType)
+    {
+        if (loggedDrops.add(context + "#" + accessorName))
+            plugin.getLogger().log(
+                Level.WARNING,
+                () -> ("LK_AGENT: Dropped value of accessor '%s' (%s) while encoding '%s'; it will appear as a "
+                    + "DROPPED marker in captured payloads.").formatted(accessorName, runtimeType, context)
+            );
+        return new IProtocolValue.PDropped(accessorName, runtimeType);
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
@@ -9,6 +9,7 @@ import org.jspecify.annotations.Nullable;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +50,12 @@ final class ProtocolValueEncoder
      * Maximum number of accessors encoded per object; prevents pathological types from bloating payloads.
      */
     static final int MAX_ACCESSORS_PER_OBJECT = 32;
+
+    /**
+     * Maximum number of elements encoded per collection, array, or map; a truncated container carries a
+     * trailing {@link IProtocolValue.PDropped} marker naming the omitted remainder.
+     */
+    static final int MAX_CONTAINER_ELEMENTS = 128;
 
     private final JavaPlugin plugin;
     /**
@@ -118,6 +125,9 @@ final class ProtocolValueEncoder
     private List<Method> boundedAccessors(Object subject)
     {
         return Arrays.stream(subject.getClass().getMethods())
+            // Static methods are never instance state; without this, every Bukkit event's static
+            // getHandlerList() would drag server-global handler registrations into each payload.
+            .filter(method -> !Modifier.isStatic(method.getModifiers()))
             .filter(method -> method.getParameterCount() == 0)
             .filter(method -> method.getName().startsWith("get") || method.getName().startsWith("is"))
             .filter(method -> !method.getName().equals("getClass")
@@ -168,8 +178,10 @@ final class ProtocolValueEncoder
             return new IProtocolValue.PBool(bool);
         if (value instanceof UUID uuid)
             return new IProtocolValue.PUuid(uuid);
-        if (value.getClass().isEnum())
-            return new IProtocolValue.PEnum(value.getClass().getName(), ((Enum<?>) value).name());
+        // instanceof (not Class#isEnum) so enum constants with class bodies (e.g. ChatColor.RED, a synthetic
+        // ChatColor$13 subclass) still encode as enums; getDeclaringClass names the enum type, not the subclass.
+        if (value instanceof Enum<?> enumValue)
+            return new IProtocolValue.PEnum(enumValue.getDeclaringClass().getName(), enumValue.name());
         if (value instanceof Entity entity)
             return new IProtocolValue.PRef(entity.getClass().getName(), entity.getUniqueId().toString());
         if (value instanceof World world)
@@ -197,12 +209,19 @@ final class ProtocolValueEncoder
         String context,
         int remainingDepth)
     {
-        final List<IProtocolValue> elements = new ArrayList<>(collection.size());
+        final List<IProtocolValue> elements = new ArrayList<>(Math.min(collection.size(), MAX_CONTAINER_ELEMENTS));
+        int encodedCount = 0;
         for (final Object element : collection)
         {
             if (element == null)
                 continue;
+            if (encodedCount >= MAX_CONTAINER_ELEMENTS)
+            {
+                elements.add(truncated(context, accessorName, collection.size() - encodedCount));
+                break;
+            }
             elements.add(encodeValue(element, accessorName, context, remainingDepth - 1));
+            encodedCount++;
         }
         return new IProtocolValue.PList(elements);
     }
@@ -210,13 +229,20 @@ final class ProtocolValueEncoder
     private IProtocolValue encodeArray(Object array, String accessorName, String context, int remainingDepth)
     {
         final int length = Array.getLength(array);
-        final List<IProtocolValue> elements = new ArrayList<>(length);
+        final List<IProtocolValue> elements = new ArrayList<>(Math.min(length, MAX_CONTAINER_ELEMENTS));
+        int encodedCount = 0;
         for (int i = 0; i < length; i++)
         {
             final Object element = Array.get(array, i);
             if (element == null)
                 continue;
+            if (encodedCount >= MAX_CONTAINER_ELEMENTS)
+            {
+                elements.add(truncated(context, accessorName, length - encodedCount));
+                break;
+            }
             elements.add(encodeValue(element, accessorName, context, remainingDepth - 1));
+            encodedCount++;
         }
         return new IProtocolValue.PList(elements);
     }
@@ -224,14 +250,26 @@ final class ProtocolValueEncoder
     private IProtocolValue encodeMap(Map<?, ?> map, String accessorName, String context, int remainingDepth)
     {
         final Map<String, IProtocolValue> fields = new LinkedHashMap<>();
+        int encodedCount = 0;
         for (final Map.Entry<?, ?> entry : map.entrySet())
         {
             if (entry.getValue() == null)
                 continue;
+            if (encodedCount >= MAX_CONTAINER_ELEMENTS)
+            {
+                fields.put("<truncated>", truncated(context, accessorName, map.size() - encodedCount));
+                break;
+            }
             fields.put(String.valueOf(entry.getKey()),
                 encodeValue(entry.getValue(), accessorName, context, remainingDepth - 1));
+            encodedCount++;
         }
         return new IProtocolValue.PRecord(fields);
+    }
+
+    private IProtocolValue.PDropped truncated(String context, String accessorName, int omittedCount)
+    {
+        return dropped(context, accessorName, "truncated: %d more elements".formatted(omittedCount));
     }
 
     private IProtocolValue.PDropped dropped(String context, String accessorName, String runtimeType)

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListener;
 import org.junit.jupiter.api.Test;
@@ -105,14 +106,14 @@ class AgentEventActionsTest
         final AgentEventCapture eventCapture = mock();
         final AgentEventActions actions = createEventActions(eventCapture);
         when(eventCapture.getCapturedEvents("org.bukkit.event.Event"))
-            .thenReturn(List.of(Map.of("isCancelled", "true")));
+            .thenReturn(List.of(Map.of("isCancelled", new IProtocolValue.PBool(true))));
 
         // execute
         final GetCapturedEvents.Response response = actions.handleGetCapturedEvents(
             new GetCapturedEvents.Command("req-5", "org.bukkit.event.Event"));
 
         // verify
-        assertThat(response.events()).containsExactly(Map.of("isCancelled", "true"));
+        assertThat(response.events()).containsExactly(Map.of("isCancelled", new IProtocolValue.PBool(true)));
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventException;
@@ -32,8 +33,10 @@ class AgentEventCaptureTest
     void registerListener_shouldCaptureCancelledEventsIntoRegisteredEventList()
         throws Exception
     {
-        // setup
+        // setup — every Bukkit Event exposes a static getHandlerList(), which the encoder also walks and
+        // eventually drops past MAX_DEPTH, so the logger must be stubbed whenever a real event is captured.
         final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
         final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
         final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
@@ -57,11 +60,12 @@ class AgentEventCaptureTest
         executorCaptor.getValue().execute(mock(Listener.class), new TestCaptureEvent("value", true));
 
         // verify
-        final List<Map<String, String>> events = eventCapture.getCapturedEvents(TestCaptureEvent.class.getName());
+        final List<Map<String, IProtocolValue>> events =
+            eventCapture.getCapturedEvents(TestCaptureEvent.class.getName());
         assertThat(events).hasSize(1);
         assertThat(events.getFirst())
-            .containsEntry("getValue", "value")
-            .containsEntry("isCancelled", "true");
+            .containsEntry("getValue", new IProtocolValue.PString("value"))
+            .containsEntry("isCancelled", new IProtocolValue.PBool(true));
     }
 
     @Test
@@ -94,13 +98,11 @@ class AgentEventCaptureTest
         executorCaptor.getValue().execute(mock(Listener.class), new ThrowingGetterEvent());
 
         // verify — a throwing getter must not be dropped silently; it is recorded as a visible sentinel
-        final List<Map<String, String>> events =
+        final List<Map<String, IProtocolValue>> events =
             eventCapture.getCapturedEvents(ThrowingGetterEvent.class.getName());
         assertThat(events).hasSize(1);
         assertThat(events.getFirst().get("getBroken"))
-            .isNotNull()
-            .contains("capture-failed")
-            .contains("IllegalStateException");
+            .isEqualTo(new IProtocolValue.PDropped("getBroken", "capture-failed: IllegalStateException"));
     }
 
     @Test
@@ -127,8 +129,9 @@ class AgentEventCaptureTest
     void clearCapturedEvents_shouldRemoveCapturedData()
         throws Exception
     {
-        // setup
+        // setup — see the getHandlerList() note above
         final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
         final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
 
@@ -151,8 +154,9 @@ class AgentEventCaptureTest
     void unregisterListener_shouldRemoveCapturedData()
         throws Exception
     {
-        // setup
+        // setup — see the getHandlerList() note above
         final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
         final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
 
@@ -236,11 +240,12 @@ class AgentEventCaptureTest
     }
 
     @Test
-    void captureEventForList_shouldSkipNullAndNonPrintableFieldValues()
+    void captureEventForList_shouldOmitOnlyNullFieldValues()
         throws Exception
     {
-        // setup
+        // setup — see the getHandlerList() note above
         final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
         final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
         final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
@@ -261,14 +266,55 @@ class AgentEventCaptureTest
             eq(false)
         );
 
-        // execute - fire event with string (printable) and list (not printable)
+        // execute - fire event with a string field and a null-valued field
         executorCaptor.getValue().execute(mock(Listener.class), new MixedFieldsEvent("hello", null));
 
-        // verify - only the string field should be captured
-        final List<Map<String, String>> events = eventCapture.getCapturedEvents(MixedFieldsEvent.class.getName());
+        // verify - the string field is captured; the null field is absent (null is data loss, not a marker)
+        final List<Map<String, IProtocolValue>> events =
+            eventCapture.getCapturedEvents(MixedFieldsEvent.class.getName());
         assertThat(events).hasSize(1);
-        assertThat(events.getFirst()).containsKey("getLabel");
+        assertThat(events.getFirst()).containsEntry("getLabel", new IProtocolValue.PString("hello"));
         assertThat(events.getFirst()).doesNotContainKey("getNullValue");
+    }
+
+    @Test
+    void captureEventForList_shouldEncodeNonNullNonPrintableFieldAsPList()
+        throws Exception
+    {
+        // setup — see the getHandlerList() note above
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
+        final PluginManager pluginManager = mock();
+        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            eventCapture.registerListener(MixedFieldsEvent.class.getName());
+        }
+        verify(pluginManager).registerEvent(
+            eq(MixedFieldsEvent.class),
+            any(Listener.class),
+            eq(EventPriority.MONITOR),
+            executorCaptor.capture(),
+            eq(plugin),
+            eq(false)
+        );
+
+        // execute - fire event with a non-null List value, which is no longer silently skipped
+        executorCaptor.getValue().execute(
+            mock(Listener.class), new MixedFieldsEvent("hello", List.of("a", "b")));
+
+        // verify - the list field is now encoded as a PList instead of being dropped
+        final List<Map<String, IProtocolValue>> events =
+            eventCapture.getCapturedEvents(MixedFieldsEvent.class.getName());
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst()).containsEntry(
+            "getNullValue",
+            new IProtocolValue.PList(List.of(new IProtocolValue.PString("a"), new IProtocolValue.PString("b"))));
     }
 
     private static void fireOneTestCaptureEvent(

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
@@ -453,4 +453,126 @@ class ProtocolValueEncoderTest
         public int getP33() { return 33; }
         public int getP34() { return 34; }
     }
+
+    @Test
+    void encodeAccessors_shouldExcludeStaticAccessors()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-static"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+
+        // execute
+        final Map<String, IProtocolValue> encoded =
+            encoder.encodeAccessors(new StaticAccessorFixture(), "ctx");
+
+        // verify - the static accessor must not be walked into the payload
+        assertThat(encoded).containsOnlyKeys("getInstanceValue");
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeEnumConstantsWithClassBodiesAsEnums()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-enum-body"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+
+        // execute
+        final Map<String, IProtocolValue> encoded =
+            encoder.encodeAccessors(new EnumWithBodyFixture(), "ctx");
+
+        // verify - a constant with a body is a synthetic subclass; it must still encode as the declaring enum
+        assertThat(encoded.get("getMode")).isEqualTo(
+            new IProtocolValue.PEnum(BodiedEnum.class.getName(), "SPECIAL"));
+    }
+
+    @Test
+    void encodeAccessors_shouldMarkTruncatedRemainderOfOversizedCollections()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-truncate"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+        final int oversize = ProtocolValueEncoder.MAX_CONTAINER_ELEMENTS + 5;
+
+        // execute
+        final Map<String, IProtocolValue> encoded =
+            encoder.encodeAccessors(new OversizedListFixture(oversize), "ctx");
+
+        // verify - the cap keeps the first MAX elements and reports the omitted remainder loudly
+        assertThat(encoded.get("getEntries")).isInstanceOfSatisfying(IProtocolValue.PList.class, list ->
+        {
+            assertThat(list.values()).hasSize(ProtocolValueEncoder.MAX_CONTAINER_ELEMENTS + 1);
+            assertThat(list.values().getLast()).isEqualTo(
+                new IProtocolValue.PDropped("getEntries", "truncated: 5 more elements"));
+        });
+    }
+
+    /**
+     * Fixture with one instance accessor and one static accessor that must not be encoded.
+     */
+    public static final class StaticAccessorFixture
+    {
+        public String getInstanceValue()
+        {
+            return "instance";
+        }
+
+        public static String getStaticValue()
+        {
+            return "static";
+        }
+    }
+
+    /**
+     * Enum whose constant carries a class body, producing a synthetic subclass at runtime.
+     */
+    public enum BodiedEnum
+    {
+        SPECIAL
+        {
+            @Override
+            public String describe()
+            {
+                return "special";
+            }
+        };
+
+        public String describe()
+        {
+            return "plain";
+        }
+    }
+
+    /**
+     * Fixture exposing an enum-with-body value.
+     */
+    public static final class EnumWithBodyFixture
+    {
+        public BodiedEnum getMode()
+        {
+            return BodiedEnum.SPECIAL;
+        }
+    }
+
+    /**
+     * Fixture exposing a list larger than the container cap.
+     */
+    public static final class OversizedListFixture
+    {
+        private final java.util.List<String> entries;
+
+        OversizedListFixture(int size)
+        {
+            entries = new java.util.ArrayList<>(size);
+            for (int i = 0; i < size; i++)
+                entries.add("entry-" + i);
+        }
+
+        public java.util.List<String> getEntries()
+        {
+            return entries;
+        }
+    }
 }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
@@ -227,20 +227,24 @@ class ProtocolValueEncoderTest
     }
 
     @Test
-    void encodeAccessors_shouldCapAccessorCountAtMaxAccessorsPerObject()
+    void encodeAccessors_shouldCapAccessorCountAndMarkTheOmittedRemainder()
     {
         // setup
-        final ProtocolValueEncoder encoder = createEncoder(mock());
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-accessor-cap"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
 
         // execute
         final Map<String, IProtocolValue> result =
             encoder.encodeAccessors(new AccessorCapFixture(), "ctx");
 
-        // verify — 35 getters are declared; only the first 32 in sorted order survive the cap
-        assertThat(result).hasSize(ProtocolValueEncoder.MAX_ACCESSORS_PER_OBJECT);
+        // verify — 35 getters are declared; the first 32 in sorted order survive, plus a loud marker
+        assertThat(result).hasSize(ProtocolValueEncoder.MAX_ACCESSORS_PER_OBJECT + 1);
         assertThat(result).containsKey("getP00");
         assertThat(result).containsKey("getP31");
         assertThat(result).doesNotContainKey("getP32");
+        assertThat(result.get(ProtocolValueEncoder.TRUNCATED_KEY)).isEqualTo(new IProtocolValue.PDropped(
+            ProtocolValueEncoder.TRUNCATED_KEY, "truncated: 3 more accessors"));
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
@@ -1,0 +1,456 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProtocolValueEncoderTest
+{
+    private static ProtocolValueEncoder createEncoder(JavaPlugin plugin)
+    {
+        return new ProtocolValueEncoder(plugin);
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeStringNumberBooleanUuidAndEnumLeaves()
+    {
+        // setup
+        final UUID id = UUID.fromString("00000000-0000-0000-0000-000000000042");
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new LeafFixture(id), "ctx");
+
+        // verify
+        assertThat(result)
+            .containsEntry("getText", new IProtocolValue.PString("hello"))
+            .containsEntry("getCount", new IProtocolValue.PNumber(5))
+            .containsEntry("getRatio", new IProtocolValue.PNumber(2.5))
+            .containsEntry("isActive", new IProtocolValue.PBool(true))
+            .containsEntry("getId", new IProtocolValue.PUuid(id))
+            .containsEntry("getKind", new IProtocolValue.PEnum(TestEnum.class.getName(), "ALPHA"));
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeEntityAsPRef()
+    {
+        // setup
+        final UUID entityId = UUID.fromString("00000000-0000-0000-0000-000000000043");
+        final Entity entity = mock();
+        when(entity.getUniqueId()).thenReturn(entityId);
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new EntityHolder(entity), "ctx");
+
+        // verify
+        assertThat(result).containsEntry(
+            "getEntity", new IProtocolValue.PRef(entity.getClass().getName(), entityId.toString()));
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeWorldAsPRef()
+    {
+        // setup
+        final World world = mock();
+        when(world.getName()).thenReturn("world_test");
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new WorldHolder(world), "ctx");
+
+        // verify
+        assertThat(result).containsEntry(
+            "getWorld", new IProtocolValue.PRef(world.getClass().getName(), "world_test"));
+    }
+
+    @Test
+    void encodeAccessors_shouldWalkRecordComponents()
+    {
+        // setup
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new TestRecord("hello", 5), "ctx");
+
+        // verify
+        assertThat(result)
+            .containsEntry("name", new IProtocolValue.PString("hello"))
+            .containsEntry("value", new IProtocolValue.PNumber(5));
+    }
+
+    @Test
+    void encodeAccessors_shouldSortAccessorsByNameForDeterministicOutput()
+    {
+        // setup
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new SortingFixture(), "ctx");
+
+        // verify
+        assertThat(result.keySet()).containsExactly("getA", "getB");
+    }
+
+    @Test
+    void encodeAccessors_shouldOmitNullAccessorResults()
+    {
+        // setup
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new NullFieldFixture(), "ctx");
+
+        // verify
+        assertThat(result).doesNotContainKey("getMissing");
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeListAsPList()
+    {
+        // setup
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new CollectionsFixture(), "ctx");
+
+        // verify — a null element is skipped rather than encoded
+        assertThat(result).containsEntry(
+            "getItems",
+            new IProtocolValue.PList(List.of(new IProtocolValue.PString("a"), new IProtocolValue.PString("b"))));
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeArrayAsPList()
+    {
+        // setup
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new CollectionsFixture(), "ctx");
+
+        // verify
+        assertThat(result).containsEntry(
+            "getTags",
+            new IProtocolValue.PList(List.of(new IProtocolValue.PString("x"), new IProtocolValue.PString("y"))));
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeMapAsPRecord()
+    {
+        // setup
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new CollectionsFixture(), "ctx");
+
+        // verify — a null-valued entry is skipped rather than encoded
+        assertThat(result).containsEntry(
+            "getMapping",
+            new IProtocolValue.PRecord(Map.of("k1", new IProtocolValue.PString("v1"))));
+    }
+
+    @Test
+    void encodeAccessors_shouldDropValueBeyondMaxDepth()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-depth"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+
+        // execute — a self-nesting fixture forces the walk past MAX_DEPTH
+        final Map<String, IProtocolValue> level0 = encoder.encodeAccessors(new SelfNestingFixture(), "ctx");
+
+        // verify — drill down through MAX_DEPTH nested records to reach the dropped innermost value
+        IProtocolValue current = java.util.Objects.requireNonNull(level0.get("getChild"));
+        for (int depth = 0; depth < ProtocolValueEncoder.MAX_DEPTH; depth++)
+        {
+            assertThat(current).isInstanceOf(IProtocolValue.PRecord.class);
+            current = java.util.Objects.requireNonNull(
+                ((IProtocolValue.PRecord) current).fields().get("getChild"));
+        }
+        assertThat(current).isInstanceOf(IProtocolValue.PDropped.class);
+        assertThat(((IProtocolValue.PDropped) current).accessorName()).isEqualTo("getChild");
+    }
+
+    @Test
+    void encodeAccessors_shouldDropEmptyNestedObject()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-empty"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+
+        // execute
+        final Map<String, IProtocolValue> result =
+            encoder.encodeAccessors(new HasEmptyFixtureField(), "ctx");
+
+        // verify
+        assertThat(result).containsEntry(
+            "getEmpty", new IProtocolValue.PDropped("getEmpty", EmptyFixture.class.getName()));
+    }
+
+    @Test
+    void encodeAccessors_shouldDropAndCaptureThrowingAccessor()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-throwing"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new ThrowingFixture(), "ctx");
+
+        // verify
+        assertThat(result).containsEntry(
+            "getBroken", new IProtocolValue.PDropped("getBroken", "capture-failed: IllegalStateException"));
+    }
+
+    @Test
+    void encodeAccessors_shouldCapAccessorCountAtMaxAccessorsPerObject()
+    {
+        // setup
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result =
+            encoder.encodeAccessors(new AccessorCapFixture(), "ctx");
+
+        // verify — 35 getters are declared; only the first 32 in sorted order survive the cap
+        assertThat(result).hasSize(ProtocolValueEncoder.MAX_ACCESSORS_PER_OBJECT);
+        assertThat(result).containsKey("getP00");
+        assertThat(result).containsKey("getP31");
+        assertThat(result).doesNotContainKey("getP32");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked") // any(Supplier.class) necessarily returns a raw Supplier match.
+    void encodeAccessors_shouldLogDropWarningOnlyOncePerContextAndAccessor()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final Logger logger = mock();
+        when(plugin.getLogger()).thenReturn(logger);
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+
+        // execute — the same context+accessor pair drops twice across two separate captures
+        encoder.encodeAccessors(new ThrowingFixture(), "same-context");
+        encoder.encodeAccessors(new ThrowingFixture(), "same-context");
+
+        // verify
+        verify(logger, times(1)).log(eq(Level.WARNING), any(Supplier.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixtures
+    // -----------------------------------------------------------------------
+
+    public enum TestEnum
+    {
+        ALPHA,
+        BETA
+    }
+
+    public record TestRecord(String name, int value)
+    {
+    }
+
+    public static final class LeafFixture
+    {
+        private final UUID id;
+
+        public LeafFixture(UUID id)
+        {
+            this.id = id;
+        }
+
+        public String getText()
+        {
+            return "hello";
+        }
+
+        public int getCount()
+        {
+            return 5;
+        }
+
+        public double getRatio()
+        {
+            return 2.5;
+        }
+
+        public boolean isActive()
+        {
+            return true;
+        }
+
+        public UUID getId()
+        {
+            return id;
+        }
+
+        public TestEnum getKind()
+        {
+            return TestEnum.ALPHA;
+        }
+    }
+
+    public static final class EntityHolder
+    {
+        private final Entity entity;
+
+        public EntityHolder(Entity entity)
+        {
+            this.entity = entity;
+        }
+
+        public Entity getEntity()
+        {
+            return entity;
+        }
+    }
+
+    public static final class WorldHolder
+    {
+        private final World world;
+
+        public WorldHolder(World world)
+        {
+            this.world = world;
+        }
+
+        public World getWorld()
+        {
+            return world;
+        }
+    }
+
+    public static final class SortingFixture
+    {
+        public String getB()
+        {
+            return "b-value";
+        }
+
+        public String getA()
+        {
+            return "a-value";
+        }
+    }
+
+    public static final class NullFieldFixture
+    {
+        public @Nullable String getMissing()
+        {
+            return null;
+        }
+    }
+
+    public static final class CollectionsFixture
+    {
+        public List<String> getItems()
+        {
+            return Arrays.asList("a", null, "b");
+        }
+
+        public String[] getTags()
+        {
+            return new String[]{"x", "y"};
+        }
+
+        public Map<String, String> getMapping()
+        {
+            final Map<String, String> mapping = new LinkedHashMap<>();
+            mapping.put("k1", "v1");
+            mapping.put("k2", null);
+            return mapping;
+        }
+    }
+
+    public static final class SelfNestingFixture
+    {
+        public SelfNestingFixture getChild()
+        {
+            return new SelfNestingFixture();
+        }
+    }
+
+    public static final class EmptyFixture
+    {
+    }
+
+    public static final class HasEmptyFixtureField
+    {
+        public EmptyFixture getEmpty()
+        {
+            return new EmptyFixture();
+        }
+    }
+
+    public static final class ThrowingFixture
+    {
+        public String getBroken()
+        {
+            throw new IllegalStateException("boom");
+        }
+    }
+
+    public static final class AccessorCapFixture
+    {
+        public int getP00() { return 0; }
+        public int getP01() { return 1; }
+        public int getP02() { return 2; }
+        public int getP03() { return 3; }
+        public int getP04() { return 4; }
+        public int getP05() { return 5; }
+        public int getP06() { return 6; }
+        public int getP07() { return 7; }
+        public int getP08() { return 8; }
+        public int getP09() { return 9; }
+        public int getP10() { return 10; }
+        public int getP11() { return 11; }
+        public int getP12() { return 12; }
+        public int getP13() { return 13; }
+        public int getP14() { return 14; }
+        public int getP15() { return 15; }
+        public int getP16() { return 16; }
+        public int getP17() { return 17; }
+        public int getP18() { return 18; }
+        public int getP19() { return 19; }
+        public int getP20() { return 20; }
+        public int getP21() { return 21; }
+        public int getP22() { return 22; }
+        public int getP23() { return 23; }
+        public int getP24() { return 24; }
+        public int getP25() { return 25; }
+        public int getP26() { return 26; }
+        public int getP27() { return 27; }
+        public int getP28() { return 28; }
+        public int getP29() { return 29; }
+        public int getP30() { return 30; }
+        public int getP31() { return 31; }
+        public int getP32() { return 32; }
+        public int getP33() { return 33; }
+        public int getP34() { return 34; }
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshot.java
@@ -1,18 +1,64 @@
 package nl.pim16aap2.lightkeeper.framework;
 
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * Snapshot of a captured Bukkit event.
  *
+ * <p>Values arrive as typed {@link IProtocolValue}s: numbers, booleans, UUIDs, and enum constants keep their
+ * types, identifiable objects (entities, worlds) travel as {@link IProtocolValue.PRef references}, nested
+ * objects as {@link IProtocolValue.PRecord records}, and anything the agent could not encode appears as a
+ * {@link IProtocolValue.PDropped} marker instead of being silently absent.
+ *
  * @param eventClassName
  *     The full class name of the event.
- * @param data
- *     The captured event data (getter/is-method results).
+ * @param values
+ *     The captured event values keyed by accessor name (getter/is-method or record component).
  */
 public record CapturedEventSnapshot(
     String eventClassName,
-    Map<String, String> data
+    Map<String, IProtocolValue> values
 )
 {
+    /**
+     * Validates and defensively copies the values, preserving their order.
+     */
+    public CapturedEventSnapshot
+    {
+        values = values == null
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(values));
+    }
+
+    /**
+     * Gets a single captured value by accessor name.
+     *
+     * @param accessorName
+     *     The accessor name, e.g. {@code "getAction"} or {@code "isCancelled"}.
+     * @return The captured value, or {@code null} when the accessor returned null or was not captured.
+     */
+    public @Nullable IProtocolValue value(String accessorName)
+    {
+        return values.get(accessorName);
+    }
+
+    /**
+     * Gets the captured values rendered as display text.
+     *
+     * @return Accessor name to rendered value, in capture order.
+     * @deprecated Use {@link #values()} (typed) or {@link #value(String)} instead; this string view only
+     *     remains so existing tests keep compiling for one release.
+     */
+    @Deprecated(forRemoval = true)
+    public Map<String, String> data()
+    {
+        final Map<String, String> rendered = new LinkedHashMap<>();
+        values.forEach((accessorName, value) -> rendered.put(accessorName, value.toDisplayString()));
+        return Collections.unmodifiableMap(rendered);
+    }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -37,6 +37,7 @@ import nl.pim16aap2.lightkeeper.protocol.MainWorld;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
@@ -354,7 +355,7 @@ final class UdsAgentClient implements AutoCloseable
         send(command);
     }
 
-    List<Map<String, String>> getCapturedEvents(String eventClassName)
+    List<Map<String, IProtocolValue>> getCapturedEvents(String eventClassName)
     {
         final GetCapturedEvents.Command command = new GetCapturedEvents.Command(nextRequestId(), eventClassName);
         return send(command).events();

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshotTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshotTest.java
@@ -1,0 +1,74 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CapturedEventSnapshotTest
+{
+    @Test
+    void value_shouldReturnStoredValueForKnownAccessor()
+    {
+        // setup
+        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot(
+            "org.bukkit.event.player.PlayerJoinEvent",
+            Map.of("isCancelled", new IProtocolValue.PBool(true)));
+
+        // execute
+        final IProtocolValue result = snapshot.value("isCancelled");
+
+        // verify
+        assertThat(result).isEqualTo(new IProtocolValue.PBool(true));
+    }
+
+    @Test
+    void value_shouldReturnNullForUnknownAccessor()
+    {
+        // setup
+        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot(
+            "org.bukkit.event.player.PlayerJoinEvent",
+            Map.of("isCancelled", new IProtocolValue.PBool(true)));
+
+        // execute
+        final IProtocolValue result = snapshot.value("getMissing");
+
+        // verify
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @SuppressWarnings("removal") // Intentionally exercises the deprecated-for-removal data() view.
+    void data_shouldRenderEachValueAsDisplayStringInCaptureOrder()
+    {
+        // setup
+        final Map<String, IProtocolValue> values = new LinkedHashMap<>();
+        values.put("getName", new IProtocolValue.PString("Steve"));
+        values.put("isCancelled", new IProtocolValue.PBool(false));
+        values.put("getCount", new IProtocolValue.PNumber(3));
+        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot("event.Class", values);
+
+        // execute
+        final Map<String, String> rendered = snapshot.data();
+
+        // verify
+        assertThat(rendered).containsExactly(
+            Map.entry("getName", "Steve"),
+            Map.entry("isCancelled", "false"),
+            Map.entry("getCount", "3"));
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void constructor_shouldDefaultToEmptyMapWhenValuesIsNull()
+    {
+        // setup + execute
+        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot("event.Class", null);
+
+        // verify
+        assertThat(snapshot.values()).isEmpty();
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandleTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.framework;
 
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,7 @@ class EventCaptureHandleTest
     {
         // setup
         final List<CapturedEventSnapshot> events = List.of(
-            new CapturedEventSnapshot(EVENT_CLASS_NAME, Map.of("isCancelled", "true"))
+            new CapturedEventSnapshot(EVENT_CLASS_NAME, Map.of("isCancelled", new IProtocolValue.PBool(true)))
         );
         when(frameworkGateway.getCapturedEvents(EVENT_CLASS_NAME)).thenReturn(events);
 

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -5,6 +5,7 @@ import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.ItemSnapshot;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicks;
@@ -368,17 +369,18 @@ class UdsAgentClientTest
         // setup
         final Path socketPath = tempDirectory.resolve("events.sock");
         final String responseJson =
-            "{\"requestId\":\"1\",\"success\":true,\"events\":[{\"player\":\"Steve\"}]}";
+            "{\"requestId\":\"1\",\"success\":true,"
+                + "\"events\":[{\"player\":{\"type\":\"STRING\",\"value\":\"Steve\"}}]}";
         try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final List<Map<String, String>> events =
+            final List<Map<String, IProtocolValue>> events =
                 client.getCapturedEvents("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
             assertThat(events).hasSize(1);
-            assertThat(events.getFirst()).containsEntry("player", "Steve");
+            assertThat(events.getFirst()).containsEntry("player", new IProtocolValue.PString("Steve"));
         }
     }
 

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
@@ -6,6 +6,7 @@ import nl.pim16aap2.lightkeeper.framework.InteractionResult;
 import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -205,7 +206,12 @@ class LightkeeperBotIT
 
             // verify
             assertThat(loadedAfterLoad).isTrue();
-            assertThat(eventCapture.getCapturedEvents()).isNotEmpty();
+            final var capturedEvents = eventCapture.getCapturedEvents();
+            assertThat(capturedEvents).isNotEmpty();
+            // The typed envelope carries the acting player as a reference, not a stringified object.
+            assertThat(capturedEvents.getFirst().value("getPlayer"))
+                .isInstanceOfSatisfying(IProtocolValue.PRef.class, playerRef ->
+                    assertThat(playerRef.id()).isEqualTo(player.uniqueId().toString()));
         }
     }
 }

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetCapturedEvents.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetCapturedEvents.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Returns all captured events of the given class as property-map snapshots.
+ * Returns all captured events of the given class as typed property snapshots.
  */
 public final class GetCapturedEvents
 {
@@ -45,10 +45,11 @@ public final class GetCapturedEvents
      * Response record for {@code GET_CAPTURED_EVENTS}.
      *
      * @param events
-     *     Captured event property snapshots, one map per captured event instance.
+     *     Captured event property snapshots, one map of accessor name to typed {@link IProtocolValue} per
+     *     captured event instance.
      */
     public record Response(
-        List<Map<String, String>> events
+        List<Map<String, IProtocolValue>> events
     ) implements IAgentResponse
     {
         /**

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
@@ -71,7 +71,9 @@ public sealed interface IProtocolValue
      * A numeric value.
      *
      * <p>Integral inputs are normalized to {@link Long} and floating-point inputs to {@link Double}, so equal
-     * numbers compare equal regardless of the boxed type they were encoded or deserialized from.
+     * numbers compare equal regardless of the boxed type they were encoded or deserialized from. Arbitrary
+     * precision types ({@code BigInteger}, {@code BigDecimal}) are coerced to {@code double} and may lose
+     * precision; no supported payload source produces them today.
      *
      * @param value
      *     The number; a {@link Long} for integral values, a {@link Double} for floating-point values.

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
@@ -1,0 +1,272 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Typed wire envelope for structured payload values.
+ *
+ * <p>Every value crossing the agent protocol as part of a structured payload (e.g. captured event fields) is
+ * one of these leaves. The envelope replaces flat string-only payloads: consumers receive real types, nesting
+ * is explicit ({@link PList}, {@link PRecord}), identities travel as references ({@link PRef}), and values the
+ * encoder cannot represent are reported as {@link PDropped} markers instead of being silently skipped.
+ *
+ * <p>Jackson uses the {@code "type"} JSON property to select the correct leaf during deserialization; adding a
+ * leaf requires a new {@link JsonSubTypes.Type} entry and a {@code permits} entry here.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = IProtocolValue.PString.class, name = "STRING"),
+    @JsonSubTypes.Type(value = IProtocolValue.PNumber.class, name = "NUMBER"),
+    @JsonSubTypes.Type(value = IProtocolValue.PBool.class, name = "BOOL"),
+    @JsonSubTypes.Type(value = IProtocolValue.PUuid.class, name = "UUID"),
+    @JsonSubTypes.Type(value = IProtocolValue.PEnum.class, name = "ENUM"),
+    @JsonSubTypes.Type(value = IProtocolValue.PList.class, name = "LIST"),
+    @JsonSubTypes.Type(value = IProtocolValue.PRecord.class, name = "RECORD"),
+    @JsonSubTypes.Type(value = IProtocolValue.PRef.class, name = "REF"),
+    @JsonSubTypes.Type(value = IProtocolValue.PDropped.class, name = "DROPPED"),
+})
+public sealed interface IProtocolValue
+    permits IProtocolValue.PString, IProtocolValue.PNumber, IProtocolValue.PBool, IProtocolValue.PUuid,
+            IProtocolValue.PEnum, IProtocolValue.PList, IProtocolValue.PRecord, IProtocolValue.PRef,
+            IProtocolValue.PDropped
+{
+    /**
+     * Renders this value as human-readable text for assertion messages and diagnostics.
+     *
+     * @return The rendered value.
+     */
+    String toDisplayString();
+
+    /**
+     * A text value.
+     *
+     * @param value
+     *     The text.
+     */
+    record PString(String value) implements IProtocolValue
+    {
+        /**
+         * Validates the value.
+         */
+        public PString
+        {
+            Objects.requireNonNull(value, "value may not be null.");
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return value;
+        }
+    }
+
+    /**
+     * A numeric value.
+     *
+     * <p>Integral inputs are normalized to {@link Long} and floating-point inputs to {@link Double}, so equal
+     * numbers compare equal regardless of the boxed type they were encoded or deserialized from.
+     *
+     * @param value
+     *     The number; a {@link Long} for integral values, a {@link Double} for floating-point values.
+     */
+    record PNumber(Number value) implements IProtocolValue
+    {
+        /**
+         * Validates and normalizes the value.
+         */
+        public PNumber
+        {
+            Objects.requireNonNull(value, "value may not be null.");
+            if (value instanceof Byte || value instanceof Short || value instanceof Integer
+                || value instanceof Long)
+                value = value.longValue();
+            else
+                value = value.doubleValue();
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return String.valueOf(value);
+        }
+    }
+
+    /**
+     * A boolean value.
+     *
+     * @param value
+     *     The boolean.
+     */
+    record PBool(boolean value) implements IProtocolValue
+    {
+        @Override
+        public String toDisplayString()
+        {
+            return String.valueOf(value);
+        }
+    }
+
+    /**
+     * A UUID value.
+     *
+     * @param value
+     *     The UUID.
+     */
+    record PUuid(UUID value) implements IProtocolValue
+    {
+        /**
+         * Validates the value.
+         */
+        public PUuid
+        {
+            Objects.requireNonNull(value, "value may not be null.");
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return value.toString();
+        }
+    }
+
+    /**
+     * An enum constant.
+     *
+     * @param enumClass
+     *     Fully-qualified class name of the enum type.
+     * @param name
+     *     The constant's name.
+     */
+    record PEnum(String enumClass, String name) implements IProtocolValue
+    {
+        /**
+         * Validates the fields.
+         */
+        public PEnum
+        {
+            ProtocolPreconditions.requireNonBlank(enumClass, "enumClass");
+            ProtocolPreconditions.requireNonBlank(name, "name");
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return name;
+        }
+    }
+
+    /**
+     * An ordered list of values.
+     *
+     * @param values
+     *     The list elements.
+     */
+    record PList(List<IProtocolValue> values) implements IProtocolValue
+    {
+        /**
+         * Validates and defensively copies the elements.
+         */
+        public PList
+        {
+            values = values == null ? List.of() : List.copyOf(values);
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return values.stream()
+                .map(IProtocolValue::toDisplayString)
+                .collect(Collectors.joining(", ", "[", "]"));
+        }
+    }
+
+    /**
+     * A nested structured value: named fields, insertion-ordered.
+     *
+     * @param fields
+     *     The field values by name.
+     */
+    record PRecord(Map<String, IProtocolValue> fields) implements IProtocolValue
+    {
+        /**
+         * Validates and defensively copies the fields, preserving their order.
+         */
+        public PRecord
+        {
+            // Map.copyOf would discard iteration order; an unmodifiable LinkedHashMap copy keeps the
+            // encoder's field order observable on the consumer side.
+            fields = fields == null
+                ? Map.of()
+                : java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(fields));
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return fields.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue().toDisplayString())
+                .collect(Collectors.joining(", ", "{", "}"));
+        }
+    }
+
+    /**
+     * A reference to an identifiable object (e.g. an entity by UUID or a world by name) rather than its
+     * contents.
+     *
+     * @param className
+     *     Fully-qualified class name of the referenced object.
+     * @param id
+     *     The reference identity, e.g. an entity UUID or a world name.
+     */
+    record PRef(String className, String id) implements IProtocolValue
+    {
+        /**
+         * Validates the fields.
+         */
+        public PRef
+        {
+            ProtocolPreconditions.requireNonBlank(className, "className");
+            ProtocolPreconditions.requireNonBlank(id, "id");
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return className + "@" + id;
+        }
+    }
+
+    /**
+     * A marker for a value the encoder could not represent — the fail-loud replacement for silently skipping
+     * it. The accessor's presence with this marker tells the consumer exactly what was lost and why.
+     *
+     * @param accessorName
+     *     Name of the accessor whose value was dropped.
+     * @param runtimeType
+     *     The runtime type (or failure description) of the dropped value.
+     */
+    record PDropped(String accessorName, String runtimeType) implements IProtocolValue
+    {
+        /**
+         * Validates the fields.
+         */
+        public PDropped
+        {
+            ProtocolPreconditions.requireNonBlank(accessorName, "accessorName");
+            ProtocolPreconditions.requireNonBlank(runtimeType, "runtimeType");
+        }
+
+        @Override
+        public String toDisplayString()
+        {
+            return "<dropped: %s (%s)>".formatted(accessorName, runtimeType);
+        }
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -57,7 +56,7 @@ public sealed interface IProtocolValue
          */
         public PString
         {
-            Objects.requireNonNull(value, "value may not be null.");
+            ProtocolPreconditions.requireNonNull(value, "value");
         }
 
         @Override
@@ -85,7 +84,7 @@ public sealed interface IProtocolValue
          */
         public PNumber
         {
-            Objects.requireNonNull(value, "value may not be null.");
+            ProtocolPreconditions.requireNonNull(value, "value");
             if (value instanceof Byte || value instanceof Short || value instanceof Integer
                 || value instanceof Long)
                 value = value.longValue();
@@ -128,7 +127,7 @@ public sealed interface IProtocolValue
          */
         public PUuid
         {
-            Objects.requireNonNull(value, "value may not be null.");
+            ProtocolPreconditions.requireNonNull(value, "value");
         }
 
         @Override

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
@@ -163,7 +163,7 @@ class AgentCommandValidationTest
     {
         // execute + verify
         assertThatThrownBy(() -> new IProtocolValue.PString(null))
-            .isInstanceOf(NullPointerException.class)
+            .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("value");
     }
 
@@ -173,7 +173,7 @@ class AgentCommandValidationTest
     {
         // execute + verify
         assertThatThrownBy(() -> new IProtocolValue.PNumber(null))
-            .isInstanceOf(NullPointerException.class)
+            .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("value");
     }
 

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
@@ -153,6 +153,84 @@ class AgentCommandValidationTest
             .hasMessageContaining("result");
     }
 
+    // -----------------------------------------------------------------------
+    // IProtocolValue leaf validation
+    // -----------------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void pStringConstructor_shouldRejectNullValue()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PString(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("value");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void pNumberConstructor_shouldRejectNullValue()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PNumber(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("value");
+    }
+
+    @Test
+    void pEnumConstructor_shouldRejectBlankEnumClass()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PEnum("   ", "ALPHA"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("enumClass");
+    }
+
+    @Test
+    void pEnumConstructor_shouldRejectBlankName()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PEnum("com.example.SomeEnum", "   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("name");
+    }
+
+    @Test
+    void pRefConstructor_shouldRejectBlankClassName()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PRef("   ", "id-1"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("className");
+    }
+
+    @Test
+    void pRefConstructor_shouldRejectBlankId()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PRef("com.example.Thing", "   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("id");
+    }
+
+    @Test
+    void pDroppedConstructor_shouldRejectBlankAccessorName()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PDropped("   ", "capture-failed: Boom"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("accessorName");
+    }
+
+    @Test
+    void pDroppedConstructor_shouldRejectBlankRuntimeType()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new IProtocolValue.PDropped("getBroken", "   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("runtimeType");
+    }
+
     private static Object validDefault(Class<?> type)
     {
         if (type == String.class)

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
@@ -1,0 +1,282 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies Jackson round-trip serialization and polymorphic deserialization for every {@link IProtocolValue} leaf,
+ * nested combinations, {@link IProtocolValue.PNumber} normalization, {@link IProtocolValue.PRecord} field-order
+ * preservation, and a {@link GetCapturedEvents.Response} round-trip carrying a typed event map.
+ */
+class ProtocolValueSerializationTest
+{
+    // -----------------------------------------------------------------------
+    // Round-trip: every leaf
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_pString_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PString original = new IProtocolValue.PString("hello");
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"STRING\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pNumber_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PNumber original = new IProtocolValue.PNumber(42);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"NUMBER\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pBool_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PBool original = new IProtocolValue.PBool(true);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"BOOL\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pUuid_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PUuid original =
+            new IProtocolValue.PUuid(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"UUID\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pEnum_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PEnum original =
+            new IProtocolValue.PEnum("org.bukkit.event.block.Action", "RIGHT_CLICK_BLOCK");
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"ENUM\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pList_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PList original = new IProtocolValue.PList(
+            List.of(new IProtocolValue.PString("a"), new IProtocolValue.PString("b")));
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"LIST\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pRecord_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PRecord original =
+            new IProtocolValue.PRecord(Map.of("label", new IProtocolValue.PString("value")));
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"RECORD\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pRef_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PRef original =
+            new IProtocolValue.PRef("org.bukkit.entity.Player", "00000000-0000-0000-0000-000000000002");
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"REF\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_pDropped_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PDropped original =
+            new IProtocolValue.PDropped("getBroken", "capture-failed: IllegalStateException");
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"DROPPED\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested case: PRecord containing PList containing PString
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_pRecordContainingPListContainingPString_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PRecord original = new IProtocolValue.PRecord(Map.of(
+            "tags",
+            new IProtocolValue.PList(List.of(new IProtocolValue.PString("a"), new IProtocolValue.PString("b")))
+        ));
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(IProtocolValue.PRecord.class);
+        final IProtocolValue.PRecord result = (IProtocolValue.PRecord) deserialized;
+        assertThat(result.fields().get("tags")).isEqualTo(original.fields().get("tags"));
+        assertThat(result).isEqualTo(original);
+    }
+
+    // -----------------------------------------------------------------------
+    // PNumber normalization: equal regardless of the boxed input type
+    // -----------------------------------------------------------------------
+
+    @Test
+    void pNumber_shouldNormalizeIntegralTypesToLong()
+    {
+        // setup + execute
+        final IProtocolValue.PNumber fromInt = new IProtocolValue.PNumber(3);
+        final IProtocolValue.PNumber fromLong = new IProtocolValue.PNumber(3L);
+
+        // verify
+        assertThat(fromInt).isEqualTo(fromLong);
+        assertThat(fromInt.value()).isInstanceOf(Long.class);
+    }
+
+    @Test
+    void pNumber_shouldNormalizeFloatingTypesToDouble()
+    {
+        // setup + execute
+        final IProtocolValue.PNumber fromFloat = new IProtocolValue.PNumber(2.5f);
+        final IProtocolValue.PNumber fromDouble = new IProtocolValue.PNumber(2.5d);
+
+        // verify
+        assertThat(fromFloat).isEqualTo(fromDouble);
+        assertThat(fromFloat.value()).isInstanceOf(Double.class);
+    }
+
+    // -----------------------------------------------------------------------
+    // PRecord field-order preservation, including across a JSON round-trip
+    // -----------------------------------------------------------------------
+
+    @Test
+    void pRecord_shouldPreserveFieldOrderAcrossRoundTrip() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final Map<String, IProtocolValue> fields = new LinkedHashMap<>();
+        fields.put("zeta", new IProtocolValue.PString("z"));
+        fields.put("alpha", new IProtocolValue.PString("a"));
+        fields.put("mid", new IProtocolValue.PString("m"));
+        final IProtocolValue.PRecord original = new IProtocolValue.PRecord(fields);
+
+        // execute
+        assertThat(original.fields().keySet()).containsExactly("zeta", "alpha", "mid");
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(IProtocolValue.PRecord.class);
+        assertThat(((IProtocolValue.PRecord) deserialized).fields().keySet())
+            .containsExactly("zeta", "alpha", "mid");
+    }
+
+    // -----------------------------------------------------------------------
+    // GetCapturedEvents.Response round-trip: the first nested-polymorphic response in the codebase
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_getCapturedEventsResponse_withTypedEventMap_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final Map<String, IProtocolValue> eventValues = new LinkedHashMap<>();
+        eventValues.put("isCancelled", new IProtocolValue.PBool(true));
+        eventValues.put("getDamage", new IProtocolValue.PNumber(4.5));
+        eventValues.put(
+            "getPlayer",
+            new IProtocolValue.PRef("org.bukkit.entity.Player", "00000000-0000-0000-0000-000000000003"));
+        eventValues.put(
+            "getDrops",
+            new IProtocolValue.PList(List.of(new IProtocolValue.PString("minecraft:stone"))));
+        final GetCapturedEvents.Response original = new GetCapturedEvents.Response(List.of(eventValues));
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final GetCapturedEvents.Response result = mapper.readValue(json, GetCapturedEvents.Response.class);
+
+        // verify
+        assertThat(result.events()).hasSize(1);
+        assertThat(result.events().getFirst()).containsExactlyEntriesOf(eventValues);
+        assertThat(result).isEqualTo(original);
+    }
+}

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -20,7 +20,7 @@ public final class RuntimeProtocol
      * in a backward-incompatible way. Both the framework and the agent must agree on this value;
      * a mismatch causes an {@code HANDSHAKE} failure.
      */
-    public static final int VERSION = 5;
+    public static final int VERSION = 6;
 
     /**
      * Minecraft server version supported by this LightKeeper build.


### PR DESCRIPTION
## Why
- Completes roadmap slice S2 (D5, with the capability handshake withdrawn by amendment): flat string-only payloads are the shared disease behind the LK-2/5/6 asks — funded once here so later commands ride the same envelope.
- The old event capture silently skipped every non-printable getter (the bug class that cost a whole research pass to discover); silent data loss is now designed out (D7).

## How
- **`IProtocolValue`** (protocol v6): sealed envelope with typed leaves — `PString/PNumber/PBool/PUuid/PEnum`, nesting via `PList/PRecord` (field order preserved), identities as `PRef` (entities by UUID, worlds by name), and `PDropped` as the fail-loud marker for anything unencodable. First nested-polymorphic wire type in the codebase; `PNumber` normalizes integral→Long / floating→Double so equal numbers compare equal.
- **`ProtocolValueEncoder`** (agent): generic reflective encoder — records walk their components (record-style accessor names are no longer invisible), other objects walk sorted non-static `get*/is*` accessors (32/object cap), depth-capped at 3, containers capped at 128 elements with a loud truncation marker; every drop WARNs once per accessor. Nulls stay absent: an absent value is data, not data loss.
- **Event capture** rides the envelope end-to-end: `CapturedEventSnapshot` exposes typed `values()`/`value(name)` with the old string map kept one release as a deprecated `data()` view.
- BotIT proves it live: the captured `PlayerTeleportEvent`'s `getPlayer` arrives as a `PRef` with the acting bot's UUID.

## Tests
- `mvn -Perrorprone clean install checkstyle:checkstyle pmd:check`: BUILD SUCCESS, 0 violations; ~490 unit tests incl. new per-leaf round-trips (plus the first nested-polymorphic `Response` round-trip), encoder suite (depth cap, accessor cap, sorting, PRef, warn-once), and regression tests for static-accessor exclusion, enum-with-body constants, and container truncation.
- `mvn clean verify -pl lightkeeper-integration-tests`: 28/28 on both Paper and Spigot lanes.
- Pre-PR deep review (Opus agent, verified against the real spigot-api jar): MERGE-WITH-FIXES — both MAJORs (static `getHandlerList()` payload bloat, enum-with-body missing the `PEnum` leaf) fixed with regression tests in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Captured event data now preserves typed values, including numbers, booleans, UUIDs, enums, collections, nested records, and entity/world references.
  * Unsupported, failed, or truncated values are explicitly shown as `DROPPED` markers instead of being silently omitted.
  * Added access to individual typed event values while retaining a deprecated string-rendering view.

* **Documentation**
  * Updated feature documentation to describe typed event payloads and dropped-value markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->