### PR TITLE
feat: event capture v2 — tick stamps, cancelNext(n), and bot chat (S4, protocol v8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ class MyPluginIT
 - Typed event payloads: captured events carry real types (numbers, booleans, UUIDs, enums, entity/world
   references, nested records) — values the agent cannot encode appear as explicit `DROPPED` markers instead
   of being silently absent
+- Bot chat and deterministic cancellation: `player.chat("...")` fires the real chat event;
+  `capture.cancelNext(n)` cancels exactly the next N events of a captured class (LOWEST priority, so the
+  capture still records the final cancelled state); captured events carry the server tick they fired on
 - Block state as a first-class value: place blocks with full state via
   `world.setBlockAt(pos, BlockSpec.parse("minecraft:lever[face=floor,powered=true]"))` and assert partially
   via `world.blockAt(pos).is(BlockSpec.parse("minecraft:lever[powered=true]"))` — only named properties

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
@@ -1,13 +1,12 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
+import nl.pim16aap2.lightkeeper.protocol.CancelNextEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
-import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListener;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -74,8 +73,30 @@ final class AgentEventActions
     GetCapturedEvents.Response handleGetCapturedEvents(GetCapturedEvents.Command command)
     {
         final String eventClassName = command.eventClassName();
-        final List<Map<String, IProtocolValue>> events = eventCapture.getCapturedEvents(eventClassName);
+        final List<GetCapturedEvents.CapturedEvent> events = eventCapture.getCapturedEvents(eventClassName);
         return new GetCapturedEvents.Response(events);
+    }
+
+    /**
+     * Handles {@code CANCEL_NEXT_EVENTS} by arming a LOWEST-priority listener that cancels the next N fired
+     * events of the class.
+     *
+     * @param command
+     *     Typed cancel-next-events command.
+     * @return
+     *     Success response, or {@code INVALID_ARGUMENT} when the class is unknown or not Cancellable.
+     */
+    CancelNextEvents.Response handleCancelNextEvents(CancelNextEvents.Command command)
+    {
+        try
+        {
+            eventCapture.cancelNextEvents(command.eventClassName(), command.count());
+        }
+        catch (ClassNotFoundException exception)
+        {
+            throw new IllegalArgumentException("Event class not found: " + command.eventClassName(), exception);
+        }
+        return new CancelNextEvents.Response();
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActions.java
@@ -96,6 +96,14 @@ final class AgentEventActions
         {
             throw new IllegalArgumentException("Event class not found: " + command.eventClassName(), exception);
         }
+        catch (IllegalStateException exception)
+        {
+            // Re-arming while a cancellation is active is caller error, not a server failure: surface it as
+            // INVALID_ARGUMENT instead of REQUEST_FAILED + a SEVERE log the error capture would pick up.
+            throw new IllegalArgumentException(
+                Objects.requireNonNullElse(exception.getMessage(), exception.getClass().getName()),
+                exception);
+        }
         return new CancelNextEvents.Response();
     }
 

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
-import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 
@@ -47,13 +49,23 @@ final class AgentEventCapture
      */
     private final ProtocolValueEncoder protocolValueEncoder;
     /**
+     * Shared monotonic server-tick counter, read (thread-safely) at capture time to stamp events.
+     */
+    private final AtomicLong tickCounter;
+    /**
      * Captured event payloads keyed by fully qualified event class name.
      */
-    private final Map<String, List<Map<String, IProtocolValue>>> capturedEvents = new ConcurrentHashMap<>();
+    private final Map<String, List<GetCapturedEvents.CapturedEvent>> capturedEvents = new ConcurrentHashMap<>();
     /**
      * Active marker listeners keyed by fully qualified event class name.
      */
     private final Map<String, Listener> activeListeners = new ConcurrentHashMap<>();
+    /**
+     * Active cancel-next marker listeners keyed by fully qualified event class name. Kept separate from the
+     * MONITOR capture listeners: cancellation acts at LOWEST priority so the capture listener observes the
+     * final cancelled state.
+     */
+    private final Map<String, CancelNextState> cancelListeners = new ConcurrentHashMap<>();
     /**
      * Event class names whose capture cap has already been warned about, so hitting the cap is reported once
      * rather than silently discarding every subsequent event.
@@ -66,10 +78,11 @@ final class AgentEventCapture
      * @param mainThreadExecutor
      *     Main-thread executor used to route Bukkit listener (un)registration onto the server thread.
      */
-    AgentEventCapture(JavaPlugin plugin, AgentMainThreadExecutor mainThreadExecutor)
+    AgentEventCapture(JavaPlugin plugin, AgentMainThreadExecutor mainThreadExecutor, AtomicLong tickCounter)
     {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.mainThreadExecutor = Objects.requireNonNull(mainThreadExecutor, "mainThreadExecutor");
+        this.tickCounter = Objects.requireNonNull(tickCounter, "tickCounter");
         this.protocolValueEncoder = new ProtocolValueEncoder(plugin);
     }
 
@@ -100,7 +113,7 @@ final class AgentEventCapture
                 throw new IllegalArgumentException("Class '%s' is not a Bukkit Event.".formatted(eventClassName));
 
             final Class<? extends Event> eventClass = resolvedClass.asSubclass(Event.class);
-            final List<Map<String, IProtocolValue>> events =
+            final List<GetCapturedEvents.CapturedEvent> events =
                 capturedEvents.computeIfAbsent(eventClassName, ignored -> new CopyOnWriteArrayList<>());
 
             mainThreadExecutor.callOnMainThread(() ->
@@ -219,9 +232,9 @@ final class AgentEventCapture
      * @return
      *     Snapshot list of captured event payloads, or an empty list when nothing has been captured.
      */
-    List<Map<String, IProtocolValue>> getCapturedEvents(String eventClassName)
+    List<GetCapturedEvents.CapturedEvent> getCapturedEvents(String eventClassName)
     {
-        final List<Map<String, IProtocolValue>> events = capturedEvents.get(eventClassName);
+        final List<GetCapturedEvents.CapturedEvent> events = capturedEvents.get(eventClassName);
         if (events == null)
             throw new IllegalArgumentException(
                 ("No capture listener is registered for event class '%s'; register it before querying captured "
@@ -238,7 +251,7 @@ final class AgentEventCapture
      */
     void clearCapturedEvents(String eventClassName)
     {
-        final List<Map<String, IProtocolValue>> events = capturedEvents.get(eventClassName);
+        final List<GetCapturedEvents.CapturedEvent> events = capturedEvents.get(eventClassName);
         if (events == null)
             throw new IllegalArgumentException(
                 "No capture listener is registered for event class '%s'; register it before clearing events."
@@ -246,7 +259,7 @@ final class AgentEventCapture
         events.clear();
     }
 
-    private void captureEventForList(Event event, List<Map<String, IProtocolValue>> targetList)
+    private void captureEventForList(Event event, List<GetCapturedEvents.CapturedEvent> targetList)
     {
         if (targetList.size() >= MAX_CAPTURED_EVENTS_PER_CLASS)
         {
@@ -258,6 +271,97 @@ final class AgentEventCapture
             return;
         }
 
-        targetList.add(protocolValueEncoder.encodeAccessors(event, event.getClass().getName()));
+        targetList.add(new GetCapturedEvents.CapturedEvent(
+            tickCounter.get(),
+            protocolValueEncoder.encodeAccessors(event, event.getClass().getName())));
+    }
+
+    /**
+     * Arms cancellation of the next {@code count} fired events of the class via a LOWEST-priority listener,
+     * so regular plugin listeners (and the MONITOR capture listener) observe the cancelled state.
+     *
+     * <p>One armed cancellation per event class at a time; arming again while one is active throws. The
+     * listener unregisters itself (on the next tick) once its count is exhausted.
+     *
+     * @param eventClassName
+     *     Fully qualified Bukkit event class; must implement {@code Cancellable}.
+     * @param count
+     *     How many upcoming events to cancel.
+     * @throws ClassNotFoundException
+     *     When the class cannot be resolved by any reachable class loader.
+     */
+    void cancelNextEvents(String eventClassName, int count)
+        throws ClassNotFoundException
+    {
+        final Class<?> resolvedClass = resolveEventClass(eventClassName);
+        if (!Event.class.isAssignableFrom(resolvedClass))
+            throw new IllegalArgumentException("Class '%s' is not a Bukkit Event.".formatted(eventClassName));
+        if (!org.bukkit.event.Cancellable.class.isAssignableFrom(resolvedClass))
+            throw new IllegalArgumentException(
+                "Class '%s' is not Cancellable; cancelNext cannot apply.".formatted(eventClassName));
+
+        final CancelNextState state = new CancelNextState(new Listener() {}, new AtomicInteger(count));
+        final CancelNextState previous = cancelListeners.putIfAbsent(eventClassName, state);
+        if (previous != null)
+            throw new IllegalStateException(
+                "A cancelNext for '%s' is already armed with %d remaining."
+                    .formatted(eventClassName, previous.remaining().get()));
+
+        boolean registered = false;
+        try
+        {
+            final Class<? extends Event> eventClass = resolvedClass.asSubclass(Event.class);
+            mainThreadExecutor.callOnMainThread(() ->
+            {
+                Bukkit.getPluginManager().registerEvent(
+                    eventClass,
+                    state.marker(),
+                    EventPriority.LOWEST,
+                    (listenerInstance, event) -> cancelEvent(eventClassName, state, event),
+                    plugin,
+                    false
+                );
+                return Boolean.TRUE;
+            });
+            registered = true;
+        }
+        catch (ClassNotFoundException | RuntimeException exception)
+        {
+            throw exception;
+        }
+        catch (Exception exception)
+        {
+            throw new IllegalStateException(
+                "Failed to register the cancelNext listener for '%s' on the main thread."
+                    .formatted(eventClassName), exception);
+        }
+        finally
+        {
+            if (!registered)
+                cancelListeners.remove(eventClassName, state);
+        }
+    }
+
+    private void cancelEvent(String eventClassName, CancelNextState state, Event event)
+    {
+        final int before = state.remaining().getAndDecrement();
+        if (before <= 0)
+            return;
+        if (event instanceof org.bukkit.event.Cancellable cancellable)
+            cancellable.setCancelled(true);
+        if (before == 1)
+        {
+            // Exhausted: detach on the next tick (unregistering mid-dispatch from inside the handler is
+            // avoided deliberately), and drop the bookkeeping so a new cancelNext can be armed.
+            cancelListeners.remove(eventClassName, state);
+            Bukkit.getScheduler().runTask(plugin, () -> HandlerList.unregisterAll(state.marker()));
+        }
+    }
+
+    /**
+     * Bookkeeping for one armed cancellation: its marker listener and the remaining cancel budget.
+     */
+    private record CancelNextState(Listener marker, AtomicInteger remaining)
+    {
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
@@ -206,7 +206,12 @@ final class AgentEventCapture
         // cancel listener would silently cancel later tests' events on the shared server.
         final CancelNextState armedCancellation = cancelListeners.remove(eventClassName);
         if (armedCancellation != null)
+        {
+            // Zero the budget immediately: the marker stays registered until the scheduled unregister runs,
+            // and events fired in that window must not be cancelled after close() promised a disarm.
+            armedCancellation.remaining().set(0);
             Bukkit.getScheduler().runTask(plugin, () -> HandlerList.unregisterAll(armedCancellation.marker()));
+        }
         if (listener == null)
             return;
 

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCapture.java
@@ -202,6 +202,11 @@ final class AgentEventCapture
     {
         final Listener listener = activeListeners.remove(eventClassName);
         capturedEvents.remove(eventClassName);
+        // Closing a capture also disarms any pending cancellation for the class: a leftover LOWEST-priority
+        // cancel listener would silently cancel later tests' events on the shared server.
+        final CancelNextState armedCancellation = cancelListeners.remove(eventClassName);
+        if (armedCancellation != null)
+            Bukkit.getScheduler().runTask(plugin, () -> HandlerList.unregisterAll(armedCancellation.marker()));
         if (listener == null)
             return;
 

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.lightkeeper.protocol.HasPlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.LeftClickBlock;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
+import nl.pim16aap2.lightkeeper.protocol.PlayerChat;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
 import nl.pim16aap2.lightkeeper.protocol.TeleportPlayer;
@@ -345,6 +346,34 @@ final class AgentPlayerActions
         );
 
         return new HasPlayerPermission.Response(value);
+    }
+
+    /**
+     * Handles {@code PLAYER_CHAT} by making the player say a chat message on the main thread.
+     *
+     * <p>A plugin-triggered {@code Player#chat} fires the chat event synchronously, so routing through the
+     * main thread satisfies Bukkit's sync-event threading rule.
+     *
+     * @param command
+     *     Typed command carrying player UUID and message.
+     * @return Response when the chat has been dispatched.
+     *
+     * @throws Exception
+     *     Propagates validation and main-thread execution failures.
+     */
+    PlayerChat.Response handlePlayerChat(PlayerChat.Command command)
+        throws Exception
+    {
+        final UUID uuid = command.uuid();
+        final String message = command.message();
+
+        mainThreadExecutor.callOnMainThread(() ->
+        {
+            playerStore.getRequiredPlayer(uuid).chat(message);
+            return Boolean.TRUE;
+        });
+
+        return new PlayerChat.Response();
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -5,6 +5,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.exc.ValueInstantiationException;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
+import nl.pim16aap2.lightkeeper.protocol.CancelNextEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.ClickMenuSlot;
@@ -34,6 +35,7 @@ import nl.pim16aap2.lightkeeper.protocol.MainWorld;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
+import nl.pim16aap2.lightkeeper.protocol.PlayerChat;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
@@ -275,6 +277,8 @@ final class AgentRequestDispatcher
                 case ClearServerErrors.Command c -> handle(c, serverErrorActions::handleClearServerErrors);
                 case MutatePlayerPermission.Command c -> handle(c, playerActions::handleMutatePlayerPermission);
                 case HasPlayerPermission.Command c -> handle(c, playerActions::handleHasPlayerPermission);
+                case CancelNextEvents.Command c -> handle(c, eventActions::handleCancelNextEvents);
+                case PlayerChat.Command c -> handle(c, playerActions::handlePlayerChat);
                 case Handshake.Command ignored ->
                     throw new IllegalStateException("Unreachable HANDSHAKE dispatch branch.");
             };

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -133,10 +133,11 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 mainThreadExecutor,
                 playerStore
             );
+            final AtomicLong tickCounter = new AtomicLong(0L);
             final AgentWorldActions worldActions = new AgentWorldActions(
                 this,
                 mainThreadExecutor,
-                new AtomicLong(0L)
+                tickCounter
             );
             final AgentPlayerActions playerActions = new AgentPlayerActions(
                 this,
@@ -150,7 +151,7 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
                 objectMapper,
                 botPlayerNmsAdapter
             );
-            final AgentEventCapture eventCapture = new AgentEventCapture(this, mainThreadExecutor);
+            final AgentEventCapture eventCapture = new AgentEventCapture(this, mainThreadExecutor, tickCounter);
             final AgentEventActions eventActions = new AgentEventActions(eventCapture);
 
             final AgentServerErrorCapture errorCapture = serverErrorCapture;

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
+import nl.pim16aap2.lightkeeper.protocol.CancelNextEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
@@ -105,15 +106,51 @@ class AgentEventActionsTest
         // setup
         final AgentEventCapture eventCapture = mock();
         final AgentEventActions actions = createEventActions(eventCapture);
+        final GetCapturedEvents.CapturedEvent capturedEvent = new GetCapturedEvents.CapturedEvent(
+            3L, Map.of("isCancelled", new IProtocolValue.PBool(true)));
         when(eventCapture.getCapturedEvents("org.bukkit.event.Event"))
-            .thenReturn(List.of(Map.of("isCancelled", new IProtocolValue.PBool(true))));
+            .thenReturn(List.of(capturedEvent));
 
         // execute
         final GetCapturedEvents.Response response = actions.handleGetCapturedEvents(
             new GetCapturedEvents.Command("req-5", "org.bukkit.event.Event"));
 
         // verify
-        assertThat(response.events()).containsExactly(Map.of("isCancelled", new IProtocolValue.PBool(true)));
+        assertThat(response.events()).containsExactly(capturedEvent);
+    }
+
+    @Test
+    void handleCancelNextEvents_shouldSucceedAndDelegateToEventCapture()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+
+        // execute
+        final CancelNextEvents.Response response = actions.handleCancelNextEvents(
+            new CancelNextEvents.Command("req-cancel", "org.bukkit.event.Event", 2));
+
+        // verify
+        assertThat(response).isNotNull();
+        verify(eventCapture).cancelNextEvents("org.bukkit.event.Event", 2);
+    }
+
+    @Test
+    void handleCancelNextEvents_shouldThrowWhenClassIsNotFound()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock();
+        final AgentEventActions actions = createEventActions(eventCapture);
+        org.mockito.Mockito.doThrow(new ClassNotFoundException("com.example.NonExistent"))
+            .when(eventCapture).cancelNextEvents("com.example.NonExistent", 1);
+
+        // execute + verify
+        assertThatThrownBy(() -> actions.handleCancelNextEvents(
+            new CancelNextEvents.Command("req-cancel-cnf", "com.example.NonExistent", 1)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Event class not found: com.example.NonExistent");
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventActionsTest.java
@@ -12,7 +12,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -134,6 +136,26 @@ class AgentEventActionsTest
         // verify
         assertThat(response).isNotNull();
         verify(eventCapture).cancelNextEvents("org.bukkit.event.Event", 2);
+    }
+
+    @Test
+    void handleCancelNextEvents_shouldMapRearmToInvalidArgument()
+        throws Exception
+    {
+        // setup
+        final AgentEventCapture eventCapture = mock(AgentEventCapture.class);
+        doThrow(new IllegalStateException("already armed"))
+            .when(eventCapture).cancelNextEvents("org.example.Evt", 2);
+        final AgentEventActions eventActions = new AgentEventActions(eventCapture);
+        final CancelNextEvents.Command command = new CancelNextEvents.Command("req-1", "org.example.Evt", 2);
+
+        // execute
+        final Throwable thrown = catchThrowable(() -> eventActions.handleCancelNextEvents(command));
+
+        // verify - caller error surfaces as IllegalArgumentException (INVALID_ARGUMENT), not a server failure
+        assertThat(thrown)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("already armed");
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
@@ -1,7 +1,9 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import org.bukkit.Bukkit;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventException;
 import org.bukkit.event.EventPriority;
@@ -11,12 +13,13 @@ import org.bukkit.plugin.EventExecutor;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -24,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,7 +42,8 @@ class AgentEventCaptureTest
         final JavaPlugin plugin = mock();
         when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
         final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
 
         // execute
@@ -60,10 +65,10 @@ class AgentEventCaptureTest
         executorCaptor.getValue().execute(mock(Listener.class), new TestCaptureEvent("value", true));
 
         // verify
-        final List<Map<String, IProtocolValue>> events =
+        final List<GetCapturedEvents.CapturedEvent> events =
             eventCapture.getCapturedEvents(TestCaptureEvent.class.getName());
         assertThat(events).hasSize(1);
-        assertThat(events.getFirst())
+        assertThat(events.getFirst().values())
             .containsEntry("getValue", new IProtocolValue.PString("value"))
             .containsEntry("isCancelled", new IProtocolValue.PBool(true));
     }
@@ -76,7 +81,8 @@ class AgentEventCaptureTest
         final JavaPlugin plugin = mock();
         when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
         final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
 
         // execute
@@ -98,10 +104,10 @@ class AgentEventCaptureTest
         executorCaptor.getValue().execute(mock(Listener.class), new ThrowingGetterEvent());
 
         // verify — a throwing getter must not be dropped silently; it is recorded as a visible sentinel
-        final List<Map<String, IProtocolValue>> events =
+        final List<GetCapturedEvents.CapturedEvent> events =
             eventCapture.getCapturedEvents(ThrowingGetterEvent.class.getName());
         assertThat(events).hasSize(1);
-        assertThat(events.getFirst().get("getBroken"))
+        assertThat(events.getFirst().values().get("getBroken"))
             .isEqualTo(new IProtocolValue.PDropped("getBroken", "capture-failed: IllegalStateException"));
     }
 
@@ -110,7 +116,8 @@ class AgentEventCaptureTest
     {
         // setup
         final JavaPlugin plugin = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
         final PluginManager pluginManager = mock();
 
         // execute + verify
@@ -133,7 +140,8 @@ class AgentEventCaptureTest
         final JavaPlugin plugin = mock();
         when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
 
         try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
         {
@@ -158,7 +166,8 @@ class AgentEventCaptureTest
         final JavaPlugin plugin = mock();
         when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
 
         try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
         {
@@ -183,7 +192,8 @@ class AgentEventCaptureTest
         // setup
         final JavaPlugin plugin = mock();
         final PluginManager pluginManager = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
 
         try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
         {
@@ -212,7 +222,8 @@ class AgentEventCaptureTest
     {
         // setup
         final JavaPlugin plugin = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
 
         // execute + verify — a typo'd/unregistered class must fail rather than masquerade as "no events fired"
         assertThatThrownBy(() -> eventCapture.getCapturedEvents("com.example.NonExistentEvent"))
@@ -225,7 +236,8 @@ class AgentEventCaptureTest
     {
         // setup
         final JavaPlugin plugin = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
         final PluginManager pluginManager = mock();
 
         // execute + verify
@@ -240,6 +252,152 @@ class AgentEventCaptureTest
     }
 
     @Test
+    void registerListener_shouldStampCapturedEventWithCurrentTick()
+        throws Exception
+    {
+        // setup — see the getHandlerList() note above
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
+        final PluginManager pluginManager = mock();
+        final AtomicLong tickCounter = new AtomicLong(42L);
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), tickCounter);
+        final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            eventCapture.registerListener(TestCaptureEvent.class.getName());
+        }
+        verify(pluginManager).registerEvent(
+            eq(TestCaptureEvent.class),
+            any(Listener.class),
+            eq(EventPriority.MONITOR),
+            executorCaptor.capture(),
+            eq(plugin),
+            eq(false)
+        );
+
+        // execute
+        executorCaptor.getValue().execute(mock(Listener.class), new TestCaptureEvent("value", false));
+
+        // verify
+        final List<GetCapturedEvents.CapturedEvent> events =
+            eventCapture.getCapturedEvents(TestCaptureEvent.class.getName());
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst().tick()).isEqualTo(42L);
+    }
+
+    @Test
+    void cancelNextEvents_shouldCancelUpToBudgetThenScheduleUnregisterOnExhaustion()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final PluginManager pluginManager = mock();
+        final BukkitScheduler scheduler = mock();
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
+        final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            bukkitMockedStatic.when(Bukkit::getScheduler).thenReturn(scheduler);
+
+            // execute
+            eventCapture.cancelNextEvents(CancellableTestEvent.class.getName(), 2);
+
+            verify(pluginManager).registerEvent(
+                eq(CancellableTestEvent.class),
+                any(Listener.class),
+                eq(EventPriority.LOWEST),
+                executorCaptor.capture(),
+                eq(plugin),
+                eq(false)
+            );
+
+            final EventExecutor executor = executorCaptor.getValue();
+            final CancellableTestEvent first = mock(CancellableTestEvent.class);
+            final CancellableTestEvent second = mock(CancellableTestEvent.class);
+            final CancellableTestEvent third = mock(CancellableTestEvent.class);
+
+            executor.execute(mock(Listener.class), first);
+            executor.execute(mock(Listener.class), second);
+            executor.execute(mock(Listener.class), third);
+
+            // verify — the budget of 2 cancels the first two events; the third (count+1) is left alone, and
+            // exhaustion schedules the marker listener's removal via the Bukkit scheduler
+            verify(first).setCancelled(true);
+            verify(second).setCancelled(true);
+            verify(third, never()).setCancelled(true);
+            verify(scheduler).runTask(eq(plugin), any(Runnable.class));
+        }
+    }
+
+    @Test
+    void cancelNextEvents_shouldThrowExceptionWhenClassIsNotCancellable()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
+
+        // execute + verify
+        assertThatThrownBy(() -> eventCapture.cancelNextEvents(TestCaptureEvent.class.getName(), 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("not Cancellable");
+    }
+
+    @Test
+    void cancelNextEvents_shouldThrowExceptionWhenClassIsNotFound()
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
+        final PluginManager pluginManager = mock();
+
+        // execute + verify
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            assertThatThrownBy(() -> eventCapture.cancelNextEvents("com.example.NonExistentEvent", 1))
+                .isInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    @Test
+    void cancelNextEvents_shouldThrowIllegalStateExceptionWhenAlreadyArmed()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        final PluginManager pluginManager = mock();
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
+
+        // execute + verify
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            eventCapture.cancelNextEvents(CancellableTestEvent.class.getName(), 1);
+
+            assertThatThrownBy(() -> eventCapture.cancelNextEvents(CancellableTestEvent.class.getName(), 1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already armed");
+        }
+    }
+
+    @Test
     void captureEventForList_shouldOmitOnlyNullFieldValues()
         throws Exception
     {
@@ -247,7 +405,8 @@ class AgentEventCaptureTest
         final JavaPlugin plugin = mock();
         when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
         final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
 
         try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
@@ -270,11 +429,11 @@ class AgentEventCaptureTest
         executorCaptor.getValue().execute(mock(Listener.class), new MixedFieldsEvent("hello", null));
 
         // verify - the string field is captured; the null field is absent (null is data loss, not a marker)
-        final List<Map<String, IProtocolValue>> events =
+        final List<GetCapturedEvents.CapturedEvent> events =
             eventCapture.getCapturedEvents(MixedFieldsEvent.class.getName());
         assertThat(events).hasSize(1);
-        assertThat(events.getFirst()).containsEntry("getLabel", new IProtocolValue.PString("hello"));
-        assertThat(events.getFirst()).doesNotContainKey("getNullValue");
+        assertThat(events.getFirst().values()).containsEntry("getLabel", new IProtocolValue.PString("hello"));
+        assertThat(events.getFirst().values()).doesNotContainKey("getNullValue");
     }
 
     @Test
@@ -285,7 +444,8 @@ class AgentEventCaptureTest
         final JavaPlugin plugin = mock();
         when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test"));
         final PluginManager pluginManager = mock();
-        final AgentEventCapture eventCapture = new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin));
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
         final ArgumentCaptor<EventExecutor> executorCaptor = ArgumentCaptor.forClass(EventExecutor.class);
 
         try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
@@ -309,10 +469,10 @@ class AgentEventCaptureTest
             mock(Listener.class), new MixedFieldsEvent("hello", List.of("a", "b")));
 
         // verify - the list field is now encoded as a PList instead of being dropped
-        final List<Map<String, IProtocolValue>> events =
+        final List<GetCapturedEvents.CapturedEvent> events =
             eventCapture.getCapturedEvents(MixedFieldsEvent.class.getName());
         assertThat(events).hasSize(1);
-        assertThat(events.getFirst()).containsEntry(
+        assertThat(events.getFirst().values()).containsEntry(
             "getNullValue",
             new IProtocolValue.PList(List.of(new IProtocolValue.PString("a"), new IProtocolValue.PString("b"))));
     }
@@ -332,6 +492,36 @@ class AgentEventCaptureTest
             eq(false)
         );
         executorCaptor.getValue().execute(mock(Listener.class), new TestCaptureEvent("value", false));
+    }
+
+    public static class CancellableTestEvent extends Event implements Cancellable
+    {
+        private static final HandlerList HANDLERS = new HandlerList();
+        private boolean cancelled;
+
+        @Override
+        public boolean isCancelled()
+        {
+            return cancelled;
+        }
+
+        @Override
+        public void setCancelled(boolean cancel)
+        {
+            this.cancelled = cancel;
+        }
+
+        @Override
+        public HandlerList getHandlers()
+        {
+            return HANDLERS;
+        }
+
+        @SuppressWarnings("unused")
+        public static HandlerList getHandlerList()
+        {
+            return HANDLERS;
+        }
     }
 
     public static final class TestCaptureEvent extends Event

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentEventCaptureTest.java
@@ -621,4 +621,35 @@ class AgentEventCaptureTest
             return HANDLERS;
         }
     }
+
+    @Test
+    void unregisterListener_shouldDisarmPendingCancellation()
+        throws Exception
+    {
+        // setup
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(java.util.logging.Logger.getLogger("test-close-disarm"));
+        final PluginManager pluginManager = mock();
+        final org.bukkit.scheduler.BukkitScheduler scheduler = mock();
+        final AgentEventCapture eventCapture =
+            new AgentEventCapture(plugin, new AgentMainThreadExecutor(plugin), new AtomicLong(0L));
+
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class);
+             MockedStatic<HandlerList> handlerListMockedStatic = mockStatic(HandlerList.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            when(pluginManager.getPlugins()).thenReturn(new Plugin[0]);
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            bukkitMockedStatic.when(Bukkit::getScheduler).thenReturn(scheduler);
+            eventCapture.registerListener(CancellableTestEvent.class.getName());
+            eventCapture.cancelNextEvents(CancellableTestEvent.class.getName(), 5);
+
+            // execute - closing the capture must also disarm the unexhausted cancellation
+            eventCapture.unregisterListener(CancellableTestEvent.class.getName());
+
+            // verify - the disarm schedules the cancel marker's unregistration and frees the class for re-arm
+            verify(scheduler, org.mockito.Mockito.times(1)).runTask(eq(plugin), any(Runnable.class));
+            eventCapture.cancelNextEvents(CancellableTestEvent.class.getName(), 1);
+        }
+    }
 }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
@@ -13,6 +13,7 @@ import nl.pim16aap2.lightkeeper.protocol.HasPlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.LeftClickBlock;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
+import nl.pim16aap2.lightkeeper.protocol.PlayerChat;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
 import nl.pim16aap2.lightkeeper.protocol.TeleportPlayer;
 import org.bukkit.Bukkit;
@@ -576,6 +577,48 @@ class AgentPlayerActionsTest
         // is dropped and removePermissionAttachment finds nothing to detach.
         fixture.playerStore().removePermissionAttachment(uuid, player);
         verify(player).removeAttachment(attachment);
+    }
+
+    @Test
+    void handlePlayerChat_shouldInvokePlayerChatOnMainThread()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        final PlayerChat.Command command = new PlayerChat.Command("request-chat", uuid, "hello world");
+
+        // execute
+        final PlayerChat.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            response = fixture.playerActions().handlePlayerChat(command);
+        }
+
+        // verify
+        assertThat(response).isNotNull();
+        verify(player).chat("hello world");
+    }
+
+    @Test
+    void handlePlayerChat_shouldPropagateWhenPlayerUnknown()
+    {
+        // setup
+        final AgentPlayerActions playerActions = createPlayerActions();
+        final PlayerChat.Command command =
+            new PlayerChat.Command("request-chat-unknown", UUID.randomUUID(), "hello");
+
+        // execute + verify
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            assertThatThrownBy(() -> playerActions.handlePlayerChat(command))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not registered");
+        }
     }
 
     private static AgentPlayerActions createPlayerActions()

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
 import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import nl.pim16aap2.lightkeeper.protocol.AgentProtocolMapper;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
+import nl.pim16aap2.lightkeeper.protocol.CancelNextEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.ClickMenuSlot;
@@ -35,6 +36,7 @@ import nl.pim16aap2.lightkeeper.protocol.MainWorld;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
+import nl.pim16aap2.lightkeeper.protocol.PlayerChat;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
@@ -368,6 +370,10 @@ class AgentRequestDispatcherTest
             .thenReturn(new MutatePlayerPermission.Response());
         when(fixture.playerActions().handleHasPlayerPermission(any(HasPlayerPermission.Command.class)))
             .thenReturn(new HasPlayerPermission.Response(true));
+        when(fixture.eventActions().handleCancelNextEvents(any(CancelNextEvents.Command.class)))
+            .thenReturn(new CancelNextEvents.Response());
+        when(fixture.playerActions().handlePlayerChat(any(PlayerChat.Command.class)))
+            .thenReturn(new PlayerChat.Response());
 
         // execute
         dispatchExpectingSuccess(fixture, toJson(new NewWorld.Command("request-1", "w", "NORMAL", "NORMAL", 0L)));
@@ -403,6 +409,9 @@ class AgentRequestDispatcherTest
         dispatchExpectingSuccess(fixture, toJson(new MutatePlayerPermission.Command(
             "request-31", uuid, "test.perm", MutatePlayerPermission.Mode.GRANT)));
         dispatchExpectingSuccess(fixture, toJson(new HasPlayerPermission.Command("request-32", uuid, "test.perm")));
+        dispatchExpectingSuccess(fixture, toJson(new CancelNextEvents.Command(
+            "request-33", "org.bukkit.event.player.PlayerJoinEvent", 1)));
+        dispatchExpectingSuccess(fixture, toJson(new PlayerChat.Command("request-34", uuid, "hello")));
 
         // verify
         verify(fixture.worldActions()).handleNewWorld(any(NewWorld.Command.class));
@@ -437,6 +446,8 @@ class AgentRequestDispatcherTest
         verify(fixture.serverErrorActions()).handleClearServerErrors(any(ClearServerErrors.Command.class));
         verify(fixture.playerActions()).handleMutatePlayerPermission(any(MutatePlayerPermission.Command.class));
         verify(fixture.playerActions()).handleHasPlayerPermission(any(HasPlayerPermission.Command.class));
+        verify(fixture.eventActions()).handleCancelNextEvents(any(CancelNextEvents.Command.class));
+        verify(fixture.playerActions()).handlePlayerChat(any(PlayerChat.Command.class));
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshot.java
@@ -17,11 +17,15 @@ import java.util.Map;
  *
  * @param eventClassName
  *     The full class name of the event.
+ * @param tick
+ *     The server tick the event fired on, for correlating events with each other and with
+ *     {@code ILightkeeperFramework#currentServerTick()}.
  * @param values
  *     The captured event values keyed by accessor name (getter/is-method or record component).
  */
 public record CapturedEventSnapshot(
     String eventClassName,
+    long tick,
     Map<String, IProtocolValue> values
 )
 {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandle.java
@@ -34,6 +34,10 @@ public final class EventCaptureHandle implements AutoCloseable
      * MONITOR listener — observe the cancelled state. Deterministic only: exactly the next {@code count}
      * events are cancelled, with no predicate filtering. The event class must implement {@code Cancellable}.
      *
+     * <p>Only one cancellation may be armed per event class at a time; arming again while one is active
+     * fails. Closing this handle disarms any remaining budget, so unexhausted cancellations never leak into
+     * later tests on a shared server.
+     *
      * @param count
      *     How many upcoming events to cancel; must be positive.
      * @return This handle for fluent chaining.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandle.java
@@ -28,6 +28,23 @@ public final class EventCaptureHandle implements AutoCloseable
     }
 
     /**
+     * Arms cancellation of the next {@code count} fired events of this capture's class.
+     *
+     * <p>The agent registers a LOWEST-priority listener, so regular plugin listeners — and this capture's
+     * MONITOR listener — observe the cancelled state. Deterministic only: exactly the next {@code count}
+     * events are cancelled, with no predicate filtering. The event class must implement {@code Cancellable}.
+     *
+     * @param count
+     *     How many upcoming events to cancel; must be positive.
+     * @return This handle for fluent chaining.
+     */
+    public EventCaptureHandle cancelNext(int count)
+    {
+        frameworkGateway.cancelNextEvents(eventClassName, count);
+        return this;
+    }
+
+    /**
      * Clears all captured events for this session.
      *
      * @return This handle for fluent chaining.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -175,6 +175,21 @@ public interface IFrameworkGatewayView
     void unregisterEventListener(String eventClassName);
 
     /**
+     * Arms cancellation of the next N fired events of a class (LOWEST-priority listener).
+     */
+    void cancelNextEvents(String eventClassName, int count);
+
+    /**
+     * Makes a synthetic player say a chat message, firing the real chat event.
+     */
+    void playerChat(UUID playerId, String message);
+
+    /**
+     * Gets the server's current tick.
+     */
+    long currentServerTick();
+
+    /**
      * Gets all captured server errors: structured log events plus raw stderr stack-trace detections.
      */
     List<ServerErrorSnapshot> capturedServerErrors();

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
@@ -206,6 +206,13 @@ public interface ILightkeeperFramework extends AutoCloseable
     EventCaptureHandle captureEvents(String eventClassName);
 
     /**
+     * Gets the server's current tick, for correlating against {@link CapturedEventSnapshot#tick()} stamps.
+     *
+     * @return The monotonic server tick.
+     */
+    long currentServerTick();
+
+    /**
      * Gets a handle over the always-on server-error capture.
      *
      * <p>The agent captures every WARN-or-worse log event inside the server as a structured snapshot — with the

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/ILightkeeperFramework.java
@@ -206,9 +206,13 @@ public interface ILightkeeperFramework extends AutoCloseable
     EventCaptureHandle captureEvents(String eventClassName);
 
     /**
-     * Gets the server's current tick, for correlating against {@link CapturedEventSnapshot#tick()} stamps.
+     * Gets the agent's monotonic tick counter, for correlating against {@link CapturedEventSnapshot#tick()}
+     * stamps.
      *
-     * @return The monotonic server tick.
+     * <p>This is an agent-relative counter (ticks since the agent enabled), not the server's absolute game
+     * tick: it resets on every server start, so values are only comparable within one server session.
+     *
+     * @return The monotonic, session-relative server tick.
      */
     long currentServerTick();
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerHandle.java
@@ -292,6 +292,20 @@ public final class PlayerHandle
     }
 
     /**
+     * Makes this player say a chat message, firing the real chat event (synchronously, as with any
+     * plugin-triggered chat).
+     *
+     * @param message
+     *     The chat message.
+     * @return This handle for fluent chaining.
+     */
+    public PlayerHandle chat(String message)
+    {
+        frameworkGateway.playerChat(uniqueId, message);
+        return this;
+    }
+
+    /**
      * Gets the permission control handle for this player.
      *
      * <p>Mutations apply to LightKeeper's own permission attachment and bypass permission plugins; see

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -578,10 +578,11 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     {
         ensureOpen();
         Objects.requireNonNull(playerId, "playerId may not be null.");
-        final String trimmedMessage = Objects.requireNonNull(message, "message may not be null.").trim();
-        if (trimmedMessage.isEmpty())
+        Objects.requireNonNull(message, "message may not be null.");
+        if (message.isBlank())
             throw new IllegalArgumentException("message may not be blank.");
-        agentClient.playerChat(playerId, trimmedMessage);
+        // Deliberately NOT trimmed: intentional whitespace must reach the fired chat event unchanged.
+        agentClient.playerChat(playerId, message);
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -559,8 +559,36 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     {
         ensureOpen();
         return agentClient.getCapturedEvents(eventClassName).stream()
-            .map(data -> new CapturedEventSnapshot(eventClassName, data))
+            .map(event -> new CapturedEventSnapshot(eventClassName, event.tick(), event.values()))
             .toList();
+    }
+
+    @Override
+    public void cancelNextEvents(String eventClassName, int count)
+    {
+        ensureOpen();
+        Objects.requireNonNull(eventClassName, "eventClassName may not be null.");
+        if (count <= 0)
+            throw new IllegalArgumentException("count must be positive.");
+        agentClient.cancelNextEvents(eventClassName, count);
+    }
+
+    @Override
+    public void playerChat(UUID playerId, String message)
+    {
+        ensureOpen();
+        Objects.requireNonNull(playerId, "playerId may not be null.");
+        final String trimmedMessage = Objects.requireNonNull(message, "message may not be null.").trim();
+        if (trimmedMessage.isEmpty())
+            throw new IllegalArgumentException("message may not be blank.");
+        agentClient.playerChat(playerId, trimmedMessage);
+    }
+
+    @Override
+    public long currentServerTick()
+    {
+        ensureOpen();
+        return agentClient.getServerTick();
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.lightkeeper.framework.MenuSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
+import nl.pim16aap2.lightkeeper.protocol.CancelNextEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.ClickMenuSlot;
@@ -37,7 +38,7 @@ import nl.pim16aap2.lightkeeper.protocol.MainWorld;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
-import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import nl.pim16aap2.lightkeeper.protocol.PlayerChat;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
@@ -54,7 +55,6 @@ import tools.jackson.databind.ObjectMapper;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -384,10 +384,23 @@ final class UdsAgentClient implements AutoCloseable
         send(command);
     }
 
-    List<Map<String, IProtocolValue>> getCapturedEvents(String eventClassName)
+    List<GetCapturedEvents.CapturedEvent> getCapturedEvents(String eventClassName)
     {
         final GetCapturedEvents.Command command = new GetCapturedEvents.Command(nextRequestId(), eventClassName);
         return send(command).events();
+    }
+
+    void cancelNextEvents(String eventClassName, int count)
+    {
+        final CancelNextEvents.Command command =
+            new CancelNextEvents.Command(nextRequestId(), eventClassName, count);
+        send(command);
+    }
+
+    void playerChat(UUID uuid, String message)
+    {
+        final PlayerChat.Command command = new PlayerChat.Command(nextRequestId(), uuid, message);
+        send(command);
     }
 
     void clearCapturedEvents(String eventClassName)

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshotTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/CapturedEventSnapshotTest.java
@@ -16,6 +16,7 @@ class CapturedEventSnapshotTest
         // setup
         final CapturedEventSnapshot snapshot = new CapturedEventSnapshot(
             "org.bukkit.event.player.PlayerJoinEvent",
+            1L,
             Map.of("isCancelled", new IProtocolValue.PBool(true)));
 
         // execute
@@ -31,6 +32,7 @@ class CapturedEventSnapshotTest
         // setup
         final CapturedEventSnapshot snapshot = new CapturedEventSnapshot(
             "org.bukkit.event.player.PlayerJoinEvent",
+            1L,
             Map.of("isCancelled", new IProtocolValue.PBool(true)));
 
         // execute
@@ -49,7 +51,7 @@ class CapturedEventSnapshotTest
         values.put("getName", new IProtocolValue.PString("Steve"));
         values.put("isCancelled", new IProtocolValue.PBool(false));
         values.put("getCount", new IProtocolValue.PNumber(3));
-        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot("event.Class", values);
+        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot("event.Class", 1L, values);
 
         // execute
         final Map<String, String> rendered = snapshot.data();
@@ -66,7 +68,7 @@ class CapturedEventSnapshotTest
     void constructor_shouldDefaultToEmptyMapWhenValuesIsNull()
     {
         // setup + execute
-        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot("event.Class", null);
+        final CapturedEventSnapshot snapshot = new CapturedEventSnapshot("event.Class", 1L, null);
 
         // verify
         assertThat(snapshot.values()).isEmpty();

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EventCaptureHandleTest.java
@@ -31,7 +31,7 @@ class EventCaptureHandleTest
     {
         // setup
         final List<CapturedEventSnapshot> events = List.of(
-            new CapturedEventSnapshot(EVENT_CLASS_NAME, Map.of("isCancelled", new IProtocolValue.PBool(true)))
+            new CapturedEventSnapshot(EVENT_CLASS_NAME, 1L, Map.of("isCancelled", new IProtocolValue.PBool(true)))
         );
         when(frameworkGateway.getCapturedEvents(EVENT_CLASS_NAME)).thenReturn(events);
 
@@ -41,6 +41,17 @@ class EventCaptureHandleTest
         // verify
         assertThat(result).isSameAs(events);
         verify(frameworkGateway).getCapturedEvents(EVENT_CLASS_NAME);
+    }
+
+    @Test
+    void cancelNext_shouldDelegateToGatewayWithClassNameAndReturnSelf()
+    {
+        // execute
+        final EventCaptureHandle result = eventCaptureHandle.cancelNext(3);
+
+        // verify
+        assertThat(result).isSameAs(eventCaptureHandle);
+        verify(frameworkGateway).cancelNextEvents(EVENT_CLASS_NAME, 3);
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/PlayerHandleTest.java
@@ -97,6 +97,17 @@ class PlayerHandleTest
     }
 
     @Test
+    void chat_shouldDelegateToGatewayAndReturnSelf()
+    {
+        // execute
+        final PlayerHandle result = playerHandle.chat("hello world");
+
+        // verify
+        assertThat(result).isSameAs(playerHandle);
+        verify(frameworkGateway).playerChat(PLAYER_UUID, "hello world");
+    }
+
+    @Test
     void permissions_shouldReturnNonNullPermissionControl()
     {
         // execute

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
@@ -546,23 +546,23 @@ class DefaultLightkeeperFrameworkGatewayTest
     }
 
     @Test
-    void playerChat_shouldDelegateToAgentClientWithTrimmedMessage()
+    void playerChat_shouldDelegateToAgentClientPreservingWhitespace()
     {
         // setup
         final UdsAgentClient agentClient = mock(UdsAgentClient.class);
-        final UUID playerId = UUID.randomUUID();
         final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
             runtimeManifest(),
             mock(MinecraftServerProcess.class),
             agentClient,
             new PlayerScopeRegistry()
         );
+        final java.util.UUID playerId = java.util.UUID.randomUUID();
 
         // execute
-        framework.playerChat(playerId, "  hello world  ");
+        framework.playerChat(playerId, "  spaced message  ");
 
-        // verify
-        verify(agentClient).playerChat(playerId, "hello world");
+        // verify - intentional whitespace reaches the agent unchanged
+        verify(agentClient).playerChat(playerId, "  spaced message  ");
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
@@ -1,15 +1,19 @@
 package nl.pim16aap2.lightkeeper.framework.internal;
 
 import nl.pim16aap2.lightkeeper.framework.BlockPos;
+import nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -503,6 +507,126 @@ class DefaultLightkeeperFrameworkGatewayTest
         // execute + verify
         assertThatThrownBy(() -> framework.setBlockData("world", position, null))
             .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void cancelNextEvents_shouldDelegateToAgentClient()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        framework.cancelNextEvents("org.bukkit.event.player.PlayerJoinEvent", 3);
+
+        // verify
+        verify(agentClient).cancelNextEvents("org.bukkit.event.player.PlayerJoinEvent", 3);
+    }
+
+    @Test
+    void cancelNextEvents_shouldThrowExceptionWhenCountIsNotPositive()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            mock(UdsAgentClient.class),
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.cancelNextEvents("org.bukkit.event.player.PlayerJoinEvent", 0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("positive");
+    }
+
+    @Test
+    void playerChat_shouldDelegateToAgentClientWithTrimmedMessage()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final UUID playerId = UUID.randomUUID();
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        framework.playerChat(playerId, "  hello world  ");
+
+        // verify
+        verify(agentClient).playerChat(playerId, "hello world");
+    }
+
+    @Test
+    void playerChat_shouldThrowExceptionWhenMessageIsBlank()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            mock(UdsAgentClient.class),
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.playerChat(UUID.randomUUID(), "   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("blank");
+    }
+
+    @Test
+    void currentServerTick_shouldReturnValueFromAgentClient()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        when(agentClient.getServerTick()).thenReturn(123L);
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final long result = framework.currentServerTick();
+
+        // verify
+        assertThat(result).isEqualTo(123L);
+    }
+
+    @Test
+    void getCapturedEvents_shouldMapTickIntoSnapshot()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final Map<String, IProtocolValue> values = Map.of("isCancelled", new IProtocolValue.PBool(true));
+        final GetCapturedEvents.CapturedEvent capturedEvent = new GetCapturedEvents.CapturedEvent(9L, values);
+        when(agentClient.getCapturedEvents("org.bukkit.event.player.PlayerJoinEvent"))
+            .thenReturn(List.of(capturedEvent));
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final List<CapturedEventSnapshot> result =
+            framework.getCapturedEvents("org.bukkit.event.player.PlayerJoinEvent");
+
+        // verify
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().eventClassName()).isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
+        assertThat(result.getFirst().tick()).isEqualTo(9L);
+        assertThat(result.getFirst().values()).isEqualTo(values);
     }
 
     private static RuntimeManifest runtimeManifest()

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -5,6 +5,7 @@ import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
+import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.ItemSnapshot;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
@@ -25,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -370,17 +370,59 @@ class UdsAgentClientTest
         final Path socketPath = tempDirectory.resolve("events.sock");
         final String responseJson =
             "{\"requestId\":\"1\",\"success\":true,"
-                + "\"events\":[{\"player\":{\"type\":\"STRING\",\"value\":\"Steve\"}}]}";
+                + "\"events\":[{\"tick\":7,\"values\":{\"player\":{\"type\":\"STRING\",\"value\":\"Steve\"}}}]}";
         try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            final List<Map<String, IProtocolValue>> events =
+            final List<GetCapturedEvents.CapturedEvent> events =
                 client.getCapturedEvents("org.bukkit.event.player.PlayerJoinEvent");
 
             // verify
             assertThat(events).hasSize(1);
-            assertThat(events.getFirst()).containsEntry("player", new IProtocolValue.PString("Steve"));
+            assertThat(events.getFirst().tick()).isEqualTo(7L);
+            assertThat(events.getFirst().values()).containsEntry("player", new IProtocolValue.PString("Steve"));
+        }
+    }
+
+    @Test
+    void cancelNextEvents_shouldSendCancelRequest(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("cancel-next-events.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.cancelNextEvents("org.bukkit.event.player.PlayerJoinEvent", 3);
+
+            // verify
+            assertThat(server.capturedRequest())
+                .contains("\"action\":\"CANCEL_NEXT_EVENTS\"")
+                .contains("PlayerJoinEvent")
+                .contains("\"count\":3");
+        }
+    }
+
+    @Test
+    void playerChat_shouldSendChatRequest(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("player-chat.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.playerChat(PLAYER_ID, "hello world");
+
+            // verify
+            assertThat(server.capturedRequest())
+                .contains("\"action\":\"PLAYER_CHAT\"")
+                .contains("\"message\":\"hello world\"");
         }
     }
 

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperChatAndCancelIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperChatAndCancelIT.java
@@ -1,0 +1,70 @@
+package nl.pim16aap2.lightkeeper.maven.test;
+
+import nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot;
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
+import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.eventually;
+
+@ExtendWith(LightkeeperExtension.class)
+class LightkeeperChatAndCancelIT
+{
+    private static final String CHAT_EVENT = "org.bukkit.event.player.AsyncPlayerChatEvent";
+
+    @Test
+    void chat_shouldFireCapturedChatEventWithTickStamp(ILightkeeperFramework framework)
+        throws Exception
+    {
+        // setup
+        final var world = framework.mainWorld();
+        final var player = framework.createPlayer("lkchat001", world);
+        final long tickBefore = framework.currentServerTick();
+
+        try (var chatCapture = framework.captureEvents(CHAT_EVENT))
+        {
+            // execute
+            player.chat("hello lightkeeper");
+            eventually(Duration.ofSeconds(10), () ->
+                assertThat(chatCapture.getCapturedEvents()).isNotEmpty());
+
+            // verify
+            final CapturedEventSnapshot chatEvent = chatCapture.getCapturedEvents().getFirst();
+            assertThat(chatEvent.value("getMessage"))
+                .isEqualTo(new IProtocolValue.PString("hello lightkeeper"));
+            assertThat(chatEvent.tick()).isGreaterThanOrEqualTo(tickBefore);
+            assertThat(framework.currentServerTick()).isGreaterThanOrEqualTo(chatEvent.tick());
+        }
+    }
+
+    @Test
+    void cancelNext_shouldCancelExactlyTheNextChatEvent(ILightkeeperFramework framework)
+        throws Exception
+    {
+        // setup
+        final var world = framework.mainWorld();
+        final var player = framework.createPlayer("lkchat002", world);
+
+        try (var chatCapture = framework.captureEvents(CHAT_EVENT))
+        {
+            // execute
+            chatCapture.cancelNext(1);
+            player.chat("this one is cancelled");
+            player.chat("this one goes through");
+            eventually(Duration.ofSeconds(10), () ->
+                assertThat(chatCapture.getCapturedEvents()).hasSize(2));
+
+            // verify — the MONITOR capture observes the final cancelled state set at LOWEST priority
+            final var events = chatCapture.getCapturedEvents();
+            assertThat(events.get(0).value("isCancelled"))
+                .isEqualTo(new IProtocolValue.PBool(true));
+            assertThat(events.get(1).value("isCancelled"))
+                .isEqualTo(new IProtocolValue.PBool(false));
+        }
+    }
+}

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperChatAndCancelIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperChatAndCancelIT.java
@@ -67,4 +67,23 @@ class LightkeeperChatAndCancelIT
                 .isEqualTo(new IProtocolValue.PBool(false));
         }
     }
+
+    @Test
+    void cancelNext_shouldRejectNonCancellableEventClassWithTypedError(ILightkeeperFramework framework)
+        throws Exception
+    {
+        // setup — PlayerJoinEvent does not implement Cancellable, so arming must fail loudly
+        try (var joinCapture = framework.captureEvents("org.bukkit.event.player.PlayerJoinEvent"))
+        {
+            // execute
+            final Throwable thrown =
+                nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.catchThrowable(
+                    () -> joinCapture.cancelNext(1));
+
+            // verify
+            assertThat(thrown)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("INVALID_ARGUMENT");
+        }
+    }
 }

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/CancelNextEvents.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/CancelNextEvents.java
@@ -1,0 +1,56 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+/**
+ * Arms deterministic cancellation of the next N fired events of a class.
+ */
+public final class CancelNextEvents
+{
+    private CancelNextEvents()
+    {
+    }
+
+    /**
+     * Command record for {@code CANCEL_NEXT_EVENTS}.
+     *
+     * <p>The agent registers a LOWEST-priority listener (so it acts before regular plugin listeners) that
+     * cancels the next {@code count} fired events of the class; the MONITOR-priority capture listener still
+     * observes every event with its final cancelled state.
+     *
+     * @param requestId
+     *     Correlation identifier matching the response's {@code requestId}.
+     * @param eventClassName
+     *     Fully-qualified class name of the Bukkit event to cancel; must implement {@code Cancellable}.
+     * @param count
+     *     How many upcoming events to cancel; must be positive.
+     */
+    public record Command(
+        String requestId,
+        String eventClassName,
+        int count
+    ) implements IAgentCommand<Response>
+    {
+        /**
+         * Validates command inputs.
+         */
+        public Command
+        {
+            ProtocolPreconditions.requireNonBlank(requestId, "requestId");
+            ProtocolPreconditions.requireNonBlank(eventClassName, "eventClassName");
+            if (count <= 0)
+                throw new IllegalArgumentException("'count' must be positive.");
+        }
+
+        @Override
+        public Class<Response> responseType()
+        {
+            return Response.class;
+        }
+    }
+
+    /**
+     * Response record for {@code CANCEL_NEXT_EVENTS}.
+     */
+    public record Response() implements IAgentResponse
+    {
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetCapturedEvents.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetCapturedEvents.java
@@ -42,14 +42,37 @@ public final class GetCapturedEvents
     }
 
     /**
+     * A single captured event instance: its typed property values plus the server tick it fired on.
+     *
+     * @param tick
+     *     The server tick at capture time.
+     * @param values
+     *     Accessor name to typed value, in encoding order.
+     */
+    public record CapturedEvent(
+        long tick,
+        Map<String, IProtocolValue> values
+    )
+    {
+        /**
+         * Validates and defensively copies the values, preserving their order.
+         */
+        public CapturedEvent
+        {
+            values = values == null
+                ? Map.of()
+                : java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(values));
+        }
+    }
+
+    /**
      * Response record for {@code GET_CAPTURED_EVENTS}.
      *
      * @param events
-     *     Captured event property snapshots, one map of accessor name to typed {@link IProtocolValue} per
-     *     captured event instance.
+     *     Captured event instances, oldest first.
      */
     public record Response(
-        List<Map<String, IProtocolValue>> events
+        List<CapturedEvent> events
     ) implements IAgentResponse
     {
         /**

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
@@ -55,6 +55,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = ClearServerErrors.Command.class, name = "CLEAR_SERVER_ERRORS"),
     @JsonSubTypes.Type(value = MutatePlayerPermission.Command.class, name = "MUTATE_PLAYER_PERMISSION"),
     @JsonSubTypes.Type(value = HasPlayerPermission.Command.class, name = "HAS_PLAYER_PERMISSION"),
+    @JsonSubTypes.Type(value = CancelNextEvents.Command.class, name = "CANCEL_NEXT_EVENTS"),
+    @JsonSubTypes.Type(value = PlayerChat.Command.class, name = "PLAYER_CHAT"),
 })
 public sealed interface IAgentCommand<R extends IAgentResponse>
     permits Handshake.Command, MainWorld.Command, NewWorld.Command, ExecuteCommand.Command,
@@ -68,7 +70,8 @@ public sealed interface IAgentCommand<R extends IAgentResponse>
             ClearCapturedEvents.Command, UnregisterEventListener.Command,
             GetPlayerChatComponents.Command, GetServerPlatform.Command,
             GetServerErrors.Command, ClearServerErrors.Command,
-            MutatePlayerPermission.Command, HasPlayerPermission.Command
+            MutatePlayerPermission.Command, HasPlayerPermission.Command,
+            CancelNextEvents.Command, PlayerChat.Command
 {
     /**
      * Correlation identifier matching the response's {@code requestId}.

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
@@ -14,6 +14,7 @@ package nl.pim16aap2.lightkeeper.protocol;
 public sealed interface IAgentResponse
     permits
     BlockType.Response,
+    CancelNextEvents.Response,
     ClearCapturedEvents.Response,
     ClearServerErrors.Response,
     ClickMenuSlot.Response,
@@ -39,6 +40,7 @@ public sealed interface IAgentResponse
     MutatePlayerPermission.Response,
     NewWorld.Response,
     PlacePlayerBlock.Response,
+    PlayerChat.Response,
     RegisterEventListener.Response,
     RemovePlayer.Response,
     RightClickBlock.Response,

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/PlayerChat.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/PlayerChat.java
@@ -1,0 +1,53 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import java.util.UUID;
+
+/**
+ * Makes a synthetic player say a chat message, firing the real chat event.
+ */
+public final class PlayerChat
+{
+    private PlayerChat()
+    {
+    }
+
+    /**
+     * Command record for {@code PLAYER_CHAT}.
+     *
+     * @param requestId
+     *     Correlation identifier matching the response's {@code requestId}.
+     * @param uuid
+     *     Unique identifier of the chatting player.
+     * @param message
+     *     The chat message.
+     */
+    public record Command(
+        String requestId,
+        UUID uuid,
+        String message
+    ) implements IAgentCommand<Response>
+    {
+        /**
+         * Validates command inputs.
+         */
+        public Command
+        {
+            ProtocolPreconditions.requireNonBlank(requestId, "requestId");
+            ProtocolPreconditions.requireNonNull(uuid, "uuid");
+            ProtocolPreconditions.requireNonBlank(message, "message");
+        }
+
+        @Override
+        public Class<Response> responseType()
+        {
+            return Response.class;
+        }
+    }
+
+    /**
+     * Response record for {@code PLAYER_CHAT}.
+     */
+    public record Response() implements IAgentResponse
+    {
+    }
+}

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
@@ -271,6 +271,90 @@ class AgentCommandSerializationTest
     }
 
     // -----------------------------------------------------------------------
+    // Round-trip: CancelNextEvents.Command
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_cancelNextEventsCommand_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final CancelNextEvents.Command original = new CancelNextEvents.Command(
+            "req-15", "org.bukkit.event.player.PlayerMoveEvent", 3);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        @SuppressWarnings("rawtypes")
+        final IAgentCommand deserialized = mapper.readValue(json, IAgentCommand.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(CancelNextEvents.Command.class);
+        final CancelNextEvents.Command result = (CancelNextEvents.Command) deserialized;
+        assertThat(result.requestId()).isEqualTo("req-15");
+        assertThat(result.eventClassName()).isEqualTo("org.bukkit.event.player.PlayerMoveEvent");
+        assertThat(result.count()).isEqualTo(3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip: PlayerChat.Command
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_playerChatCommand_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000009");
+        final PlayerChat.Command original = new PlayerChat.Command("req-16", uuid, "hello world");
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        @SuppressWarnings("rawtypes")
+        final IAgentCommand deserialized = mapper.readValue(json, IAgentCommand.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(PlayerChat.Command.class);
+        final PlayerChat.Command result = (PlayerChat.Command) deserialized;
+        assertThat(result.requestId()).isEqualTo("req-16");
+        assertThat(result.uuid()).isEqualTo(uuid);
+        assertThat(result.message()).isEqualTo("hello world");
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip: CancelNextEvents.Response / PlayerChat.Response (empty records)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_cancelNextEventsResponse_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final CancelNextEvents.Response original = new CancelNextEvents.Response();
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final CancelNextEvents.Response result = mapper.readValue(json, CancelNextEvents.Response.class);
+
+        // verify
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    void serialize_playerChatResponse_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final PlayerChat.Response original = new PlayerChat.Response();
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final PlayerChat.Response result = mapper.readValue(json, PlayerChat.Response.class);
+
+        // verify
+        assertThat(result).isEqualTo(original);
+    }
+
+    // -----------------------------------------------------------------------
     // Deserialization from raw JSON: discriminator field selects subtype
     // -----------------------------------------------------------------------
 

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
@@ -153,6 +153,79 @@ class AgentCommandValidationTest
             .hasMessageContaining("result");
     }
 
+    @Test
+    void cancelNextEventsCommand_shouldRejectBlankRequestId()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new CancelNextEvents.Command(
+            "   ", "org.bukkit.event.player.PlayerMoveEvent", 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("requestId");
+    }
+
+    @Test
+    void cancelNextEventsCommand_shouldRejectBlankEventClassName()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new CancelNextEvents.Command("request-1", "   ", 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("eventClassName");
+    }
+
+    @Test
+    void cancelNextEventsCommand_shouldRejectZeroCount()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new CancelNextEvents.Command(
+            "request-1", "org.bukkit.event.player.PlayerMoveEvent", 0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("count");
+    }
+
+    @Test
+    void cancelNextEventsCommand_shouldRejectNegativeCount()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new CancelNextEvents.Command(
+            "request-1", "org.bukkit.event.player.PlayerMoveEvent", -1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("count");
+    }
+
+    @Test
+    void playerChatCommand_shouldRejectBlankRequestId()
+    {
+        // setup
+        final UUID uuid = UUID.randomUUID();
+
+        // execute + verify
+        assertThatThrownBy(() -> new PlayerChat.Command("   ", uuid, "hello"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("requestId");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void playerChatCommand_shouldRejectNullUuid()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new PlayerChat.Command("request-1", null, "hello"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("uuid");
+    }
+
+    @Test
+    void playerChatCommand_shouldRejectBlankMessage()
+    {
+        // setup
+        final UUID uuid = UUID.randomUUID();
+
+        // execute + verify
+        assertThatThrownBy(() -> new PlayerChat.Command("request-1", uuid, "   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("message");
+    }
+
     // -----------------------------------------------------------------------
     // IProtocolValue leaf validation
     // -----------------------------------------------------------------------

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
@@ -268,7 +268,9 @@ class ProtocolValueSerializationTest
         eventValues.put(
             "getDrops",
             new IProtocolValue.PList(List.of(new IProtocolValue.PString("minecraft:stone"))));
-        final GetCapturedEvents.Response original = new GetCapturedEvents.Response(List.of(eventValues));
+        final GetCapturedEvents.CapturedEvent capturedEvent =
+            new GetCapturedEvents.CapturedEvent(5L, eventValues);
+        final GetCapturedEvents.Response original = new GetCapturedEvents.Response(List.of(capturedEvent));
 
         // execute
         final String json = mapper.writeValueAsString(original);
@@ -276,7 +278,8 @@ class ProtocolValueSerializationTest
 
         // verify
         assertThat(result.events()).hasSize(1);
-        assertThat(result.events().getFirst()).containsExactlyEntriesOf(eventValues);
+        assertThat(result.events().getFirst().tick()).isEqualTo(5L);
+        assertThat(result.events().getFirst().values()).containsExactlyEntriesOf(eventValues);
         assertThat(result).isEqualTo(original);
     }
 }

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -20,7 +20,7 @@ public final class RuntimeProtocol
      * in a backward-incompatible way. Both the framework and the agent must agree on this value;
      * a mismatch causes an {@code HANDSHAKE} failure.
      */
-    public static final int VERSION = 7;
+    public static final int VERSION = 8;
 
     /**
      * Minecraft server version supported by this LightKeeper build.


### PR DESCRIPTION
## Why
- Roadmap slice S4: AA's event assertions need attributable, time-correlated captures (trap #14), deterministic cancellation for EVT-3..6, and bots that can produce chat (LK-7).
- S2's envelope already delivered typed `PRecord` payloads and record-accessor support, so this lands the remainder.

## How
- **Tick stamps** (protocol v8): captured events carry the server tick they fired on (`CapturedEvent(tick, values)` / `CapturedEventSnapshot.tick()`), with `currentServerTick()` as the live counterpart — documented honestly as an agent-relative, per-session counter.
- **`capture.cancelNext(n)`** (D9 — deterministic only): a separate LOWEST-priority marker listener cancels exactly the next N events, so regular listeners and the MONITOR capture observe the final cancelled state. One armed per class; `close()` disarms any remainder so cancellations never leak into later tests; re-arm surfaces as `INVALID_ARGUMENT`.
- **`player.chat(message)`**: fires the real chat event via `Player#chat` on the main thread — plugin-triggered chat is synchronous by Bukkit's contract, and the review verified the whole path against real CraftBukkit bytecode (including why it works on NMS-spawned bots: the adapter's live Connection). A dedicated `ChatLog` type was deliberately deferred: generic `captureEvents("...AsyncPlayerChatEvent")` already provides server-wide chat capture, as the IT proves.

## Tests
- `mvn -Perrorprone clean install checkstyle:checkstyle pmd:check`: BUILD SUCCESS, 0 violations; ~500 unit tests incl. new suites (tick stamping, cancel budget boundary + scheduled unregister, close-disarm, re-arm mapping, chat dispatch, wire round-trips).
- `mvn clean verify -pl lightkeeper-integration-tests`: green on both Paper and Spigot lanes incl. `LightkeeperChatAndCancelIT` — a bot chat captured with a valid tick window, and `cancelNext(1)` cancelling exactly the first of two chats.
- Pre-PR deep review (Opus agent, verified against CraftBukkit 1.21.x bytecode): MERGE-WITH-FIXES — both MAJORs (close-leak of armed cancellations, re-arm misclassified as REQUEST_FAILED+SEVERE) fixed with regression tests in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Synthetic players can now send chat messages that trigger the real chat event.
  * Added support for cancelling exactly the next number of matching events.
  * Captured events now include the server tick when they occurred.
  * Added access to the current server tick for event correlation.
* **Documentation**
  * Updated the README with chat and deterministic event-cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->