### PR TITLE
feat: entity queries — EntityQuery, EntitySnapshot, and QUERY_ENTITIES (protocol v9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ class MyPluginIT
   `world.setBlockAt(pos, BlockSpec.parse("minecraft:lever[face=floor,powered=true]"))` and assert partially
   via `world.blockAt(pos).is(BlockSpec.parse("minecraft:lever[powered=true]"))` — only named properties
   are compared
+- Entity queries: `world.entities().ofType("minecraft:block_display").within(min, max).count()` counts
+  live entities cheaply (pairs with `eventually`), and `.snapshot()` freezes matching entities — position,
+  custom name, PDC keys, and the display transformation (translation/scale/rotations) — in one main-thread
+  burst so every snapshot shares one server tick
 - Diagnostics-on-failure: failed tests automatically get a bundle (test outcome, captured server errors,
   server console output) under `target/lightkeeper-reports/`
 - Graceful server lifecycle control from tests (`stopServer()`, `startServer()`, `restartServer()`), plus

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -36,6 +36,7 @@ import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
 import nl.pim16aap2.lightkeeper.protocol.PlayerChat;
+import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
@@ -279,6 +280,7 @@ final class AgentRequestDispatcher
                 case HasPlayerPermission.Command c -> handle(c, playerActions::handleHasPlayerPermission);
                 case CancelNextEvents.Command c -> handle(c, eventActions::handleCancelNextEvents);
                 case PlayerChat.Command c -> handle(c, playerActions::handlePlayerChat);
+                case QueryEntities.Command c -> handle(c, worldActions::handleQueryEntities);
                 case Handshake.Command ignored ->
                     throw new IllegalStateException("Unreachable HANDSHAKE dispatch branch.");
             };

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -10,16 +10,27 @@ import nl.pim16aap2.lightkeeper.protocol.IsChunkLoaded;
 import nl.pim16aap2.lightkeeper.protocol.LoadChunk;
 import nl.pim16aap2.lightkeeper.protocol.MainWorld;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
+import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.protocol.SetBlock;
 import nl.pim16aap2.lightkeeper.protocol.UnloadChunk;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicks;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.Transformation;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
@@ -222,6 +233,94 @@ final class AgentWorldActions
         });
 
         return new SetBlock.Response(setMaterial);
+    }
+
+    /**
+     * Handles {@code QUERY_ENTITIES} by reading all matching entities in one main-thread burst, so the
+     * returned states are internally consistent and share one tick stamp.
+     *
+     * @param command
+     *     Typed command carrying world name, optional type filter, optional bounds, and the count-only flag.
+     * @return
+     *     Response with the match count and (unless count-only) the entity states.
+     * @throws Exception
+     *     Propagates validation and main-thread execution failures.
+     */
+    QueryEntities.Response handleQueryEntities(QueryEntities.Command command)
+        throws Exception
+    {
+        final String worldName = command.worldName();
+        final String entityTypeKey = command.entityTypeKey() == null
+            ? null
+            : normalizeEntityTypeKey(command.entityTypeKey());
+
+        return mainThreadExecutor.callOnMainThread(() ->
+        {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null)
+                throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
+
+            final Collection<Entity> candidates = command.bounded()
+                ? world.getNearbyEntities(new BoundingBox(
+                    command.minX(), command.minY(), command.minZ(),
+                    command.maxX() + 1.0, command.maxY() + 1.0, command.maxZ() + 1.0))
+                : world.getEntities();
+
+            final List<QueryEntities.EntityData> matches = new ArrayList<>();
+            int count = 0;
+            for (final Entity entity : candidates)
+            {
+                if (entityTypeKey != null
+                    && !entity.getType().getKey().toString().equals(entityTypeKey))
+                    continue;
+                count++;
+                if (!command.countOnly())
+                    matches.add(toEntityData(entity));
+            }
+            return new QueryEntities.Response(tickCounter.get(), count, matches);
+        });
+    }
+
+    private static String normalizeEntityTypeKey(String entityTypeKey)
+    {
+        final String trimmed = entityTypeKey.trim().toLowerCase(Locale.ROOT);
+        return trimmed.startsWith("minecraft:") ? trimmed : "minecraft:" + trimmed;
+    }
+
+    private static QueryEntities.EntityData toEntityData(Entity entity)
+    {
+        final Location location = entity.getLocation();
+        final List<String> pdcKeys = entity.getPersistentDataContainer().getKeys().stream()
+            .map(Object::toString)
+            .sorted()
+            .toList();
+        return new QueryEntities.EntityData(
+            entity.getUniqueId(),
+            entity.getType().getKey().toString(),
+            location.getX(),
+            location.getY(),
+            location.getZ(),
+            entity.getCustomName(),
+            pdcKeys,
+            entity instanceof Display display ? toTransformData(display) : null
+        );
+    }
+
+    private static QueryEntities.TransformData toTransformData(Display display)
+    {
+        final Transformation transformation = display.getTransformation();
+        final Vector3f translation = transformation.getTranslation();
+        final Vector3f scale = transformation.getScale();
+        final Quaternionf leftRotation = transformation.getLeftRotation();
+        final Quaternionf rightRotation = transformation.getRightRotation();
+        return new QueryEntities.TransformData(
+            translation.x(), translation.y(), translation.z(),
+            scale.x(), scale.y(), scale.z(),
+            List.of((double) leftRotation.x(), (double) leftRotation.y(),
+                (double) leftRotation.z(), (double) leftRotation.w()),
+            List.of((double) rightRotation.x(), (double) rightRotation.y(),
+                (double) rightRotation.z(), (double) rightRotation.w())
+        );
     }
 
     /**

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -239,6 +239,10 @@ final class AgentWorldActions
      * Handles {@code QUERY_ENTITIES} by reading all matching entities in one main-thread burst, so the
      * returned states are internally consistent and share one tick stamp.
      *
+     * <p>Bounded queries match by hitbox intersection with the block-inclusive box (each max axis is
+     * extended by one so block coordinates span their full world-space cell), per the Bukkit
+     * nearby-entities semantic — not by position containment.
+     *
      * @param command
      *     Typed command carrying world name, optional type filter, optional bounds, and the count-only flag.
      * @return
@@ -270,6 +274,8 @@ final class AgentWorldActions
             int count = 0;
             for (final Entity entity : candidates)
             {
+                // getKey(), not getKeyOrThrow(): the latter exists only in the Spigot API jar; Paper's
+                // EntityType lacks it at runtime and the agent must run on both.
                 if (entityTypeKey != null
                     && !entity.getType().getKey().toString().equals(entityTypeKey))
                     continue;
@@ -284,7 +290,7 @@ final class AgentWorldActions
     private static String normalizeEntityTypeKey(String entityTypeKey)
     {
         final String trimmed = entityTypeKey.trim().toLowerCase(Locale.ROOT);
-        return trimmed.startsWith("minecraft:") ? trimmed : "minecraft:" + trimmed;
+        return trimmed.indexOf(':') < 0 ? "minecraft:" + trimmed : trimmed;
     }
 
     private static QueryEntities.EntityData toEntityData(Entity entity)

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
@@ -1,9 +1,11 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Array;
@@ -201,6 +203,12 @@ final class ProtocolValueEncoder
             return new IProtocolValue.PRef(entity.getClass().getName(), entity.getUniqueId().toString());
         if (value instanceof World world)
             return new IProtocolValue.PRef(world.getClass().getName(), world.getName());
+        // Positions are identity-shaped leaves like refs: a Location's getChunk()/getBlock() accessors would
+        // otherwise drag world geometry into the payload through the generic walk. Orientation is dropped.
+        if (value instanceof Location location)
+            return new IProtocolValue.PVec(location.getX(), location.getY(), location.getZ());
+        if (value instanceof Vector vector)
+            return new IProtocolValue.PVec(vector.getX(), vector.getY(), vector.getZ());
 
         if (remainingDepth <= 0)
             return dropped(context, accessorName, value.getClass().getName());

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoder.java
@@ -204,9 +204,11 @@ final class ProtocolValueEncoder
         if (value instanceof World world)
             return new IProtocolValue.PRef(world.getClass().getName(), world.getName());
         // Positions are identity-shaped leaves like refs: a Location's getChunk()/getBlock() accessors would
-        // otherwise drag world geometry into the payload through the generic walk. Orientation is dropped.
+        // otherwise drag world geometry into the payload through the generic walk. The record is built by
+        // hand (world ref + position) so cross-world events at equal coordinates stay distinguishable;
+        // orientation is dropped. The world key is omitted for unbound/unloaded-world locations.
         if (value instanceof Location location)
-            return new IProtocolValue.PVec(location.getX(), location.getY(), location.getZ());
+            return encodeLocation(location);
         if (value instanceof Vector vector)
             return new IProtocolValue.PVec(vector.getX(), vector.getY(), vector.getZ());
 
@@ -298,6 +300,26 @@ final class ProtocolValueEncoder
     private IProtocolValue.PDropped truncated(String context, String accessorName, int omittedCount)
     {
         return dropped(context, accessorName, "truncated: %d more elements".formatted(omittedCount));
+    }
+
+
+    /**
+     * Encodes a {@link Location} as a hand-built record of world identity plus position, never via the
+     * generic accessor walk.
+     */
+    private static IProtocolValue.PRecord encodeLocation(Location location)
+    {
+        final LinkedHashMap<String, IProtocolValue> fields = new LinkedHashMap<>();
+        // isWorldLoaded guards Location#getWorld's IllegalArgumentException for stale world references; the
+        // null check covers unbound locations (and satisfies NullAway).
+        if (location.isWorldLoaded())
+        {
+            final @Nullable World world = location.getWorld();
+            if (world != null)
+                fields.put("world", new IProtocolValue.PRef(world.getClass().getName(), world.getName()));
+        }
+        fields.put("position", new IProtocolValue.PVec(location.getX(), location.getY(), location.getZ()));
+        return new IProtocolValue.PRecord(fields);
     }
 
     private IProtocolValue.PDropped dropped(String context, String accessorName, String runtimeType)

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
@@ -9,18 +9,33 @@ import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.IsChunkLoaded;
 import nl.pim16aap2.lightkeeper.protocol.LoadChunk;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
+import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.protocol.SetBlock;
 import nl.pim16aap2.lightkeeper.protocol.UnloadChunk;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicks;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.Transformation;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.*;
@@ -169,6 +184,250 @@ class AgentWorldActionsTest
 
         // verify
         assertThat(response.loaded()).isTrue();
+    }
+
+    @Test
+    void handleQueryEntities_shouldReturnAllEntitiesWhenUnbounded()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong(42L));
+        final World world = mock();
+        final UUID entityId = UUID.randomUUID();
+        final Entity entity = mockZombieEntity(entityId, 1.0, 2.0, 3.0, null, Set.of());
+        when(world.getEntities()).thenReturn(List.of(entity));
+        final QueryEntities.Command command =
+            new QueryEntities.Command("request-qe-1", "world", null, false, 0, 0, 0, 0, 0, 0, false);
+
+        // execute
+        final QueryEntities.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleQueryEntities(command);
+        }
+
+        // verify
+        assertThat(response.tick()).isEqualTo(42L);
+        assertThat(response.count()).isEqualTo(1);
+        assertThat(response.entities()).singleElement().satisfies(data ->
+        {
+            assertThat(data.uuid()).isEqualTo(entityId);
+            assertThat(data.typeKey()).isEqualTo("minecraft:zombie");
+            assertThat(data.x()).isEqualTo(1.0);
+            assertThat(data.y()).isEqualTo(2.0);
+            assertThat(data.z()).isEqualTo(3.0);
+        });
+    }
+
+    @Test
+    void handleQueryEntities_shouldQueryNearbyEntitiesWhenBounded()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        final Entity entity = mockZombieEntity(UUID.randomUUID(), 1.0, 2.0, 3.0, null, Set.of());
+        final BoundingBox expectedBounds = new BoundingBox(0, 1, 2, 11.0, 12.0, 13.0);
+        when(world.getNearbyEntities(expectedBounds)).thenReturn(List.of(entity));
+        final QueryEntities.Command command =
+            new QueryEntities.Command("request-qe-2", "world", null, true, 0, 1, 2, 10, 11, 12, false);
+
+        // execute
+        final QueryEntities.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleQueryEntities(command);
+        }
+
+        // verify
+        assertThat(response.count()).isEqualTo(1);
+        verify(world).getNearbyEntities(expectedBounds);
+    }
+
+    @Test
+    void handleQueryEntities_shouldMatchTypeFilterGivenUppercaseTypeKeyWithoutNamespace()
+        throws Exception
+    {
+        // setup + execute + verify
+        assertTypeFilterMatchesOnlyZombie("ZOMBIE");
+    }
+
+    @Test
+    void handleQueryEntities_shouldMatchTypeFilterGivenNamespacedTypeKeyWithWhitespace()
+        throws Exception
+    {
+        // setup + execute + verify
+        assertTypeFilterMatchesOnlyZombie(" minecraft:zombie ");
+    }
+
+    @Test
+    void handleQueryEntities_shouldMatchTypeFilterGivenLowercaseTypeKeyWithoutNamespace()
+        throws Exception
+    {
+        // setup + execute + verify
+        assertTypeFilterMatchesOnlyZombie("zombie");
+    }
+
+    private void assertTypeFilterMatchesOnlyZombie(String entityTypeKey)
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        final UUID zombieId = UUID.randomUUID();
+        final Entity zombie = mockZombieEntity(zombieId, 0.0, 0.0, 0.0, null, Set.of());
+        final Entity creeper = mock();
+        when(creeper.getType()).thenReturn(EntityType.CREEPER);
+        when(world.getEntities()).thenReturn(List.of(zombie, creeper));
+        final QueryEntities.Command command =
+            new QueryEntities.Command("request-qe-filter", "world", entityTypeKey, false, 0, 0, 0, 0, 0, 0, false);
+
+        // execute
+        final QueryEntities.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleQueryEntities(command);
+        }
+
+        // verify
+        assertThat(response.count()).isEqualTo(1);
+        assertThat(response.entities()).singleElement()
+            .extracting(QueryEntities.EntityData::uuid).isEqualTo(zombieId);
+    }
+
+    @Test
+    void handleQueryEntities_shouldReturnCountOnlyResultsWhenCountOnlyIsTrue()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        when(world.getEntities()).thenReturn(List.of(mock(Entity.class), mock(Entity.class)));
+        final QueryEntities.Command command =
+            new QueryEntities.Command("request-qe-count", "world", null, false, 0, 0, 0, 0, 0, 0, true);
+
+        // execute
+        final QueryEntities.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleQueryEntities(command);
+        }
+
+        // verify
+        assertThat(response.count()).isEqualTo(2);
+        assertThat(response.entities()).isEmpty();
+    }
+
+    @Test
+    void handleQueryEntities_shouldMapEntityDataFieldsAndReturnNullTransformForNonDisplayEntity()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        final UUID entityId = UUID.randomUUID();
+        final Set<NamespacedKey> pdcKeys = Set.of(
+            new NamespacedKey("custom", "zeta"), new NamespacedKey("custom", "alpha"));
+        final Entity entity = mockZombieEntity(entityId, 1.5, 64.0, -2.75, "Bob", pdcKeys);
+        when(world.getEntities()).thenReturn(List.of(entity));
+        final QueryEntities.Command command =
+            new QueryEntities.Command("request-qe-map", "world", null, false, 0, 0, 0, 0, 0, 0, false);
+
+        // execute
+        final QueryEntities.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleQueryEntities(command);
+        }
+
+        // verify
+        assertThat(response.entities()).singleElement().satisfies(data ->
+        {
+            assertThat(data.uuid()).isEqualTo(entityId);
+            assertThat(data.x()).isEqualTo(1.5);
+            assertThat(data.y()).isEqualTo(64.0);
+            assertThat(data.z()).isEqualTo(-2.75);
+            assertThat(data.customName()).isEqualTo("Bob");
+            assertThat(data.pdcKeys()).containsExactly("custom:alpha", "custom:zeta");
+            assertThat(data.transform()).isNull();
+        });
+    }
+
+    @Test
+    void handleQueryEntities_shouldMapTransformDataForDisplayEntity()
+        throws Exception
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+        final World world = mock();
+        final Display display = mock();
+        when(display.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(display.getType()).thenReturn(EntityType.BLOCK_DISPLAY);
+        when(display.getLocation()).thenReturn(new Location(null, 0.0, 0.0, 0.0));
+        when(display.getCustomName()).thenReturn(null);
+        final PersistentDataContainer pdc = mock();
+        when(pdc.getKeys()).thenReturn(Set.of());
+        when(display.getPersistentDataContainer()).thenReturn(pdc);
+        final Transformation transformation = new Transformation(
+            new Vector3f(1.0f, 2.0f, 3.0f),
+            new Quaternionf(0.1f, 0.2f, 0.3f, 0.4f),
+            new Vector3f(4.0f, 5.0f, 6.0f),
+            new Quaternionf(0.5f, 0.6f, 0.7f, 0.8f)
+        );
+        when(display.getTransformation()).thenReturn(transformation);
+        when(world.getEntities()).thenReturn(List.of(display));
+        final QueryEntities.Command command =
+            new QueryEntities.Command("request-qe-transform", "world", null, false, 0, 0, 0, 0, 0, 0, false);
+
+        // execute
+        final QueryEntities.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkitMockedStatic.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            response = worldActions.handleQueryEntities(command);
+        }
+
+        // verify
+        assertThat(response.entities()).singleElement().extracting(QueryEntities.EntityData::transform)
+            .satisfies(transform ->
+            {
+                assertThat(transform).isNotNull();
+                assertThat(transform.translationX()).isEqualTo(1.0);
+                assertThat(transform.translationY()).isEqualTo(2.0);
+                assertThat(transform.translationZ()).isEqualTo(3.0);
+                assertThat(transform.scaleX()).isEqualTo(4.0);
+                assertThat(transform.scaleY()).isEqualTo(5.0);
+                assertThat(transform.scaleZ()).isEqualTo(6.0);
+                assertThat(transform.leftRotation()).containsExactly(
+                    (double) 0.1f, (double) 0.2f, (double) 0.3f, (double) 0.4f);
+                assertThat(transform.rightRotation()).containsExactly(
+                    (double) 0.5f, (double) 0.6f, (double) 0.7f, (double) 0.8f);
+            });
+    }
+
+    private static Entity mockZombieEntity(
+        UUID uuid, double x, double y, double z, @Nullable String customName, Set<NamespacedKey> pdcKeys)
+    {
+        final Entity entity = mock();
+        when(entity.getUniqueId()).thenReturn(uuid);
+        when(entity.getType()).thenReturn(EntityType.ZOMBIE);
+        when(entity.getLocation()).thenReturn(new Location(null, x, y, z));
+        when(entity.getCustomName()).thenReturn(customName);
+        final PersistentDataContainer pdc = mock();
+        when(pdc.getKeys()).thenReturn(pdcKeys);
+        when(entity.getPersistentDataContainer()).thenReturn(pdc);
+        return entity;
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
@@ -85,6 +85,63 @@ class ProtocolValueEncoderTest
     }
 
     @Test
+    void encodeAccessors_shouldEncodeLocationAsPVecLeafWithoutWalkingAccessors()
+    {
+        // setup — a null world verifies the leaf never touches getWorld()/getChunk()/getBlock()
+        final org.bukkit.Location location = new org.bukkit.Location(null, 1.5, 64.0, -2.25);
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new LocationHolder(location), "ctx");
+
+        // verify
+        assertThat(result).containsEntry("getLocation", new IProtocolValue.PVec(1.5, 64.0, -2.25));
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeLocationAsPVecEvenWhenDepthIsExhausted()
+    {
+        // setup — a self-nesting fixture forces the walk past MAX_DEPTH; a sibling getChild() at the same,
+        // depth-exhausted level is dropped (see encodeAccessors_shouldDropValueBeyondMaxDepth), but the
+        // position leaf must still resolve because it is checked before the depth cutoff.
+        final JavaPlugin plugin = mock();
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("protocol-value-encoder-test-location-depth"));
+        final ProtocolValueEncoder encoder = createEncoder(plugin);
+
+        // execute
+        final Map<String, IProtocolValue> level0 =
+            encoder.encodeAccessors(new LocationBearingNestingFixture(), "ctx");
+
+        // verify — drill down MAX_DEPTH - 1 levels to reach the depth-exhausted record, then read its sibling
+        IProtocolValue current = java.util.Objects.requireNonNull(level0.get("getChild"));
+        for (int depth = 0; depth < ProtocolValueEncoder.MAX_DEPTH - 1; depth++)
+        {
+            assertThat(current).isInstanceOf(IProtocolValue.PRecord.class);
+            current = java.util.Objects.requireNonNull(
+                ((IProtocolValue.PRecord) current).fields().get("getChild"));
+        }
+        assertThat(current).isInstanceOfSatisfying(IProtocolValue.PRecord.class, record ->
+        {
+            assertThat(record.fields().get("getChild")).isInstanceOf(IProtocolValue.PDropped.class);
+            assertThat(record.fields().get("getLocation")).isEqualTo(new IProtocolValue.PVec(7.0, 8.0, 9.0));
+        });
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeVectorAsPVecLeaf()
+    {
+        // setup
+        final org.bukkit.util.Vector vector = new org.bukkit.util.Vector(4.0, 5.0, 6.0);
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result = encoder.encodeAccessors(new VectorHolder(vector), "ctx");
+
+        // verify
+        assertThat(result).containsEntry("getVector", new IProtocolValue.PVec(4.0, 5.0, 6.0));
+    }
+
+    @Test
     void encodeAccessors_shouldWalkRecordComponents()
     {
         // setup
@@ -346,6 +403,54 @@ class ProtocolValueEncoderTest
         public World getWorld()
         {
             return world;
+        }
+    }
+
+    public static final class LocationHolder
+    {
+        private final org.bukkit.Location location;
+
+        public LocationHolder(org.bukkit.Location location)
+        {
+            this.location = location;
+        }
+
+        public org.bukkit.Location getLocation()
+        {
+            return location;
+        }
+    }
+
+    public static final class VectorHolder
+    {
+        private final org.bukkit.util.Vector vector;
+
+        public VectorHolder(org.bukkit.util.Vector vector)
+        {
+            this.vector = vector;
+        }
+
+        public org.bukkit.util.Vector getVector()
+        {
+            return vector;
+        }
+    }
+
+    /**
+     * Self-nesting fixture (like {@link SelfNestingFixture}) with an additional constant-valued
+     * {@code getLocation()} accessor on every level, used to prove position leaves resolve even once
+     * {@code remainingDepth} is exhausted by the {@code getChild()} recursion.
+     */
+    public static final class LocationBearingNestingFixture
+    {
+        public LocationBearingNestingFixture getChild()
+        {
+            return new LocationBearingNestingFixture();
+        }
+
+        public org.bukkit.Location getLocation()
+        {
+            return new org.bukkit.Location(null, 7.0, 8.0, 9.0);
         }
     }
 

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/ProtocolValueEncoderTest.java
@@ -1,11 +1,13 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -20,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,7 +88,7 @@ class ProtocolValueEncoderTest
     }
 
     @Test
-    void encodeAccessors_shouldEncodeLocationAsPVecLeafWithoutWalkingAccessors()
+    void encodeAccessors_shouldEncodeWorldlessLocationAsPositionOnlyRecordWithoutWalkingAccessors()
     {
         // setup — a null world verifies the leaf never touches getWorld()/getChunk()/getBlock()
         final org.bukkit.Location location = new org.bukkit.Location(null, 1.5, 64.0, -2.25);
@@ -95,11 +98,39 @@ class ProtocolValueEncoderTest
         final Map<String, IProtocolValue> result = encoder.encodeAccessors(new LocationHolder(location), "ctx");
 
         // verify
-        assertThat(result).containsEntry("getLocation", new IProtocolValue.PVec(1.5, 64.0, -2.25));
+        assertThat(result).containsEntry("getLocation", new IProtocolValue.PRecord(
+            new java.util.LinkedHashMap<>(Map.of("position", new IProtocolValue.PVec(1.5, 64.0, -2.25)))));
     }
 
     @Test
-    void encodeAccessors_shouldEncodeLocationAsPVecEvenWhenDepthIsExhausted()
+    void encodeAccessors_shouldPreserveWorldIdentityWhenLocationHasLoadedWorld()
+    {
+        // setup — cross-world events at equal coordinates must stay distinguishable in payloads;
+        // Location#isWorldLoaded resolves the world through Bukkit#getWorld(UUID), hence the static mock.
+        final World world = mock();
+        final UUID worldId = UUID.randomUUID();
+        when(world.getUID()).thenReturn(worldId);
+        when(world.getName()).thenReturn("world_nether");
+        final org.bukkit.Location location = new org.bukkit.Location(world, 1.5, 64.0, -2.25);
+        final ProtocolValueEncoder encoder = createEncoder(mock());
+
+        // execute
+        final Map<String, IProtocolValue> result;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(() -> Bukkit.getWorld(worldId)).thenReturn(world);
+            result = encoder.encodeAccessors(new LocationHolder(location), "ctx");
+        }
+
+        // verify
+        final java.util.LinkedHashMap<String, IProtocolValue> expectedFields = new java.util.LinkedHashMap<>();
+        expectedFields.put("world", new IProtocolValue.PRef(world.getClass().getName(), "world_nether"));
+        expectedFields.put("position", new IProtocolValue.PVec(1.5, 64.0, -2.25));
+        assertThat(result).containsEntry("getLocation", new IProtocolValue.PRecord(expectedFields));
+    }
+
+    @Test
+    void encodeAccessors_shouldEncodeLocationEvenWhenDepthIsExhausted()
     {
         // setup — a self-nesting fixture forces the walk past MAX_DEPTH; a sibling getChild() at the same,
         // depth-exhausted level is dropped (see encodeAccessors_shouldDropValueBeyondMaxDepth), but the
@@ -123,7 +154,8 @@ class ProtocolValueEncoderTest
         assertThat(current).isInstanceOfSatisfying(IProtocolValue.PRecord.class, record ->
         {
             assertThat(record.fields().get("getChild")).isInstanceOf(IProtocolValue.PDropped.class);
-            assertThat(record.fields().get("getLocation")).isEqualTo(new IProtocolValue.PVec(7.0, 8.0, 9.0));
+            assertThat(record.fields().get("getLocation")).isEqualTo(new IProtocolValue.PRecord(
+                new java.util.LinkedHashMap<>(Map.of("position", new IProtocolValue.PVec(7.0, 8.0, 9.0)))));
         });
     }
 

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntityQuery.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntityQuery.java
@@ -1,0 +1,109 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * LIVE, composable entity query for one world: filters build new immutable queries, terminals re-query the
+ * server per call.
+ *
+ * <p>{@link #count()} is a single cheap RPC, the natural probe for
+ * {@code eventually(timeout, () -> assertThat(query.count()).isEqualTo(n))}; {@link #snapshot()} reads all
+ * matching entities in one main-thread burst, so the returned states are internally consistent and share one
+ * tick stamp — the property that makes "N in flight, zero after" accounting deterministic.
+ *
+ * <p>Only entities in loaded chunks are visible (the Bukkit contract). In a world with no players keep the
+ * relevant chunks loaded — e.g. via the console command {@code forceload add} — or the server unloads them,
+ * taking their entities out of query range.
+ */
+public final class EntityQuery
+{
+    private final IFrameworkGatewayView frameworkGateway;
+    private final String worldName;
+    private final @Nullable String entityTypeKey;
+    private final @Nullable BlockPos boundsMin;
+    private final @Nullable BlockPos boundsMax;
+
+    /**
+     * Creates an unfiltered query for a world.
+     *
+     * @param frameworkGateway
+     *     Internal gateway for operations.
+     * @param worldName
+     *     Name of the world to query.
+     */
+    EntityQuery(IFrameworkGatewayView frameworkGateway, String worldName)
+    {
+        this(frameworkGateway, worldName, null, null, null);
+    }
+
+    private EntityQuery(
+        IFrameworkGatewayView frameworkGateway,
+        String worldName,
+        @Nullable String entityTypeKey,
+        @Nullable BlockPos boundsMin,
+        @Nullable BlockPos boundsMax)
+    {
+        this.frameworkGateway = Objects.requireNonNull(frameworkGateway, "frameworkGateway may not be null.");
+        this.worldName = Objects.requireNonNull(worldName, "worldName may not be null.");
+        this.entityTypeKey = entityTypeKey;
+        this.boundsMin = boundsMin;
+        this.boundsMax = boundsMax;
+    }
+
+    /**
+     * Returns a copy of this query filtered to one entity type.
+     *
+     * @param typeKey
+     *     Namespaced entity type key, e.g. {@code minecraft:block_display} (the {@code minecraft:} prefix is
+     *     optional).
+     * @return A new query with the type filter applied.
+     */
+    public EntityQuery ofType(String typeKey)
+    {
+        final String trimmed = Objects.requireNonNull(typeKey, "typeKey may not be null.").trim();
+        if (trimmed.isEmpty())
+            throw new IllegalArgumentException("typeKey may not be blank.");
+        return new EntityQuery(frameworkGateway, worldName, trimmed, boundsMin, boundsMax);
+    }
+
+    /**
+     * Returns a copy of this query restricted to a block-aligned bounding box (inclusive on every axis).
+     *
+     * @param min
+     *     Minimum corner.
+     * @param max
+     *     Maximum corner.
+     * @return A new query with the spatial bound applied.
+     */
+    public EntityQuery within(BlockPos min, BlockPos max)
+    {
+        Objects.requireNonNull(min, "min may not be null.");
+        Objects.requireNonNull(max, "max may not be null.");
+        if (min.x() > max.x() || min.y() > max.y() || min.z() > max.z())
+            throw new IllegalArgumentException("min must be <= max on every axis.");
+        return new EntityQuery(frameworkGateway, worldName, entityTypeKey, min, max);
+    }
+
+    /**
+     * Counts the matching entities — one RPC, the cheap probe shape for retrying assertions.
+     *
+     * @return The number of matching entities right now.
+     */
+    public int count()
+    {
+        return frameworkGateway.countEntities(worldName, entityTypeKey, boundsMin, boundsMax);
+    }
+
+    /**
+     * Snapshots all matching entities in one main-thread burst.
+     *
+     * @return Internally consistent snapshots sharing one tick stamp.
+     */
+    public List<EntitySnapshot> snapshot()
+    {
+        return frameworkGateway.snapshotEntities(worldName, entityTypeKey, boundsMin, boundsMax);
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntityQuery.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntityQuery.java
@@ -72,6 +72,10 @@ public final class EntityQuery
     /**
      * Returns a copy of this query restricted to a block-aligned bounding box (inclusive on every axis).
      *
+     * <p>An entity matches when its hitbox intersects the box (the Bukkit nearby-entities semantic), not
+     * only when its position lies inside it — a large entity standing just outside the box whose hitbox
+     * overlaps it still counts.
+     *
      * @param min
      *     Minimum corner.
      * @param max

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshot.java
@@ -1,0 +1,95 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Frozen snapshot of one entity's state, read in the same main-thread burst as its query siblings — every
+ * snapshot from one {@link EntityQuery#snapshot()} call shares one tick and is internally consistent.
+ *
+ * @param uuid
+ *     The entity's UUID.
+ * @param typeKey
+ *     Namespaced entity type key, e.g. {@code minecraft:block_display}.
+ * @param position
+ *     The entity's position at the burst tick.
+ * @param customName
+ *     The entity's custom name, or {@code null} when unnamed.
+ * @param pdcKeys
+ *     Namespaced keys present in the entity's persistent data container, sorted.
+ * @param transform
+ *     The display transformation for display entities, or {@code null} for all other entities.
+ * @param tick
+ *     The server tick of the query burst.
+ */
+public record EntitySnapshot(
+    UUID uuid,
+    String typeKey,
+    Vec3 position,
+    @Nullable String customName,
+    List<String> pdcKeys,
+    @Nullable Transform transform,
+    long tick
+)
+{
+    /**
+     * Validates and defensively copies the fields.
+     */
+    public EntitySnapshot
+    {
+        Objects.requireNonNull(uuid, "uuid may not be null.");
+        Objects.requireNonNull(typeKey, "typeKey may not be null.");
+        Objects.requireNonNull(position, "position may not be null.");
+        pdcKeys = pdcKeys == null ? List.of() : List.copyOf(pdcKeys);
+    }
+
+    /**
+     * A display entity's transformation: display entities move via transform, not position.
+     *
+     * @param translation
+     *     The translation component.
+     * @param scale
+     *     The scale component.
+     * @param leftRotation
+     *     Left rotation quaternion.
+     * @param rightRotation
+     *     Right rotation quaternion.
+     */
+    public record Transform(
+        Vec3 translation,
+        Vec3 scale,
+        Rotation leftRotation,
+        Rotation rightRotation
+    )
+    {
+        /**
+         * Validates the components.
+         */
+        public Transform
+        {
+            Objects.requireNonNull(translation, "translation may not be null.");
+            Objects.requireNonNull(scale, "scale may not be null.");
+            Objects.requireNonNull(leftRotation, "leftRotation may not be null.");
+            Objects.requireNonNull(rightRotation, "rightRotation may not be null.");
+        }
+    }
+
+    /**
+     * A rotation quaternion.
+     *
+     * @param x
+     *     X component.
+     * @param y
+     *     Y component.
+     * @param z
+     *     Z component.
+     * @param w
+     *     W component.
+     */
+    public record Rotation(double x, double y, double z, double w)
+    {
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshot.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshot.java
@@ -36,14 +36,15 @@ public record EntitySnapshot(
 )
 {
     /**
-     * Validates and defensively copies the fields.
+     * Validates and defensively copies the fields; sorts {@code pdcKeys} so the documented ordering holds
+     * regardless of the source.
      */
     public EntitySnapshot
     {
         Objects.requireNonNull(uuid, "uuid may not be null.");
         Objects.requireNonNull(typeKey, "typeKey may not be null.");
         Objects.requireNonNull(position, "position may not be null.");
-        pdcKeys = pdcKeys == null ? List.of() : List.copyOf(pdcKeys);
+        pdcKeys = pdcKeys == null ? List.of() : pdcKeys.stream().sorted().toList();
     }
 
     /**

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IFrameworkGatewayView.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.lightkeeper.framework;
 
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.List;
@@ -188,6 +189,24 @@ public interface IFrameworkGatewayView
      * Gets the server's current tick.
      */
     long currentServerTick();
+
+    /**
+     * Counts entities in a world matching the optional type and bounds filters.
+     */
+    int countEntities(
+        String worldName,
+        @Nullable String entityTypeKey,
+        @Nullable BlockPos boundsMin,
+        @Nullable BlockPos boundsMax);
+
+    /**
+     * Snapshots entities in a world matching the optional type and bounds filters, in one main-thread burst.
+     */
+    List<EntitySnapshot> snapshotEntities(
+        String worldName,
+        @Nullable String entityTypeKey,
+        @Nullable BlockPos boundsMin,
+        @Nullable BlockPos boundsMax);
 
     /**
      * Gets all captured server errors: structured log events plus raw stderr stack-trace detections.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/WorldHandle.java
@@ -30,6 +30,17 @@ public final class WorldHandle
     }
 
     /**
+     * Gets a live, composable entity query for this world.
+     *
+     * @return An unfiltered entity query; add filters via {@link EntityQuery#ofType} and
+     *     {@link EntityQuery#within}.
+     */
+    public EntityQuery entities()
+    {
+        return new EntityQuery(frameworkGateway, name);
+    }
+
+    /**
      * Gets a live reference to the block at a position.
      *
      * <p>The reference stores only the address; every read through it re-queries the server.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -5,6 +5,7 @@ import nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot;
 import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.CommandResult;
 import nl.pim16aap2.lightkeeper.framework.Condition;
+import nl.pim16aap2.lightkeeper.framework.EntitySnapshot;
 import nl.pim16aap2.lightkeeper.framework.EventCaptureHandle;
 import nl.pim16aap2.lightkeeper.framework.FrameworkHandleFactory;
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
@@ -16,12 +17,14 @@ import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorSnapshot;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
+import nl.pim16aap2.lightkeeper.framework.Vec3;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
+import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.protocol.ServerErrorEntry;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifestReader;
@@ -590,6 +593,67 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
     {
         ensureOpen();
         return agentClient.getServerTick();
+    }
+
+    @Override
+    public int countEntities(
+        String worldName,
+        @Nullable String entityTypeKey,
+        @Nullable BlockPos boundsMin,
+        @Nullable BlockPos boundsMax)
+    {
+        ensureOpen();
+        Objects.requireNonNull(worldName, "worldName may not be null.");
+        return agentClient.queryEntities(worldName, entityTypeKey, boundsMin, boundsMax, true).count();
+    }
+
+    @Override
+    public List<EntitySnapshot> snapshotEntities(
+        String worldName,
+        @Nullable String entityTypeKey,
+        @Nullable BlockPos boundsMin,
+        @Nullable BlockPos boundsMax)
+    {
+        ensureOpen();
+        Objects.requireNonNull(worldName, "worldName may not be null.");
+        final QueryEntities.Response response =
+            agentClient.queryEntities(worldName, entityTypeKey, boundsMin, boundsMax, false);
+        return response.entities().stream()
+            .map(entity -> toEntitySnapshot(entity, response.tick()))
+            .toList();
+    }
+
+    private static EntitySnapshot toEntitySnapshot(QueryEntities.EntityData entity, long tick)
+    {
+        return new EntitySnapshot(
+            entity.uuid(),
+            entity.typeKey(),
+            new Vec3(entity.x(), entity.y(), entity.z()),
+            entity.customName(),
+            entity.pdcKeys(),
+            entity.transform() == null ? null : toTransform(entity.transform()),
+            tick
+        );
+    }
+
+    private static EntitySnapshot.Transform toTransform(QueryEntities.TransformData transform)
+    {
+        return new EntitySnapshot.Transform(
+            new Vec3(transform.translationX(), transform.translationY(), transform.translationZ()),
+            new Vec3(transform.scaleX(), transform.scaleY(), transform.scaleZ()),
+            toRotation(transform.leftRotation()),
+            toRotation(transform.rightRotation())
+        );
+    }
+
+    private static EntitySnapshot.Rotation toRotation(List<Double> quaternion)
+    {
+        if (quaternion.size() != 4)
+            throw new IllegalStateException(
+                "Expected a 4-component rotation quaternion but received %d components."
+                    .formatted(quaternion.size()));
+        return new EntitySnapshot.Rotation(
+            quaternion.get(0), quaternion.get(1), quaternion.get(2), quaternion.get(3));
     }
 
     @Override

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -39,6 +39,7 @@ import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.PlacePlayerBlock;
 import nl.pim16aap2.lightkeeper.protocol.PlayerChat;
+import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
@@ -401,6 +402,39 @@ final class UdsAgentClient implements AutoCloseable
     {
         final PlayerChat.Command command = new PlayerChat.Command(nextRequestId(), uuid, message);
         send(command);
+    }
+
+    QueryEntities.Response queryEntities(
+        String worldName,
+        @Nullable String entityTypeKey,
+        @Nullable BlockPos boundsMin,
+        @Nullable BlockPos boundsMax,
+        boolean countOnly)
+    {
+        if (boundsMin != null && boundsMax != null)
+        {
+            return send(new QueryEntities.Command(
+                nextRequestId(),
+                worldName,
+                entityTypeKey,
+                true,
+                boundsMin.x(),
+                boundsMin.y(),
+                boundsMin.z(),
+                boundsMax.x(),
+                boundsMax.y(),
+                boundsMax.z(),
+                countOnly
+            ));
+        }
+        return send(new QueryEntities.Command(
+            nextRequestId(),
+            worldName,
+            entityTypeKey,
+            false,
+            0, 0, 0, 0, 0, 0,
+            countOnly
+        ));
     }
 
     void clearCapturedEvents(String eventClassName)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -411,6 +411,8 @@ final class UdsAgentClient implements AutoCloseable
         @Nullable BlockPos boundsMax,
         boolean countOnly)
     {
+        if ((boundsMin == null) != (boundsMax == null))
+            throw new IllegalArgumentException("Bounds must be both present or both absent.");
         if (boundsMin != null && boundsMax != null)
         {
             return send(new QueryEntities.Command(

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EntityQueryTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EntityQueryTest.java
@@ -1,0 +1,199 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EntityQueryTest
+{
+    private IFrameworkGatewayView frameworkGateway;
+    private EntityQuery entityQuery;
+
+    @BeforeEach
+    void setUp()
+    {
+        frameworkGateway = mock(IFrameworkGatewayView.class);
+        entityQuery = new EntityQuery(frameworkGateway, "world");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void ofType_shouldRejectNullTypeKey()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> entityQuery.ofType(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void ofType_shouldRejectBlankTypeKey()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> entityQuery.ofType("   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("blank");
+    }
+
+    @Test
+    void ofType_shouldTrimTypeKeyBeforeUseByGateway()
+    {
+        // setup
+        final EntityQuery typed = entityQuery.ofType("  minecraft:zombie  ");
+
+        // execute
+        typed.count();
+
+        // verify
+        verify(frameworkGateway).countEntities(
+            eq("world"), eq("minecraft:zombie"), isNull(), isNull());
+    }
+
+    @Test
+    void ofType_shouldReturnNewInstanceLeavingOriginalUnfiltered()
+    {
+        // setup
+        final EntityQuery typed = entityQuery.ofType("minecraft:zombie");
+
+        // execute
+        entityQuery.count();
+        typed.count();
+
+        // verify — the original query still passes a null type filter to the gateway
+        verify(frameworkGateway).countEntities(eq("world"), isNull(), isNull(), isNull());
+        verify(frameworkGateway).countEntities(eq("world"), eq("minecraft:zombie"), isNull(), isNull());
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void within_shouldRejectNullMin()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> entityQuery.within(null, new BlockPos(1, 1, 1)))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void within_shouldRejectNullMax()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> entityQuery.within(new BlockPos(0, 0, 0), null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void within_shouldRejectBoundsWhenMinXGreaterThanMaxX()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> entityQuery.within(new BlockPos(5, 0, 0), new BlockPos(4, 0, 0)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("min must be <= max");
+    }
+
+    @Test
+    void within_shouldRejectBoundsWhenMinYGreaterThanMaxY()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> entityQuery.within(new BlockPos(0, 5, 0), new BlockPos(0, 4, 0)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("min must be <= max");
+    }
+
+    @Test
+    void within_shouldRejectBoundsWhenMinZGreaterThanMaxZ()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> entityQuery.within(new BlockPos(0, 0, 5), new BlockPos(0, 0, 4)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("min must be <= max");
+    }
+
+    @Test
+    void within_shouldAllowEqualMinAndMax()
+    {
+        // setup
+        final BlockPos pos = new BlockPos(1, 2, 3);
+        final EntityQuery bounded = entityQuery.within(pos, pos);
+
+        // execute
+        bounded.count();
+
+        // verify
+        verify(frameworkGateway).countEntities(eq("world"), isNull(), eq(pos), eq(pos));
+    }
+
+    @Test
+    void within_shouldReturnNewInstanceLeavingOriginalUnbounded()
+    {
+        // setup
+        final BlockPos min = new BlockPos(0, 0, 0);
+        final BlockPos max = new BlockPos(10, 10, 10);
+        final EntityQuery bounded = entityQuery.within(min, max);
+
+        // execute
+        entityQuery.count();
+        bounded.count();
+
+        // verify — the original query still passes null bounds to the gateway
+        verify(frameworkGateway).countEntities(eq("world"), isNull(), isNull(), isNull());
+        verify(frameworkGateway).countEntities(eq("world"), isNull(), eq(min), eq(max));
+    }
+
+    @Test
+    void ofTypeThenWithin_shouldChainFiltersWithoutMutatingOriginal()
+    {
+        // setup
+        final BlockPos min = new BlockPos(0, 0, 0);
+        final BlockPos max = new BlockPos(10, 10, 10);
+        final EntityQuery chained = entityQuery.ofType("minecraft:zombie").within(min, max);
+
+        // execute
+        chained.count();
+        entityQuery.count();
+
+        // verify
+        verify(frameworkGateway).countEntities(eq("world"), eq("minecraft:zombie"), eq(min), eq(max));
+        verify(frameworkGateway).countEntities(eq("world"), isNull(), isNull(), isNull());
+    }
+
+    @Test
+    void count_shouldReturnValueFromGateway()
+    {
+        // setup
+        when(frameworkGateway.countEntities(eq("world"), isNull(), isNull(), isNull())).thenReturn(3);
+
+        // execute
+        final int result = entityQuery.count();
+
+        // verify
+        assertThat(result).isEqualTo(3);
+    }
+
+    @Test
+    void snapshot_shouldDelegateToGatewayWithConfiguredFilters()
+    {
+        // setup
+        final BlockPos min = new BlockPos(0, 0, 0);
+        final BlockPos max = new BlockPos(10, 10, 10);
+        final EntityQuery bounded = entityQuery.ofType("minecraft:zombie").within(min, max);
+        final EntitySnapshot snapshot = new EntitySnapshot(
+            java.util.UUID.randomUUID(), "minecraft:zombie", new Vec3(1, 2, 3), null, List.of(), null, 5L);
+        when(frameworkGateway.snapshotEntities(eq("world"), eq("minecraft:zombie"), eq(min), eq(max)))
+            .thenReturn(List.of(snapshot));
+
+        // execute
+        final List<EntitySnapshot> result = bounded.snapshot();
+
+        // verify
+        assertThat(result).containsExactly(snapshot);
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshotTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshotTest.java
@@ -62,6 +62,20 @@ class EntitySnapshotTest
     }
 
     @Test
+    void pdcKeys_shouldBeSortedRegardlessOfSourceOrder()
+    {
+        // setup
+        final List<String> source = List.of("plugin:gamma", "plugin:alpha", "plugin:beta");
+
+        // execute
+        final EntitySnapshot snapshot = new EntitySnapshot(
+            UUID.randomUUID(), "minecraft:zombie", new Vec3(0, 0, 0), null, source, null, 0L);
+
+        // verify
+        assertThat(snapshot.pdcKeys()).containsExactly("plugin:alpha", "plugin:beta", "plugin:gamma");
+    }
+
+    @Test
     @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
     void pdcKeys_shouldDefaultToEmptyListWhenConstructedWithNull()
     {

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshotTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/EntitySnapshotTest.java
@@ -1,0 +1,183 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EntitySnapshotTest
+{
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void constructor_shouldRejectNullUuid()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new EntitySnapshot(
+            null, "minecraft:zombie", new Vec3(0, 0, 0), null, List.of(), null, 0L))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("uuid");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void constructor_shouldRejectNullTypeKey()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new EntitySnapshot(
+            UUID.randomUUID(), null, new Vec3(0, 0, 0), null, List.of(), null, 0L))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("typeKey");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void constructor_shouldRejectNullPosition()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new EntitySnapshot(
+            UUID.randomUUID(), "minecraft:zombie", null, null, List.of(), null, 0L))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("position");
+    }
+
+    @Test
+    void pdcKeys_shouldNotExposeConstructorSourceList()
+    {
+        // setup
+        final List<String> source = new ArrayList<>(List.of("plugin:alpha"));
+        final EntitySnapshot snapshot = new EntitySnapshot(
+            UUID.randomUUID(), "minecraft:zombie", new Vec3(0, 0, 0), null, source, null, 0L);
+
+        // execute
+        source.add("plugin:beta");
+
+        // verify
+        assertThat(snapshot.pdcKeys()).containsExactly("plugin:alpha");
+        assertThatThrownBy(() -> snapshot.pdcKeys().add("plugin:gamma"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void pdcKeys_shouldDefaultToEmptyListWhenConstructedWithNull()
+    {
+        // setup + execute
+        final EntitySnapshot snapshot = new EntitySnapshot(
+            UUID.randomUUID(), "minecraft:zombie", new Vec3(0, 0, 0), null, null, null, 0L);
+
+        // verify
+        assertThat(snapshot.pdcKeys()).isEmpty();
+    }
+
+    @Test
+    void constructor_shouldStoreAllFields()
+    {
+        // setup
+        final UUID uuid = UUID.randomUUID();
+        final Vec3 position = new Vec3(1.0, 2.0, 3.0);
+
+        // execute
+        final EntitySnapshot snapshot = new EntitySnapshot(
+            uuid, "minecraft:zombie", position, "Bob", List.of("plugin:alpha"), null, 42L);
+
+        // verify
+        assertThat(snapshot.uuid()).isEqualTo(uuid);
+        assertThat(snapshot.typeKey()).isEqualTo("minecraft:zombie");
+        assertThat(snapshot.position()).isEqualTo(position);
+        assertThat(snapshot.customName()).isEqualTo("Bob");
+        assertThat(snapshot.pdcKeys()).containsExactly("plugin:alpha");
+        assertThat(snapshot.transform()).isNull();
+        assertThat(snapshot.tick()).isEqualTo(42L);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void transformConstructor_shouldRejectNullTranslation()
+    {
+        // setup
+        final EntitySnapshot.Rotation rotation = new EntitySnapshot.Rotation(0, 0, 0, 1);
+
+        // execute + verify
+        assertThatThrownBy(() -> new EntitySnapshot.Transform(null, new Vec3(1, 1, 1), rotation, rotation))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("translation");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void transformConstructor_shouldRejectNullScale()
+    {
+        // setup
+        final EntitySnapshot.Rotation rotation = new EntitySnapshot.Rotation(0, 0, 0, 1);
+
+        // execute + verify
+        assertThatThrownBy(() -> new EntitySnapshot.Transform(new Vec3(0, 0, 0), null, rotation, rotation))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("scale");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void transformConstructor_shouldRejectNullLeftRotation()
+    {
+        // setup
+        final EntitySnapshot.Rotation rotation = new EntitySnapshot.Rotation(0, 0, 0, 1);
+
+        // execute + verify
+        assertThatThrownBy(() -> new EntitySnapshot.Transform(
+            new Vec3(0, 0, 0), new Vec3(1, 1, 1), null, rotation))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("leftRotation");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void transformConstructor_shouldRejectNullRightRotation()
+    {
+        // setup
+        final EntitySnapshot.Rotation rotation = new EntitySnapshot.Rotation(0, 0, 0, 1);
+
+        // execute + verify
+        assertThatThrownBy(() -> new EntitySnapshot.Transform(
+            new Vec3(0, 0, 0), new Vec3(1, 1, 1), rotation, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("rightRotation");
+    }
+
+    @Test
+    void transformConstructor_shouldStoreAllComponents()
+    {
+        // setup
+        final Vec3 translation = new Vec3(1, 2, 3);
+        final Vec3 scale = new Vec3(1, 1, 1);
+        final EntitySnapshot.Rotation leftRotation = new EntitySnapshot.Rotation(0.1, 0.2, 0.3, 0.4);
+        final EntitySnapshot.Rotation rightRotation = new EntitySnapshot.Rotation(0.5, 0.6, 0.7, 0.8);
+
+        // execute
+        final EntitySnapshot.Transform transform =
+            new EntitySnapshot.Transform(translation, scale, leftRotation, rightRotation);
+
+        // verify
+        assertThat(transform.translation()).isEqualTo(translation);
+        assertThat(transform.scale()).isEqualTo(scale);
+        assertThat(transform.leftRotation()).isEqualTo(leftRotation);
+        assertThat(transform.rightRotation()).isEqualTo(rightRotation);
+    }
+
+    @Test
+    void rotation_shouldStoreComponents()
+    {
+        // setup + execute
+        final EntitySnapshot.Rotation rotation = new EntitySnapshot.Rotation(0.1, 0.2, 0.3, 0.4);
+
+        // verify
+        assertThat(rotation.x()).isEqualTo(0.1);
+        assertThat(rotation.y()).isEqualTo(0.2);
+        assertThat(rotation.z()).isEqualTo(0.3);
+        assertThat(rotation.w()).isEqualTo(0.4);
+    }
+}

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/FrameworkApiVisibilityTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/FrameworkApiVisibilityTest.java
@@ -26,6 +26,8 @@ class FrameworkApiVisibilityTest
             PermissionControl.class.getDeclaredConstructor(IFrameworkGatewayView.class, UUID.class);
         final Constructor<BlockRef> blockRefConstructor =
             BlockRef.class.getDeclaredConstructor(IFrameworkGatewayView.class, String.class, BlockPos.class);
+        final Constructor<EntityQuery> entityQueryConstructor =
+            EntityQuery.class.getDeclaredConstructor(IFrameworkGatewayView.class, String.class);
 
         // execute
         final boolean isPlayerConstructorPublic = Modifier.isPublic(playerConstructor.getModifiers());
@@ -35,6 +37,7 @@ class FrameworkApiVisibilityTest
         final boolean isPermissionControlConstructorPublic =
             Modifier.isPublic(permissionControlConstructor.getModifiers());
         final boolean isBlockRefConstructorPublic = Modifier.isPublic(blockRefConstructor.getModifiers());
+        final boolean isEntityQueryConstructorPublic = Modifier.isPublic(entityQueryConstructor.getModifiers());
 
         // verify
         assertThat(isPlayerConstructorPublic).isFalse();
@@ -43,5 +46,6 @@ class FrameworkApiVisibilityTest
         assertThat(isServerErrorsConstructorPublic).isFalse();
         assertThat(isPermissionControlConstructorPublic).isFalse();
         assertThat(isBlockRefConstructorPublic).isFalse();
+        assertThat(isEntityQueryConstructorPublic).isFalse();
     }
 }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/WorldHandleTest.java
@@ -32,6 +32,32 @@ class WorldHandleTest
     }
 
     @Test
+    void entities_shouldReturnUnfilteredQueryBoundToWorld()
+    {
+        // setup
+        when(frameworkGateway.countEntities("world", null, null, null)).thenReturn(2);
+
+        // execute
+        final EntityQuery query = worldHandle.entities();
+        final int count = query.count();
+
+        // verify
+        assertThat(count).isEqualTo(2);
+        verify(frameworkGateway).countEntities("world", null, null, null);
+    }
+
+    @Test
+    void entities_shouldReturnNewQueryInstanceOnEachCall()
+    {
+        // execute
+        final EntityQuery first = worldHandle.entities();
+        final EntityQuery second = worldHandle.entities();
+
+        // verify
+        assertThat(first).isNotSameAs(second);
+    }
+
+    @Test
     void blockTypeAt_shouldDelegateToGateway()
     {
         // setup

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFrameworkGatewayTest.java
@@ -2,22 +2,27 @@ package nl.pim16aap2.lightkeeper.framework.internal;
 
 import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.CapturedEventSnapshot;
+import nl.pim16aap2.lightkeeper.framework.EntitySnapshot;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.WorldSpec;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
 import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.MutatePlayerPermission;
+import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -627,6 +632,154 @@ class DefaultLightkeeperFrameworkGatewayTest
         assertThat(result.getFirst().eventClassName()).isEqualTo("org.bukkit.event.player.PlayerJoinEvent");
         assertThat(result.getFirst().tick()).isEqualTo(9L);
         assertThat(result.getFirst().values()).isEqualTo(values);
+    }
+
+    @Test
+    void countEntities_shouldDelegateToAgentClientWithCountOnlyTrue()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final BlockPos min = new BlockPos(0, 0, 0);
+        final BlockPos max = new BlockPos(10, 10, 10);
+        when(agentClient.queryEntities(eq("world"), eq("minecraft:zombie"), eq(min), eq(max), eq(true)))
+            .thenReturn(new QueryEntities.Response(5L, 3, List.of()));
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final int result = framework.countEntities("world", "minecraft:zombie", min, max);
+
+        // verify
+        assertThat(result).isEqualTo(3);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void countEntities_shouldThrowNullPointerExceptionWhenWorldNameIsNull()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            mock(UdsAgentClient.class),
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.countEntities(null, null, null, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void snapshotEntities_shouldMapEntityDataIncludingTransformAndThreadTickIntoEverySnapshot()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final UUID entityId = UUID.randomUUID();
+        final QueryEntities.TransformData transformData = new QueryEntities.TransformData(
+            1.0, 2.0, 3.0, 1.5, 1.5, 1.5, List.of(0.1, 0.2, 0.3, 0.4), List.of(0.5, 0.6, 0.7, 0.8));
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            entityId, "minecraft:block_display", 10.0, 64.0, -5.0, "Display",
+            List.of("plugin:alpha"), transformData);
+        when(agentClient.queryEntities(eq("world"), isNull(), isNull(), isNull(), eq(false)))
+            .thenReturn(new QueryEntities.Response(99L, 1, List.of(entityData)));
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final List<EntitySnapshot> result = framework.snapshotEntities("world", null, null, null);
+
+        // verify
+        assertThat(result).singleElement().satisfies(snapshot ->
+        {
+            assertThat(snapshot.uuid()).isEqualTo(entityId);
+            assertThat(snapshot.typeKey()).isEqualTo("minecraft:block_display");
+            assertThat(snapshot.position()).isEqualTo(new nl.pim16aap2.lightkeeper.framework.Vec3(10.0, 64.0, -5.0));
+            assertThat(snapshot.customName()).isEqualTo("Display");
+            assertThat(snapshot.pdcKeys()).containsExactly("plugin:alpha");
+            assertThat(snapshot.tick()).isEqualTo(99L);
+            final EntitySnapshot.Transform transform = Objects.requireNonNull(snapshot.transform());
+            assertThat(transform.translation())
+                .isEqualTo(new nl.pim16aap2.lightkeeper.framework.Vec3(1.0, 2.0, 3.0));
+            assertThat(transform.scale())
+                .isEqualTo(new nl.pim16aap2.lightkeeper.framework.Vec3(1.5, 1.5, 1.5));
+            assertThat(transform.leftRotation())
+                .isEqualTo(new EntitySnapshot.Rotation(0.1, 0.2, 0.3, 0.4));
+            assertThat(transform.rightRotation())
+                .isEqualTo(new EntitySnapshot.Rotation(0.5, 0.6, 0.7, 0.8));
+        });
+    }
+
+    @Test
+    void snapshotEntities_shouldPassThroughNullTransformForNonDisplayEntity()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            UUID.randomUUID(), "minecraft:zombie", 1.0, 2.0, 3.0, null, List.of(), null);
+        when(agentClient.queryEntities(eq("world"), isNull(), isNull(), isNull(), eq(false)))
+            .thenReturn(new QueryEntities.Response(1L, 1, List.of(entityData)));
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute
+        final List<EntitySnapshot> result = framework.snapshotEntities("world", null, null, null);
+
+        // verify
+        assertThat(result).singleElement().extracting(EntitySnapshot::transform).isNull();
+    }
+
+    @Test
+    void snapshotEntities_shouldThrowIllegalStateExceptionWhenRotationListSizeIsNotFour()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final QueryEntities.TransformData badTransform = new QueryEntities.TransformData(
+            0.0, 0.0, 0.0, 1.0, 1.0, 1.0, List.of(0.1, 0.2, 0.3), List.of(0.0, 0.0, 0.0, 1.0));
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            UUID.randomUUID(), "minecraft:block_display", 0.0, 0.0, 0.0, null, List.of(), badTransform);
+        when(agentClient.queryEntities(eq("world"), isNull(), isNull(), isNull(), eq(false)))
+            .thenReturn(new QueryEntities.Response(1L, 1, List.of(entityData)));
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            agentClient,
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.snapshotEntities("world", null, null, null))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("4");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void snapshotEntities_shouldThrowNullPointerExceptionWhenWorldNameIsNull()
+    {
+        // setup
+        final DefaultLightkeeperFramework framework = new DefaultLightkeeperFramework(
+            runtimeManifest(),
+            mock(MinecraftServerProcess.class),
+            mock(UdsAgentClient.class),
+            new PlayerScopeRegistry()
+        );
+
+        // execute + verify
+        assertThatThrownBy(() -> framework.snapshotEntities(null, null, null, null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     private static RuntimeManifest runtimeManifest()

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -909,24 +909,23 @@ class UdsAgentClientTest
     }
 
     @Test
-    void queryEntities_shouldTreatOneNullBoundAsUnbounded(@TempDir Path tempDirectory)
+    void queryEntities_shouldRejectMixedBounds(@TempDir Path tempDirectory)
         throws Exception
     {
-        // setup — only one of the two bounds present must not be sent as a bounded query
+        // setup — a lone bound is a caller bug and must fail fast instead of silently querying unbounded
         final Path socketPath = tempDirectory.resolve("query-entities-partial-bounds.sock");
         final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"tick\":1,\"count\":0,\"entities\":[]}";
         try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
              UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
         {
             // execute
-            client.queryEntities("world", null, new BlockPos(0, 1, 2), null, false);
+            final Throwable thrown =
+                catchThrowable(() -> client.queryEntities("world", null, new BlockPos(0, 1, 2), null, false));
 
             // verify
-            assertThat(server.capturedRequest())
-                .contains("\"bounded\":false")
-                .contains("\"minX\":0")
-                .contains("\"minY\":0")
-                .contains("\"minZ\":0");
+            assertThat(thrown)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("both present or both absent");
         }
     }
 

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -854,6 +854,102 @@ class UdsAgentClientTest
     }
 
     @Test
+    void queryEntities_shouldSendUnboundedRequestWithZeroedBoundsWhenBoundsAreNull(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("query-entities-unbounded.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"tick\":10,\"count\":0,\"entities\":[]}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final var response = client.queryEntities("world", null, null, null, false);
+
+            // verify
+            assertThat(response.tick()).isEqualTo(10L);
+            assertThat(response.count()).isZero();
+            assertThat(server.capturedRequest())
+                .contains("\"action\":\"QUERY_ENTITIES\"")
+                .contains("\"worldName\":\"world\"")
+                .contains("\"bounded\":false")
+                .contains("\"minX\":0")
+                .contains("\"maxZ\":0")
+                .contains("\"countOnly\":false");
+        }
+    }
+
+    @Test
+    void queryEntities_shouldSendBoundedRequestOnlyWhenBothBoundsArePresent(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("query-entities-bounded.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"tick\":1,\"count\":2,\"entities\":[]}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final var response = client.queryEntities(
+                "world", "minecraft:zombie", new BlockPos(0, 1, 2), new BlockPos(10, 11, 12), false);
+
+            // verify
+            assertThat(response.count()).isEqualTo(2);
+            assertThat(server.capturedRequest())
+                .contains("\"action\":\"QUERY_ENTITIES\"")
+                .contains("\"entityTypeKey\":\"minecraft:zombie\"")
+                .contains("\"bounded\":true")
+                .contains("\"minX\":0")
+                .contains("\"minY\":1")
+                .contains("\"minZ\":2")
+                .contains("\"maxX\":10")
+                .contains("\"maxY\":11")
+                .contains("\"maxZ\":12");
+        }
+    }
+
+    @Test
+    void queryEntities_shouldTreatOneNullBoundAsUnbounded(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup — only one of the two bounds present must not be sent as a bounded query
+        final Path socketPath = tempDirectory.resolve("query-entities-partial-bounds.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"tick\":1,\"count\":0,\"entities\":[]}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            client.queryEntities("world", null, new BlockPos(0, 1, 2), null, false);
+
+            // verify
+            assertThat(server.capturedRequest())
+                .contains("\"bounded\":false")
+                .contains("\"minX\":0")
+                .contains("\"minY\":0")
+                .contains("\"minZ\":0");
+        }
+    }
+
+    @Test
+    void queryEntities_shouldSendCountOnlyFlag(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("query-entities-count-only.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":true,\"tick\":1,\"count\":5,\"entities\":[]}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson);
+             UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3)))
+        {
+            // execute
+            final var response = client.queryEntities("world", null, null, null, true);
+
+            // verify
+            assertThat(response.count()).isEqualTo(5);
+            assertThat(server.capturedRequest()).contains("\"countOnly\":true");
+        }
+    }
+
+    @Test
     void hasPlayerPermission_shouldReturnFalseFromResponse(@TempDir Path tempDirectory)
         throws Exception
     {

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperEntityQueryIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperEntityQueryIT.java
@@ -1,0 +1,132 @@
+package nl.pim16aap2.lightkeeper.maven.test;
+
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
+import nl.pim16aap2.lightkeeper.framework.CommandResult;
+import nl.pim16aap2.lightkeeper.framework.EntitySnapshot;
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
+import nl.pim16aap2.lightkeeper.framework.Vec3;
+import nl.pim16aap2.lightkeeper.framework.WorldHandle;
+import nl.pim16aap2.lightkeeper.framework.WorldSpec;
+import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
+import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.eventually;
+
+@ExtendWith(LightkeeperExtension.class)
+class LightkeeperEntityQueryIT
+{
+    private static final String BLOCK_DISPLAY = "minecraft:block_display";
+
+    @Test
+    void entities_shouldCountAndSnapshotSummonedDisplayEntity(ILightkeeperFramework framework)
+    {
+        // setup — a fresh world isolates the query from other tests; natural mob spawning is not suppressed,
+        // so every query filters on the display type only this test summons. All transform components are
+        // binary-exact floats so the float-to-double comparison below is exact. The target chunk must be
+        // force-loaded: a playerless world unloads its chunks (and their entities) right after the summon
+        // command's temporary chunk ticket expires, and entity queries only see loaded chunks.
+        final WorldHandle world = framework.newWorld(new WorldSpec(
+            "lk_entityquery_" + UUID.randomUUID().toString().replace("-", ""),
+            WorldSpec.WorldType.FLAT,
+            WorldSpec.WorldEnvironment.NORMAL,
+            99L
+        ));
+        final CommandResult forceloadResult = framework.executeCommand(
+            CommandSource.CONSOLE,
+            "execute in minecraft:%s run forceload add 8 8".formatted(world.name()));
+        assertThat(forceloadResult.success()).isTrue();
+        final String summonCommand = (
+            "execute in minecraft:%s run summon minecraft:block_display 8.5 100.0 8.5 "
+                + "{CustomName:\"lk-display\",block_state:{Name:\"minecraft:stone\"},transformation:{"
+                + "translation:[0.25f,0.5f,0.75f],scale:[2.0f,3.0f,4.0f],"
+                + "left_rotation:[0.0f,0.0f,0.0f,1.0f],right_rotation:[0.0f,1.0f,0.0f,0.0f]}}"
+        ).formatted(world.name());
+
+        // execute
+        final CommandResult summonResult = framework.executeCommand(CommandSource.CONSOLE, summonCommand);
+
+        // verify
+        assertThat(summonResult.success()).isTrue();
+        eventually(Duration.ofSeconds(10), () ->
+            assertThat(world.entities().ofType(BLOCK_DISPLAY).count()).isEqualTo(1));
+
+        final List<EntitySnapshot> snapshots = world.entities().ofType(BLOCK_DISPLAY).snapshot();
+        assertThat(snapshots).hasSize(1);
+        final EntitySnapshot snapshot = snapshots.getFirst();
+        assertThat(snapshot.uuid()).isNotNull();
+        assertThat(snapshot.typeKey()).isEqualTo(BLOCK_DISPLAY);
+        assertThat(snapshot.position()).isEqualTo(new Vec3(8.5, 100.0, 8.5));
+        assertThat(snapshot.customName()).isEqualTo("lk-display");
+        assertThat(snapshot.pdcKeys()).isEmpty();
+        assertThat(snapshot.tick()).isPositive();
+        assertThat(framework.currentServerTick()).isGreaterThanOrEqualTo(snapshot.tick());
+
+        final EntitySnapshot.Transform transform = snapshot.transform();
+        assertThat(transform).isNotNull();
+        assertThat(transform.translation()).isEqualTo(new Vec3(0.25, 0.5, 0.75));
+        assertThat(transform.scale()).isEqualTo(new Vec3(2.0, 3.0, 4.0));
+        assertThat(transform.leftRotation()).isEqualTo(new EntitySnapshot.Rotation(0.0, 0.0, 0.0, 1.0));
+        assertThat(transform.rightRotation()).isEqualTo(new EntitySnapshot.Rotation(0.0, 1.0, 0.0, 0.0));
+
+        // Spatial bounds: the display sits inside the near box and outside the far box.
+        final var boundedNear = world.entities()
+            .ofType(BLOCK_DISPLAY)
+            .within(new BlockPos(0, 90, 0), new BlockPos(16, 110, 16));
+        final var boundedFar = world.entities()
+            .ofType(BLOCK_DISPLAY)
+            .within(new BlockPos(100, 90, 100), new BlockPos(116, 110, 116));
+        assertThat(boundedNear.count()).isEqualTo(1);
+        assertThat(boundedFar.count()).isZero();
+
+        // Type filtering: no armor stands were summoned, so the same box must be empty for that type.
+        assertThat(world.entities()
+            .ofType("minecraft:armor_stand")
+            .within(new BlockPos(0, 90, 0), new BlockPos(16, 110, 16))
+            .count())
+            .isZero();
+    }
+
+    @Test
+    void snapshot_shouldReturnNullTransformForNonDisplayEntity(ILightkeeperFramework framework)
+    {
+        // setup — armor stands are regular (non-display) entities: Marker:1b and NoGravity:1b pin it in
+        // place so the position assertion is exact. The chunk is force-loaded for the same reason as above:
+        // playerless worlds unload chunks (and their entities) otherwise.
+        final WorldHandle world = framework.newWorld(new WorldSpec(
+            "lk_entityquery_" + UUID.randomUUID().toString().replace("-", ""),
+            WorldSpec.WorldType.FLAT,
+            WorldSpec.WorldEnvironment.NORMAL,
+            99L
+        ));
+        final CommandResult forceloadResult = framework.executeCommand(
+            CommandSource.CONSOLE,
+            "execute in minecraft:%s run forceload add 4 4".formatted(world.name()));
+        assertThat(forceloadResult.success()).isTrue();
+        final String summonCommand =
+            "execute in minecraft:%s run summon minecraft:armor_stand 4.5 100.0 4.5 {Marker:1b,NoGravity:1b}"
+                .formatted(world.name());
+
+        // execute
+        final CommandResult summonResult = framework.executeCommand(CommandSource.CONSOLE, summonCommand);
+
+        // verify
+        assertThat(summonResult.success()).isTrue();
+        eventually(Duration.ofSeconds(10), () ->
+            assertThat(world.entities().ofType("minecraft:armor_stand").count()).isEqualTo(1));
+
+        final List<EntitySnapshot> snapshots = world.entities().ofType("minecraft:armor_stand").snapshot();
+        assertThat(snapshots).hasSize(1);
+        final EntitySnapshot snapshot = snapshots.getFirst();
+        assertThat(snapshot.typeKey()).isEqualTo("minecraft:armor_stand");
+        assertThat(snapshot.position()).isEqualTo(new Vec3(4.5, 100.0, 4.5));
+        assertThat(snapshot.customName()).isNull();
+        assertThat(snapshot.transform()).isNull();
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
@@ -57,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = HasPlayerPermission.Command.class, name = "HAS_PLAYER_PERMISSION"),
     @JsonSubTypes.Type(value = CancelNextEvents.Command.class, name = "CANCEL_NEXT_EVENTS"),
     @JsonSubTypes.Type(value = PlayerChat.Command.class, name = "PLAYER_CHAT"),
+    @JsonSubTypes.Type(value = QueryEntities.Command.class, name = "QUERY_ENTITIES"),
 })
 public sealed interface IAgentCommand<R extends IAgentResponse>
     permits Handshake.Command, MainWorld.Command, NewWorld.Command, ExecuteCommand.Command,
@@ -71,7 +72,7 @@ public sealed interface IAgentCommand<R extends IAgentResponse>
             GetPlayerChatComponents.Command, GetServerPlatform.Command,
             GetServerErrors.Command, ClearServerErrors.Command,
             MutatePlayerPermission.Command, HasPlayerPermission.Command,
-            CancelNextEvents.Command, PlayerChat.Command
+            CancelNextEvents.Command, PlayerChat.Command, QueryEntities.Command
 {
     /**
      * Correlation identifier matching the response's {@code requestId}.

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
@@ -41,6 +41,7 @@ public sealed interface IAgentResponse
     NewWorld.Response,
     PlacePlayerBlock.Response,
     PlayerChat.Response,
+    QueryEntities.Response,
     RegisterEventListener.Response,
     RemovePlayer.Response,
     RightClickBlock.Response,

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
     @JsonSubTypes.Type(value = IProtocolValue.PBool.class, name = "BOOL"),
     @JsonSubTypes.Type(value = IProtocolValue.PUuid.class, name = "UUID"),
     @JsonSubTypes.Type(value = IProtocolValue.PEnum.class, name = "ENUM"),
+    @JsonSubTypes.Type(value = IProtocolValue.PPos.class, name = "POS"),
+    @JsonSubTypes.Type(value = IProtocolValue.PVec.class, name = "VEC"),
     @JsonSubTypes.Type(value = IProtocolValue.PList.class, name = "LIST"),
     @JsonSubTypes.Type(value = IProtocolValue.PRecord.class, name = "RECORD"),
     @JsonSubTypes.Type(value = IProtocolValue.PRef.class, name = "REF"),
@@ -33,7 +35,8 @@ import java.util.stream.Collectors;
 })
 public sealed interface IProtocolValue
     permits IProtocolValue.PString, IProtocolValue.PNumber, IProtocolValue.PBool, IProtocolValue.PUuid,
-            IProtocolValue.PEnum, IProtocolValue.PList, IProtocolValue.PRecord, IProtocolValue.PRef,
+            IProtocolValue.PEnum, IProtocolValue.PPos, IProtocolValue.PVec,
+            IProtocolValue.PList, IProtocolValue.PRecord, IProtocolValue.PRef,
             IProtocolValue.PDropped
 {
     /**
@@ -160,6 +163,44 @@ public sealed interface IProtocolValue
         public String toDisplayString()
         {
             return name;
+        }
+    }
+
+    /**
+     * Integer block coordinates.
+     *
+     * @param x
+     *     X coordinate.
+     * @param y
+     *     Y coordinate.
+     * @param z
+     *     Z coordinate.
+     */
+    record PPos(int x, int y, int z) implements IProtocolValue
+    {
+        @Override
+        public String toDisplayString()
+        {
+            return "(%d, %d, %d)".formatted(x, y, z);
+        }
+    }
+
+    /**
+     * Double-precision position coordinates.
+     *
+     * @param x
+     *     X coordinate.
+     * @param y
+     *     Y coordinate.
+     * @param z
+     *     Z coordinate.
+     */
+    record PVec(double x, double y, double z) implements IProtocolValue
+    {
+        @Override
+        public String toDisplayString()
+        {
+            return "(%s, %s, %s)".formatted(x, y, z);
         }
     }
 

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IProtocolValue.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
     @JsonSubTypes.Type(value = IProtocolValue.PBool.class, name = "BOOL"),
     @JsonSubTypes.Type(value = IProtocolValue.PUuid.class, name = "UUID"),
     @JsonSubTypes.Type(value = IProtocolValue.PEnum.class, name = "ENUM"),
-    @JsonSubTypes.Type(value = IProtocolValue.PPos.class, name = "POS"),
     @JsonSubTypes.Type(value = IProtocolValue.PVec.class, name = "VEC"),
     @JsonSubTypes.Type(value = IProtocolValue.PList.class, name = "LIST"),
     @JsonSubTypes.Type(value = IProtocolValue.PRecord.class, name = "RECORD"),
@@ -35,7 +34,7 @@ import java.util.stream.Collectors;
 })
 public sealed interface IProtocolValue
     permits IProtocolValue.PString, IProtocolValue.PNumber, IProtocolValue.PBool, IProtocolValue.PUuid,
-            IProtocolValue.PEnum, IProtocolValue.PPos, IProtocolValue.PVec,
+            IProtocolValue.PEnum, IProtocolValue.PVec,
             IProtocolValue.PList, IProtocolValue.PRecord, IProtocolValue.PRef,
             IProtocolValue.PDropped
 {
@@ -163,25 +162,6 @@ public sealed interface IProtocolValue
         public String toDisplayString()
         {
             return name;
-        }
-    }
-
-    /**
-     * Integer block coordinates.
-     *
-     * @param x
-     *     X coordinate.
-     * @param y
-     *     Y coordinate.
-     * @param z
-     *     Z coordinate.
-     */
-    record PPos(int x, int y, int z) implements IProtocolValue
-    {
-        @Override
-        public String toDisplayString()
-        {
-            return "(%d, %d, %d)".formatted(x, y, z);
         }
     }
 

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/QueryEntities.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/QueryEntities.java
@@ -1,0 +1,185 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Queries entities in a world, optionally filtered by type and spatial bounds.
+ */
+public final class QueryEntities
+{
+    private QueryEntities()
+    {
+    }
+
+    /**
+     * Command record for {@code QUERY_ENTITIES}.
+     *
+     * @param requestId
+     *     Correlation identifier matching the response's {@code requestId}.
+     * @param worldName
+     *     Name of the world to query.
+     * @param entityTypeKey
+     *     Optional namespaced entity type key to filter by (e.g. {@code minecraft:block_display}).
+     * @param bounded
+     *     Whether the six bound coordinates constrain the query; when {@code false} they are ignored.
+     * @param minX
+     *     Minimum block X (inclusive) when bounded.
+     * @param minY
+     *     Minimum block Y (inclusive) when bounded.
+     * @param minZ
+     *     Minimum block Z (inclusive) when bounded.
+     * @param maxX
+     *     Maximum block X (inclusive) when bounded.
+     * @param maxY
+     *     Maximum block Y (inclusive) when bounded.
+     * @param maxZ
+     *     Maximum block Z (inclusive) when bounded.
+     * @param countOnly
+     *     When {@code true} the response carries only the count, skipping the per-entity payloads — the cheap
+     *     probe shape for retrying assertions.
+     */
+    public record Command(
+        String requestId,
+        String worldName,
+        @Nullable String entityTypeKey,
+        boolean bounded,
+        int minX,
+        int minY,
+        int minZ,
+        int maxX,
+        int maxY,
+        int maxZ,
+        boolean countOnly
+    ) implements IAgentCommand<Response>
+    {
+        /**
+         * Validates command inputs.
+         */
+        public Command
+        {
+            ProtocolPreconditions.requireNonBlank(requestId, "requestId");
+            ProtocolPreconditions.requireNonBlank(worldName, "worldName");
+            if (entityTypeKey != null && entityTypeKey.isBlank())
+                throw new IllegalArgumentException("'entityTypeKey' must not be blank when present.");
+            if (bounded && (minX > maxX || minY > maxY || minZ > maxZ))
+                throw new IllegalArgumentException("Bounds must satisfy min <= max on every axis.");
+        }
+
+        @Override
+        public Class<Response> responseType()
+        {
+            return Response.class;
+        }
+    }
+
+    /**
+     * A single entity's state, read in the same main-thread burst as its siblings.
+     *
+     * @param uuid
+     *     The entity's UUID.
+     * @param typeKey
+     *     Namespaced entity type key.
+     * @param x
+     *     Position X.
+     * @param y
+     *     Position Y.
+     * @param z
+     *     Position Z.
+     * @param customName
+     *     The entity's custom name, or {@code null} when unnamed.
+     * @param pdcKeys
+     *     Namespaced keys present in the entity's persistent data container.
+     * @param transform
+     *     The display transformation for display entities, or {@code null} for all other entities.
+     */
+    public record EntityData(
+        UUID uuid,
+        String typeKey,
+        double x,
+        double y,
+        double z,
+        @Nullable String customName,
+        List<String> pdcKeys,
+        @Nullable TransformData transform
+    )
+    {
+        /**
+         * Validates and defensively copies the fields.
+         */
+        public EntityData
+        {
+            ProtocolPreconditions.requireNonNull(uuid, "uuid");
+            ProtocolPreconditions.requireNonBlank(typeKey, "typeKey");
+            pdcKeys = pdcKeys == null ? List.of() : List.copyOf(pdcKeys);
+        }
+    }
+
+    /**
+     * A display entity's transformation.
+     *
+     * @param translationX
+     *     Translation X.
+     * @param translationY
+     *     Translation Y.
+     * @param translationZ
+     *     Translation Z.
+     * @param scaleX
+     *     Scale X.
+     * @param scaleY
+     *     Scale Y.
+     * @param scaleZ
+     *     Scale Z.
+     * @param leftRotation
+     *     Left rotation quaternion as {@code [x, y, z, w]}.
+     * @param rightRotation
+     *     Right rotation quaternion as {@code [x, y, z, w]}.
+     */
+    public record TransformData(
+        double translationX,
+        double translationY,
+        double translationZ,
+        double scaleX,
+        double scaleY,
+        double scaleZ,
+        List<Double> leftRotation,
+        List<Double> rightRotation
+    )
+    {
+        /**
+         * Validates and defensively copies the rotations.
+         */
+        public TransformData
+        {
+            leftRotation = leftRotation == null ? List.of() : List.copyOf(leftRotation);
+            rightRotation = rightRotation == null ? List.of() : List.copyOf(rightRotation);
+        }
+    }
+
+    /**
+     * Response record for {@code QUERY_ENTITIES}.
+     *
+     * @param tick
+     *     The server tick of the query burst; every entity in {@code entities} was read at this tick.
+     * @param count
+     *     Number of matching entities.
+     * @param entities
+     *     The matching entities' states; empty when the command was count-only.
+     */
+    public record Response(
+        long tick,
+        int count,
+        List<EntityData> entities
+    ) implements IAgentResponse
+    {
+        /**
+         * Defensively copies the entity list.
+         */
+        public Response
+        {
+            entities = entities == null ? List.of() : List.copyOf(entities);
+        }
+    }
+}

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
@@ -355,6 +355,147 @@ class AgentCommandSerializationTest
     }
 
     // -----------------------------------------------------------------------
+    // Round-trip: QueryEntities.Command (bounded, with type filter)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_queryEntitiesCommand_boundedWithTypeFilter_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final QueryEntities.Command original = new QueryEntities.Command(
+            "req-17", "world", "minecraft:block_display", true,
+            0, 1, 2, 10, 11, 12, false
+        );
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        @SuppressWarnings("rawtypes")
+        final IAgentCommand deserialized = mapper.readValue(json, IAgentCommand.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(QueryEntities.Command.class);
+        final QueryEntities.Command result = (QueryEntities.Command) deserialized;
+        assertThat(result.requestId()).isEqualTo("req-17");
+        assertThat(result.worldName()).isEqualTo("world");
+        assertThat(result.entityTypeKey()).isEqualTo("minecraft:block_display");
+        assertThat(result.bounded()).isTrue();
+        assertThat(result.minX()).isEqualTo(0);
+        assertThat(result.minY()).isEqualTo(1);
+        assertThat(result.minZ()).isEqualTo(2);
+        assertThat(result.maxX()).isEqualTo(10);
+        assertThat(result.maxY()).isEqualTo(11);
+        assertThat(result.maxZ()).isEqualTo(12);
+        assertThat(result.countOnly()).isFalse();
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip: QueryEntities.Command (unbounded, no type filter, count-only)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_queryEntitiesCommand_unboundedWithNullTypeFilter_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final QueryEntities.Command original = new QueryEntities.Command(
+            "req-18", "world", null, false,
+            0, 0, 0, 0, 0, 0, true
+        );
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        @SuppressWarnings("rawtypes")
+        final IAgentCommand deserialized = mapper.readValue(json, IAgentCommand.class);
+
+        // verify
+        assertThat(deserialized).isInstanceOf(QueryEntities.Command.class);
+        final QueryEntities.Command result = (QueryEntities.Command) deserialized;
+        assertThat(result.requestId()).isEqualTo("req-18");
+        assertThat(result.entityTypeKey()).isNull();
+        assertThat(result.bounded()).isFalse();
+        assertThat(result.countOnly()).isTrue();
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip: QueryEntities.Response with nested EntityData and TransformData
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_queryEntitiesResponse_withNestedEntityDataAndTransformData_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final UUID entityUuid = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        final QueryEntities.TransformData transformData = new QueryEntities.TransformData(
+            1.0, 2.0, 3.0,
+            1.5, 1.5, 1.5,
+            List.of(0.1, 0.2, 0.3, 0.4),
+            List.of(0.5, 0.6, 0.7, 0.8)
+        );
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            entityUuid, "minecraft:block_display", 10.0, 64.0, -5.0,
+            "Display Name", List.of("plugin:alpha", "plugin:beta"), transformData
+        );
+        final QueryEntities.Response original = new QueryEntities.Response(42L, 1, List.of(entityData));
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final QueryEntities.Response result = mapper.readValue(json, QueryEntities.Response.class);
+
+        // verify
+        assertThat(result.tick()).isEqualTo(42L);
+        assertThat(result.count()).isEqualTo(1);
+        assertThat(result.entities()).containsExactly(entityData);
+        assertThat(result).isEqualTo(original);
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip: QueryEntities.Response with a null-transform entity and empty entity list
+    // -----------------------------------------------------------------------
+
+    @Test
+    void serialize_queryEntitiesResponse_withNullTransformEntity_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final UUID entityUuid = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            entityUuid, "minecraft:zombie", 1.0, 2.0, 3.0, null, List.of(), null
+        );
+        final QueryEntities.Response original = new QueryEntities.Response(7L, 1, List.of(entityData));
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final QueryEntities.Response result = mapper.readValue(json, QueryEntities.Response.class);
+
+        // verify
+        assertThat(result.entities()).singleElement().satisfies(entity ->
+        {
+            assertThat(entity.customName()).isNull();
+            assertThat(entity.transform()).isNull();
+            assertThat(entity.pdcKeys()).isEmpty();
+        });
+    }
+
+    @Test
+    void serialize_queryEntitiesResponse_withEmptyEntities_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final QueryEntities.Response original = new QueryEntities.Response(3L, 0, List.of());
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final QueryEntities.Response result = mapper.readValue(json, QueryEntities.Response.class);
+
+        // verify
+        assertThat(result.tick()).isEqualTo(3L);
+        assertThat(result.count()).isZero();
+        assertThat(result.entities()).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
     // Deserialization from raw JSON: discriminator field selects subtype
     // -----------------------------------------------------------------------
 

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -224,6 +225,108 @@ class AgentCommandValidationTest
         assertThatThrownBy(() -> new PlayerChat.Command("request-1", uuid, "   "))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("message");
+    }
+
+    // -----------------------------------------------------------------------
+    // QueryEntities.Command validation
+    // -----------------------------------------------------------------------
+
+    @Test
+    void queryEntitiesCommand_shouldRejectBlankEntityTypeKeyWhenPresent()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new QueryEntities.Command(
+            "request-1", "world", "   ", false, 0, 0, 0, 0, 0, 0, false))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("entityTypeKey");
+    }
+
+    @Test
+    void queryEntitiesCommand_shouldAllowNullEntityTypeKey()
+    {
+        // setup + execute
+        final QueryEntities.Command command = new QueryEntities.Command(
+            "request-1", "world", null, false, 0, 0, 0, 0, 0, 0, false);
+
+        // verify
+        assertThat(command.entityTypeKey()).isNull();
+    }
+
+    @Test
+    void queryEntitiesCommand_shouldRejectBoundsWhenMinXGreaterThanMaxXAndBounded()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new QueryEntities.Command(
+            "request-1", "world", null, true, 5, 0, 0, 4, 0, 0, false))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Bounds");
+    }
+
+    @Test
+    void queryEntitiesCommand_shouldRejectBoundsWhenMinYGreaterThanMaxYAndBounded()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new QueryEntities.Command(
+            "request-1", "world", null, true, 0, 5, 0, 0, 4, 0, false))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Bounds");
+    }
+
+    @Test
+    void queryEntitiesCommand_shouldRejectBoundsWhenMinZGreaterThanMaxZAndBounded()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new QueryEntities.Command(
+            "request-1", "world", null, true, 0, 0, 5, 0, 0, 4, false))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Bounds");
+    }
+
+    @Test
+    void queryEntitiesCommand_shouldAllowInvertedBoundsWhenUnbounded()
+    {
+        // setup + execute — bounded=false must ignore the (otherwise-invalid) inverted bounds
+        final QueryEntities.Command command = new QueryEntities.Command(
+            "request-1", "world", null, false, 5, 5, 5, 0, 0, 0, false);
+
+        // verify
+        assertThat(command.bounded()).isFalse();
+    }
+
+    @Test
+    void queryEntitiesCommand_shouldAllowEqualMinAndMaxWhenBounded()
+    {
+        // setup + execute — min == max on every axis is a valid single-block bound
+        final QueryEntities.Command command = new QueryEntities.Command(
+            "request-1", "world", null, true, 5, 5, 5, 5, 5, 5, false);
+
+        // verify
+        assertThat(command.bounded()).isTrue();
+    }
+
+    // -----------------------------------------------------------------------
+    // QueryEntities.EntityData validation
+    // -----------------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
+    void entityDataConstructor_shouldRejectNullUuid()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new QueryEntities.EntityData(
+            null, "minecraft:zombie", 0.0, 0.0, 0.0, null, List.of(), null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("uuid");
+    }
+
+    @Test
+    void entityDataConstructor_shouldRejectBlankTypeKey()
+    {
+        // execute + verify
+        assertThatThrownBy(() -> new QueryEntities.EntityData(
+            UUID.randomUUID(), "   ", 0.0, 0.0, 0.0, null, List.of(), null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("typeKey");
     }
 
     // -----------------------------------------------------------------------

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolDefensiveCopyTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolDefensiveCopyTest.java
@@ -102,6 +102,111 @@ class ProtocolDefensiveCopyTest
     }
 
     @Test
+    void pdcKeys_shouldNotExposeEntityDataState()
+    {
+        // setup
+        final List<String> source = new ArrayList<>(List.of("plugin:alpha"));
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            UUID.randomUUID(), "minecraft:zombie", 0.0, 0.0, 0.0, null, source, null);
+
+        // execute
+        source.add("plugin:beta");
+
+        // verify
+        assertThat(entityData.pdcKeys()).containsExactly("plugin:alpha");
+        assertThatThrownBy(() -> entityData.pdcKeys().add("plugin:gamma"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void pdcKeys_shouldDefaultToEmptyListWhenEntityDataConstructedWithNull()
+    {
+        // setup + execute
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            UUID.randomUUID(), "minecraft:zombie", 0.0, 0.0, 0.0, null, null, null);
+
+        // verify
+        assertThat(entityData.pdcKeys()).isEmpty();
+    }
+
+    @Test
+    void leftRotation_shouldNotExposeTransformDataState()
+    {
+        // setup
+        final List<Double> source = new ArrayList<>(List.of(0.1, 0.2, 0.3, 0.4));
+        final QueryEntities.TransformData transformData = new QueryEntities.TransformData(
+            0.0, 0.0, 0.0, 1.0, 1.0, 1.0, source, List.of(0.0, 0.0, 0.0, 1.0));
+
+        // execute
+        source.set(0, 9.9);
+
+        // verify
+        assertThat(transformData.leftRotation()).containsExactly(0.1, 0.2, 0.3, 0.4);
+        assertThatThrownBy(() -> transformData.leftRotation().add(1.0))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rightRotation_shouldNotExposeTransformDataState()
+    {
+        // setup
+        final List<Double> source = new ArrayList<>(List.of(0.5, 0.6, 0.7, 0.8));
+        final QueryEntities.TransformData transformData = new QueryEntities.TransformData(
+            0.0, 0.0, 0.0, 1.0, 1.0, 1.0, List.of(0.0, 0.0, 0.0, 1.0), source);
+
+        // execute
+        source.set(0, 9.9);
+
+        // verify
+        assertThat(transformData.rightRotation()).containsExactly(0.5, 0.6, 0.7, 0.8);
+        assertThatThrownBy(() -> transformData.rightRotation().add(1.0))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void rotations_shouldDefaultToEmptyListWhenTransformDataConstructedWithNull()
+    {
+        // setup + execute
+        final QueryEntities.TransformData transformData = new QueryEntities.TransformData(
+            0.0, 0.0, 0.0, 1.0, 1.0, 1.0, null, null);
+
+        // verify
+        assertThat(transformData.leftRotation()).isEmpty();
+        assertThat(transformData.rightRotation()).isEmpty();
+    }
+
+    @Test
+    void entities_shouldNotExposeQueryEntitiesResponseState()
+    {
+        // setup
+        final QueryEntities.EntityData entityData = new QueryEntities.EntityData(
+            UUID.randomUUID(), "minecraft:zombie", 0.0, 0.0, 0.0, null, List.of(), null);
+        final List<QueryEntities.EntityData> source = new ArrayList<>(List.of(entityData));
+        final QueryEntities.Response response = new QueryEntities.Response(1L, 1, source);
+
+        // execute
+        source.clear();
+
+        // verify
+        assertThat(response.entities()).containsExactly(entityData);
+        assertThatThrownBy(() -> response.entities().add(entityData))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify default-on-null.
+    void entities_shouldDefaultToEmptyListWhenQueryEntitiesResponseConstructedWithNull()
+    {
+        // setup + execute
+        final QueryEntities.Response response = new QueryEntities.Response(1L, 0, null);
+
+        // verify
+        assertThat(response.entities()).isEmpty();
+    }
+
+    @Test
     @SuppressWarnings("NullAway") // Intentionally crosses the non-null API boundary to verify fail-fast validation.
     void response_shouldRejectNullMessages()
     {

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
@@ -104,35 +104,6 @@ class ProtocolValueSerializationTest
     }
 
     @Test
-    void serialize_pPos_roundTrips() throws Exception
-    {
-        // setup
-        final ObjectMapper mapper = AgentProtocolMapper.create();
-        final IProtocolValue.PPos original = new IProtocolValue.PPos(1, -64, 3);
-
-        // execute
-        final String json = mapper.writeValueAsString(original);
-        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
-
-        // verify
-        assertThat(json).contains("\"type\":\"POS\"");
-        assertThat(deserialized).isEqualTo(original);
-    }
-
-    @Test
-    void pPos_toDisplayString_shouldRenderCommaSeparatedCoordinates()
-    {
-        // setup
-        final IProtocolValue.PPos pos = new IProtocolValue.PPos(1, -64, 3);
-
-        // execute
-        final String result = pos.toDisplayString();
-
-        // verify
-        assertThat(result).isEqualTo("(1, -64, 3)");
-    }
-
-    @Test
     void serialize_pVec_roundTrips() throws Exception
     {
         // setup

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/ProtocolValueSerializationTest.java
@@ -104,6 +104,64 @@ class ProtocolValueSerializationTest
     }
 
     @Test
+    void serialize_pPos_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PPos original = new IProtocolValue.PPos(1, -64, 3);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"POS\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void pPos_toDisplayString_shouldRenderCommaSeparatedCoordinates()
+    {
+        // setup
+        final IProtocolValue.PPos pos = new IProtocolValue.PPos(1, -64, 3);
+
+        // execute
+        final String result = pos.toDisplayString();
+
+        // verify
+        assertThat(result).isEqualTo("(1, -64, 3)");
+    }
+
+    @Test
+    void serialize_pVec_roundTrips() throws Exception
+    {
+        // setup
+        final ObjectMapper mapper = AgentProtocolMapper.create();
+        final IProtocolValue.PVec original = new IProtocolValue.PVec(1.5, -64.25, 3.0);
+
+        // execute
+        final String json = mapper.writeValueAsString(original);
+        final IProtocolValue deserialized = mapper.readValue(json, IProtocolValue.class);
+
+        // verify
+        assertThat(json).contains("\"type\":\"VEC\"");
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Test
+    void pVec_toDisplayString_shouldRenderCommaSeparatedCoordinates()
+    {
+        // setup
+        final IProtocolValue.PVec vec = new IProtocolValue.PVec(1.5, -64.25, 3.0);
+
+        // execute
+        final String result = vec.toDisplayString();
+
+        // verify
+        assertThat(result).isEqualTo("(1.5, -64.25, 3.0)");
+    }
+
+    @Test
     void serialize_pList_roundTrips() throws Exception
     {
         // setup

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -20,7 +20,7 @@ public final class RuntimeProtocol
      * in a backward-incompatible way. Both the framework and the agent must agree on this value;
      * a mismatch causes an {@code HANDSHAKE} failure.
      */
-    public static final int VERSION = 8;
+    public static final int VERSION = 9;
 
     /**
      * Minecraft server version supported by this LightKeeper build.


### PR DESCRIPTION
## Why
- S5 of the API v2 roadmap (LK-5): tests need to count and inspect live entities — the missing piece for animation accounting ("N display entities in flight, zero after") and entity-driven assertions (unblocks ANI-16/ANI-17/RED-9).

## How
- New `QUERY_ENTITIES` wire command (protocol v9) with optional type filter, optional inclusive block bounds, and a count-only probe flag; the agent reads all matches in one main-thread burst so every returned entity shares one tick stamp. Bounded queries match by hitbox intersection with the block-inclusive box (the Bukkit nearby-entities semantic), documented on the API.
- Framework side: `world.entities()` returns an immutable, composable `EntityQuery` (`ofType`/`within` build refined copies; `count()` is the cheap `eventually()` probe; `snapshot()` freezes `EntitySnapshot` records incl. the decomposed display `Transformation`). `Location`/`Vector` now encode as `PVec` envelope leaves.
- Pre-PR deep review applied: fail-fast on a lone bound, no double-prefixing of namespaced type keys, speculative `PPos` leaf dropped (no producer), hitbox-overlap semantic documented.

## Tests
- `mvn --batch-mode -Perrorprone clean verify checkstyle:checkstyle pmd:check` → BUILD SUCCESS (full reactor: unit tests + Paper & Spigot IT lanes + checkstyle + PMD).
- 74 new unit tests across protocol (round-trips, validation, defensive copies), agent (burst handler, bounds box construction, type normalization, transform mapping, `PVec` encoder leaves incl. depth-exhaustion), and framework (query composition, mapping, tick threading, fail-loud quaternion check).
- New `LightkeeperEntityQueryIT`: summons a block_display with an explicit transformation and asserts count/snapshot/transform plus bounded and type-filtered counts; armor stand asserts the null-transform path. Chunks are force-loaded — playerless worlds unload chunks (and their entities) otherwise; documented on `EntityQuery`.

## Notes / follow-up
- Known diagnosability gap (pre-existing, observed during development): an `Error` (e.g. `NoSuchMethodError`) thrown inside a main-thread handler can surface to the client as `REQUEST_FAILED: Cannot invoke IAgentResponse.getClass() because "response" is null`, masking the original linkage error. Worth its own investigation/fix outside this slice.
- `EntityType#getKeyOrThrow()` deliberately NOT used: it exists in the Spigot API jar only — Paper's `EntityType` lacks it at runtime (verified via javap against both 1.21.11 API jars; the Paper IT lane fails with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added entity queries for counting or retrieving matching entities.
  - Supports optional filtering by entity type and axis-aligned bounding ranges.
  - Added immutable entity snapshots (UUID, position, optional custom name, PDC keys, display transforms when applicable) captured consistently with a server tick.
  - Enhanced protocol encoding to handle vector and location values.
- **Documentation**
  - Updated the README to describe entity query assertions and snapshot behavior.
- **Tests**
  - Added unit and integration test coverage for queries, snapshot mapping, and encoding/serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->