### PR TITLE
Add method to retrieve server plugin information

### DIFF
--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcher.java
@@ -1,9 +1,7 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
-import tools.jackson.core.JacksonException;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.exc.ValueInstantiationException;
+import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
+import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
 import nl.pim16aap2.lightkeeper.protocol.CancelNextEvents;
 import nl.pim16aap2.lightkeeper.protocol.ClearCapturedEvents;
@@ -21,13 +19,12 @@ import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessages;
 import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.GetServerPlatform;
+import nl.pim16aap2.lightkeeper.protocol.GetServerPlugins;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.Handshake;
 import nl.pim16aap2.lightkeeper.protocol.HasPlayerPermission;
 import nl.pim16aap2.lightkeeper.protocol.IAgentCommand;
 import nl.pim16aap2.lightkeeper.protocol.IAgentResponse;
-import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
-import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import nl.pim16aap2.lightkeeper.protocol.IsChunkLoaded;
 import nl.pim16aap2.lightkeeper.protocol.LeftClickBlock;
 import nl.pim16aap2.lightkeeper.protocol.LoadChunk;
@@ -47,6 +44,10 @@ import nl.pim16aap2.lightkeeper.protocol.UnloadChunk;
 import nl.pim16aap2.lightkeeper.protocol.UnregisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicks;
 import org.bukkit.Bukkit;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.ValueInstantiationException;
 
 import java.util.Objects;
 import java.util.logging.Level;
@@ -146,8 +147,7 @@ final class AgentRequestDispatcher
      *     Raw JSON request line.
      * @param handshakeCompleted
      *     Whether the current connection has already completed handshake successfully.
-     * @return
-     *     Dispatch result containing response JSON and updated handshake state.
+     * @return Dispatch result containing response JSON and updated handshake state.
      */
     RequestDispatchResult handleRequestLine(String line, boolean handshakeCompleted)
     {
@@ -157,8 +157,8 @@ final class AgentRequestDispatcher
         {
             final JsonNode tree = objectMapper.readTree(line);
             requestId = tree.path("requestId").asString("unknown");
-            @SuppressWarnings("rawtypes")
-            final IAgentCommand command = objectMapper.treeToValue(tree, IAgentCommand.class);
+            @SuppressWarnings("rawtypes") final IAgentCommand command = objectMapper.treeToValue(tree,
+                IAgentCommand.class);
             return dispatchCommand(command, handshakeCompleted);
         }
         catch (ValueInstantiationException exception)
@@ -211,8 +211,7 @@ final class AgentRequestDispatcher
      *     Parsed protocol command.
      * @param handshakeCompleted
      *     Current connection handshake state.
-     * @return
-     *     Dispatch result containing response JSON and updated handshake state.
+     * @return Dispatch result containing response JSON and updated handshake state.
      */
     @SuppressWarnings("rawtypes")
     private RequestDispatchResult dispatchCommand(IAgentCommand command, boolean handshakeCompleted)
@@ -246,43 +245,45 @@ final class AgentRequestDispatcher
             // fails to compile rather than silently deserializing into the wrong record on the client.
             final IAgentResponse response = switch (command)
             {
-                case MainWorld.Command c -> handle(c, worldActions::handleMainWorld);
-                case NewWorld.Command c -> handle(c, worldActions::handleNewWorld);
-                case ExecuteCommand.Command c -> handle(c, worldActions::handleExecuteCommand);
                 case BlockType.Command c -> handle(c, worldActions::handleBlockType);
-                case SetBlock.Command c -> handle(c, worldActions::handleSetBlock);
-                case CreatePlayer.Command c -> handle(c, playerActions::handleCreatePlayer);
-                case RemovePlayer.Command c -> handle(c, playerActions::handleRemovePlayer);
-                case ExecutePlayerCommand.Command c -> handle(c, playerActions::handleExecutePlayerCommand);
-                case PlacePlayerBlock.Command c -> handle(c, playerActions::handlePlacePlayerBlock);
-                case LeftClickBlock.Command c -> handle(c, playerActions::handleLeftClickBlock);
-                case RightClickBlock.Command c -> handle(c, playerActions::handleRightClickBlock);
-                case GetOpenMenu.Command c -> handle(c, menuActions::handleGetOpenMenu);
-                case ClickMenuSlot.Command c -> handle(c, menuActions::handleClickMenuSlot);
-                case DragMenuSlots.Command c -> handle(c, menuActions::handleDragMenuSlots);
-                case GetPlayerMessages.Command c -> handle(c, playerStateActions::handleGetPlayerMessages);
-                case WaitTicks.Command c -> handle(c, worldActions::handleWaitTicks);
-                case GetServerTick.Command c -> handle(c, worldActions::handleGetServerTick);
-                case TeleportPlayer.Command c -> handle(c, playerActions::handleTeleportPlayer);
-                case LoadChunk.Command c -> handle(c, worldActions::handleLoadChunk);
-                case UnloadChunk.Command c -> handle(c, worldActions::handleUnloadChunk);
-                case IsChunkLoaded.Command c -> handle(c, worldActions::handleIsChunkLoaded);
-                case GetPlayerInventory.Command c -> handle(c, playerStateActions::handleGetPlayerInventory);
-                case DropItem.Command c -> handle(c, playerStateActions::handleDropItem);
-                case RegisterEventListener.Command c -> handle(c, eventActions::handleRegisterEventListener);
-                case GetCapturedEvents.Command c -> handle(c, eventActions::handleGetCapturedEvents);
-                case ClearCapturedEvents.Command c -> handle(c, eventActions::handleClearCapturedEvents);
-                case UnregisterEventListener.Command c -> handle(c, eventActions::handleUnregisterEventListener);
-                case GetPlayerChatComponents.Command c -> handle(c, playerStateActions::handleGetPlayerChatComponents);
-                case GetServerPlatform.Command c -> handle(c, worldActions::handleGetServerPlatform);
-                case GetServerErrors.Command c -> handle(c, serverErrorActions::handleGetServerErrors);
-                case ClearServerErrors.Command c -> handle(c, serverErrorActions::handleClearServerErrors);
-                case MutatePlayerPermission.Command c -> handle(c, playerActions::handleMutatePlayerPermission);
-                case HasPlayerPermission.Command c -> handle(c, playerActions::handleHasPlayerPermission);
                 case CancelNextEvents.Command c -> handle(c, eventActions::handleCancelNextEvents);
+                case ClearCapturedEvents.Command c -> handle(c, eventActions::handleClearCapturedEvents);
+                case ClearServerErrors.Command c -> handle(c, serverErrorActions::handleClearServerErrors);
+                case ClickMenuSlot.Command c -> handle(c, menuActions::handleClickMenuSlot);
+                case CreatePlayer.Command c -> handle(c, playerActions::handleCreatePlayer);
+                case DragMenuSlots.Command c -> handle(c, menuActions::handleDragMenuSlots);
+                case DropItem.Command c -> handle(c, playerStateActions::handleDropItem);
+                case ExecuteCommand.Command c -> handle(c, worldActions::handleExecuteCommand);
+                case ExecutePlayerCommand.Command c -> handle(c, playerActions::handleExecutePlayerCommand);
+                case GetCapturedEvents.Command c -> handle(c, eventActions::handleGetCapturedEvents);
+                case GetOpenMenu.Command c -> handle(c, menuActions::handleGetOpenMenu);
+                case GetPlayerChatComponents.Command c -> handle(c, playerStateActions::handleGetPlayerChatComponents);
+                case GetPlayerInventory.Command c -> handle(c, playerStateActions::handleGetPlayerInventory);
+                case GetPlayerMessages.Command c -> handle(c, playerStateActions::handleGetPlayerMessages);
+                case GetServerErrors.Command c -> handle(c, serverErrorActions::handleGetServerErrors);
+                case GetServerPlatform.Command c -> handle(c, worldActions::handleGetServerPlatform);
+                case GetServerPlugins.Command c -> handle(c, worldActions::handleGetServerPlugins);
+                case GetServerTick.Command c -> handle(c, worldActions::handleGetServerTick);
+                case HasPlayerPermission.Command c -> handle(c, playerActions::handleHasPlayerPermission);
+                case IsChunkLoaded.Command c -> handle(c, worldActions::handleIsChunkLoaded);
+                case LeftClickBlock.Command c -> handle(c, playerActions::handleLeftClickBlock);
+                case LoadChunk.Command c -> handle(c, worldActions::handleLoadChunk);
+                case MainWorld.Command c -> handle(c, worldActions::handleMainWorld);
+                case MutatePlayerPermission.Command c -> handle(c, playerActions::handleMutatePlayerPermission);
+                case NewWorld.Command c -> handle(c, worldActions::handleNewWorld);
+                case PlacePlayerBlock.Command c -> handle(c, playerActions::handlePlacePlayerBlock);
                 case PlayerChat.Command c -> handle(c, playerActions::handlePlayerChat);
                 case QueryEntities.Command c -> handle(c, worldActions::handleQueryEntities);
+                case RegisterEventListener.Command c -> handle(c, eventActions::handleRegisterEventListener);
+                case RemovePlayer.Command c -> handle(c, playerActions::handleRemovePlayer);
+                case RightClickBlock.Command c -> handle(c, playerActions::handleRightClickBlock);
+                case SetBlock.Command c -> handle(c, worldActions::handleSetBlock);
                 case TabCompletePlayer.Command c -> handle(c, playerActions::handleTabCompletePlayer);
+                case TeleportPlayer.Command c -> handle(c, playerActions::handleTeleportPlayer);
+                case UnloadChunk.Command c -> handle(c, worldActions::handleUnloadChunk);
+                case UnregisterEventListener.Command c -> handle(c, eventActions::handleUnregisterEventListener);
+                case WaitTicks.Command c -> handle(c, worldActions::handleWaitTicks);
+
                 case Handshake.Command ignored ->
                     throw new IllegalStateException("Unreachable HANDSHAKE dispatch branch.");
             };
@@ -354,8 +355,8 @@ final class AgentRequestDispatcher
     }
 
     /**
-     * Invokes a command handler, constraining at compile time that the handler returns the response type the
-     * command declares via {@code IAgentCommand<R>}. A mispaired handler therefore fails to compile.
+     * Invokes a command handler, constraining at compile time that the handler returns the response type the command
+     * declares via {@code IAgentCommand<R>}. A mispaired handler therefore fails to compile.
      *
      * @param command
      *     The parsed command to handle.
@@ -366,6 +367,7 @@ final class AgentRequestDispatcher
      * @param <R>
      *     The response type the command is paired with.
      * @return The handler's response.
+     *
      * @throws Exception
      *     Propagates handler failures.
      */
@@ -392,10 +394,12 @@ final class AgentRequestDispatcher
          * @param command
          *     The command to handle.
          * @return The typed response.
+         *
          * @throws Exception
          *     Propagates handler failures.
          */
-        R handle(C command) throws Exception;
+        R handle(C command)
+            throws Exception;
     }
 
     /**
@@ -403,8 +407,8 @@ final class AgentRequestDispatcher
      *
      * @param command
      *     Handshake command containing token, protocol version, and agent hash.
-     * @return
-     *     Success response when validation succeeds.
+     * @return Success response when validation succeeds.
+     *
      * @throws AgentProtocolException
      *     When token, protocol version, or agent SHA validation fails.
      */
@@ -441,8 +445,7 @@ final class AgentRequestDispatcher
      *     Human-readable error message.
      * @param handshakeCompleted
      *     Current handshake state to propagate.
-     * @return
-     *     Error dispatch result.
+     * @return Error dispatch result.
      */
     private RequestDispatchResult buildErrorResult(
         String requestId,

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -501,13 +501,13 @@ final class AgentWorldActions
 
         final List<ServerPluginSnapshot> serverPlugins = plugins.stream()
             .filter(Objects::nonNull)
-            .map(this::toServerPluginSnapshot)
+            .map(AgentWorldActions::toServerPluginSnapshot)
             .toList();
 
         return new GetServerPlugins.Response(serverPlugins);
     }
 
-    private ServerPluginSnapshot toServerPluginSnapshot(Plugin plugin)
+    static ServerPluginSnapshot toServerPluginSnapshot(Plugin plugin)
     {
         return new ServerPluginSnapshot(
             plugin.getName(),

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -5,12 +5,14 @@ import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
 import nl.pim16aap2.lightkeeper.protocol.ExecuteCommand;
 import nl.pim16aap2.lightkeeper.protocol.GetServerPlatform;
+import nl.pim16aap2.lightkeeper.protocol.GetServerPlugins;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.IsChunkLoaded;
 import nl.pim16aap2.lightkeeper.protocol.LoadChunk;
 import nl.pim16aap2.lightkeeper.protocol.MainWorld;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
+import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
 import nl.pim16aap2.lightkeeper.protocol.SetBlock;
 import nl.pim16aap2.lightkeeper.protocol.UnloadChunk;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicks;
@@ -22,14 +24,18 @@ import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Transformation;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -89,8 +95,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying the request identifier.
-     * @return
-     *     Response containing {@code worldName}.
+     * @return Response containing {@code worldName}.
+     *
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -106,8 +112,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying world name, type, environment, and seed.
-     * @return
-     *     Response containing resolved world name.
+     * @return Response containing resolved world name.
+     *
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -143,8 +149,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying command source and command string.
-     * @return
-     *     Response with command execution result.
+     * @return Response with command execution result.
+     *
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -168,8 +174,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying world name and block coordinates.
-     * @return
-     *     Response containing the resolved block material.
+     * @return Response containing the resolved block material.
+     *
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -199,8 +205,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying world name, block coordinates, and material key.
-     * @return
-     *     Response containing resulting material name.
+     * @return Response containing resulting material name.
+     *
      * @throws Exception
      *     Propagates validation and main-thread execution failures.
      */
@@ -236,17 +242,17 @@ final class AgentWorldActions
     }
 
     /**
-     * Handles {@code QUERY_ENTITIES} by reading all matching entities in one main-thread burst, so the
-     * returned states are internally consistent and share one tick stamp.
+     * Handles {@code QUERY_ENTITIES} by reading all matching entities in one main-thread burst, so the returned states
+     * are internally consistent and share one tick stamp.
      *
      * <p>Bounded queries match by hitbox intersection with the block-inclusive box (each max axis is
-     * extended by one so block coordinates span their full world-space cell), per the Bukkit
-     * nearby-entities semantic — not by position containment.
+     * extended by one so block coordinates span their full world-space cell), per the Bukkit nearby-entities semantic —
+     * not by position containment.
      *
      * @param command
      *     Typed command carrying world name, optional type filter, optional bounds, and the count-only flag.
-     * @return
-     *     Response with the match count and (unless count-only) the entity states.
+     * @return Response with the match count and (unless count-only) the entity states.
+     *
      * @throws Exception
      *     Propagates validation and main-thread execution failures.
      */
@@ -266,8 +272,8 @@ final class AgentWorldActions
 
             final Collection<Entity> candidates = command.bounded()
                 ? world.getNearbyEntities(new BoundingBox(
-                    command.minX(), command.minY(), command.minZ(),
-                    command.maxX() + 1.0, command.maxY() + 1.0, command.maxZ() + 1.0))
+                command.minX(), command.minY(), command.minZ(),
+                command.maxX() + 1.0, command.maxY() + 1.0, command.maxZ() + 1.0))
                 : world.getEntities();
 
             final List<QueryEntities.EntityData> matches = new ArrayList<>();
@@ -334,8 +340,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying the number of ticks to wait.
-     * @return
-     *     Response with start/end tick values.
+     * @return Response with start/end tick values.
+     *
      * @throws AgentProtocolException
      *     On invalid arguments, timeout, or interruption.
      */
@@ -378,8 +384,7 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying the request identifier.
-     * @return
-     *     Response with current tick counter value.
+     * @return Response with current tick counter value.
      */
     GetServerTick.Response handleGetServerTick(GetServerTick.Command command)
     {
@@ -391,8 +396,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Response with whether the chunk was loaded.
+     * @return Response with whether the chunk was loaded.
+     *
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -419,8 +424,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Response with whether the chunk was unloaded.
+     * @return Response with whether the chunk was unloaded.
+     *
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -447,8 +452,8 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying world name and chunk coordinates.
-     * @return
-     *     Response with {@code loaded} boolean.
+     * @return Response with {@code loaded} boolean.
+     *
      * @throws Exception
      *     Propagates main-thread execution failures.
      */
@@ -475,11 +480,41 @@ final class AgentWorldActions
      *
      * @param command
      *     Typed command carrying the request identifier.
-     * @return
-     *     Response containing the canonical platform identifier.
+     * @return Response containing the canonical platform identifier.
      */
     GetServerPlatform.Response handleGetServerPlatform(GetServerPlatform.Command command)
     {
         return new GetServerPlatform.Response(AgentPlatformDetector.detect());
+    }
+
+    GetServerPlugins.Response handleGetServerPlugins(GetServerPlugins.Command command)
+    {
+        final List<@Nullable Plugin> plugins;
+        if (command.name() != null)
+        {
+            plugins = Collections.singletonList(Bukkit.getPluginManager().getPlugin(command.name()));
+        }
+        else
+        {
+            plugins = Arrays.asList(Bukkit.getPluginManager().getPlugins());
+        }
+
+        final List<ServerPlugin> serverPlugins = plugins.stream()
+            .filter(Objects::nonNull)
+            .map(this::toServerPlugin)
+            .toList();
+
+        return new GetServerPlugins.Response(serverPlugins);
+    }
+
+    private ServerPlugin toServerPlugin(Plugin plugin)
+    {
+        return new ServerPlugin(
+            plugin.getName(),
+            plugin.getDescription().getVersion(),
+            plugin.getDescription().getDescription(),
+            plugin.getDescription().getAuthors(),
+            plugin.isEnabled()
+        );
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActions.java
@@ -12,7 +12,7 @@ import nl.pim16aap2.lightkeeper.protocol.LoadChunk;
 import nl.pim16aap2.lightkeeper.protocol.MainWorld;
 import nl.pim16aap2.lightkeeper.protocol.NewWorld;
 import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
-import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
+import nl.pim16aap2.lightkeeper.protocol.ServerPluginSnapshot;
 import nl.pim16aap2.lightkeeper.protocol.SetBlock;
 import nl.pim16aap2.lightkeeper.protocol.UnloadChunk;
 import nl.pim16aap2.lightkeeper.protocol.WaitTicks;
@@ -499,17 +499,17 @@ final class AgentWorldActions
             plugins = Arrays.asList(Bukkit.getPluginManager().getPlugins());
         }
 
-        final List<ServerPlugin> serverPlugins = plugins.stream()
+        final List<ServerPluginSnapshot> serverPlugins = plugins.stream()
             .filter(Objects::nonNull)
-            .map(this::toServerPlugin)
+            .map(this::toServerPluginSnapshot)
             .toList();
 
         return new GetServerPlugins.Response(serverPlugins);
     }
 
-    private ServerPlugin toServerPlugin(Plugin plugin)
+    private ServerPluginSnapshot toServerPluginSnapshot(Plugin plugin)
     {
-        return new ServerPlugin(
+        return new ServerPluginSnapshot(
             plugin.getName(),
             plugin.getDescription().getVersion(),
             plugin.getDescription().getDescription(),

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -434,6 +434,7 @@ class AgentRequestDispatcherTest
         dispatchExpectingSuccess(fixture, toJson(new CancelNextEvents.Command(
             "request-33", "org.bukkit.event.player.PlayerJoinEvent", 1)));
         dispatchExpectingSuccess(fixture, toJson(new PlayerChat.Command("request-34", uuid, "hello")));
+        dispatchExpectingSuccess(fixture, toJson(new GetServerPlugins.Command("request-35", "plugin-name")));
 
         // verify
         verify(fixture.worldActions()).handleNewWorld(any(NewWorld.Command.class));

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -1,7 +1,5 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
 import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
 import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
@@ -25,6 +23,7 @@ import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessages;
 import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.GetServerPlatform;
+import nl.pim16aap2.lightkeeper.protocol.GetServerPlugins;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.Handshake;
 import nl.pim16aap2.lightkeeper.protocol.HasPlayerPermission;
@@ -50,6 +49,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -347,6 +348,8 @@ class AgentRequestDispatcherTest
             .thenReturn(new UnloadChunk.Response(true));
         when(fixture.worldActions().handleIsChunkLoaded(any(IsChunkLoaded.Command.class)))
             .thenReturn(new IsChunkLoaded.Response(true));
+        when(fixture.worldActions().handleGetServerPlugins(any(GetServerPlugins.Command.class)))
+            .thenReturn(new GetServerPlugins.Response(java.util.List.of()));
         when(fixture.playerStateActions().handleGetPlayerInventory(any(GetPlayerInventory.Command.class)))
             .thenReturn(new GetPlayerInventory.Response(java.util.List.of()));
         when(fixture.playerStateActions().handleDropItem(any(DropItem.Command.class)))
@@ -378,18 +381,32 @@ class AgentRequestDispatcherTest
 
         // execute
         dispatchExpectingSuccess(fixture, toJson(new NewWorld.Command("request-1", "w", "NORMAL", "NORMAL", 0L)));
-        dispatchExpectingSuccess(fixture, toJson(new ExecuteCommand.Command("request-2", CommandSource.CONSOLE, "time set day")));
+        dispatchExpectingSuccess(fixture,
+            toJson(new ExecuteCommand.Command("request-2", CommandSource.CONSOLE, "time set day")));
         dispatchExpectingSuccess(fixture, toJson(new BlockType.Command("request-3", "world", 0, 64, 0)));
         dispatchExpectingSuccess(fixture, toJson(new SetBlock.Command("request-4", "world", 0, 64, 0, "stone", null)));
-        dispatchExpectingSuccess(fixture, toJson(new CreatePlayer.Command("request-5", "bot", uuid, "world", null, null, null, null, null, JoinMode.LEGACY_SPAWN, null)));
+        dispatchExpectingSuccess(fixture,
+            toJson(new CreatePlayer.Command("request-5",
+                "bot",
+                uuid,
+                "world",
+                null,
+                null,
+                null,
+                null,
+                null,
+                JoinMode.LEGACY_SPAWN,
+                null)));
         dispatchExpectingSuccess(fixture, toJson(new RemovePlayer.Command("request-6", uuid)));
-        dispatchExpectingSuccess(fixture, toJson(new ExecutePlayerCommand.Command("request-7", uuid, "gamemode creative")));
+        dispatchExpectingSuccess(fixture,
+            toJson(new ExecutePlayerCommand.Command("request-7", uuid, "gamemode creative")));
         dispatchExpectingSuccess(fixture, toJson(new PlacePlayerBlock.Command("request-8", uuid, "stone", 0, 64, 0)));
         dispatchExpectingSuccess(fixture, toJson(new LeftClickBlock.Command("request-9", uuid, 0, 64, 0, "UP")));
         dispatchExpectingSuccess(fixture, toJson(new RightClickBlock.Command("request-10", uuid, 0, 64, 0, "UP")));
         dispatchExpectingSuccess(fixture, toJson(new GetOpenMenu.Command("request-11", uuid)));
         dispatchExpectingSuccess(fixture, toJson(new ClickMenuSlot.Command("request-12", uuid, 0)));
-        dispatchExpectingSuccess(fixture, toJson(new DragMenuSlots.Command("request-13", uuid, "stone", new int[]{0, 1})));
+        dispatchExpectingSuccess(fixture,
+            toJson(new DragMenuSlots.Command("request-13", uuid, "stone", new int[]{0, 1})));
         dispatchExpectingSuccess(fixture, toJson(new GetPlayerMessages.Command("request-14", uuid)));
         dispatchExpectingSuccess(fixture, toJson(new WaitTicks.Command("request-15", 0)));
         dispatchExpectingSuccess(fixture, toJson(new GetServerTick.Command("request-16")));
@@ -399,10 +416,14 @@ class AgentRequestDispatcherTest
         dispatchExpectingSuccess(fixture, toJson(new IsChunkLoaded.Command("request-20", "world", 0, 0)));
         dispatchExpectingSuccess(fixture, toJson(new GetPlayerInventory.Command("request-21", uuid)));
         dispatchExpectingSuccess(fixture, toJson(new DropItem.Command("request-22", uuid)));
-        dispatchExpectingSuccess(fixture, toJson(new RegisterEventListener.Command("request-23", "org.bukkit.event.player.PlayerJoinEvent")));
-        dispatchExpectingSuccess(fixture, toJson(new GetCapturedEvents.Command("request-24", "org.bukkit.event.player.PlayerJoinEvent")));
-        dispatchExpectingSuccess(fixture, toJson(new ClearCapturedEvents.Command("request-25", "org.bukkit.event.player.PlayerJoinEvent")));
-        dispatchExpectingSuccess(fixture, toJson(new UnregisterEventListener.Command("request-26", "org.bukkit.event.player.PlayerJoinEvent")));
+        dispatchExpectingSuccess(fixture,
+            toJson(new RegisterEventListener.Command("request-23", "org.bukkit.event.player.PlayerJoinEvent")));
+        dispatchExpectingSuccess(fixture,
+            toJson(new GetCapturedEvents.Command("request-24", "org.bukkit.event.player.PlayerJoinEvent")));
+        dispatchExpectingSuccess(fixture,
+            toJson(new ClearCapturedEvents.Command("request-25", "org.bukkit.event.player.PlayerJoinEvent")));
+        dispatchExpectingSuccess(fixture,
+            toJson(new UnregisterEventListener.Command("request-26", "org.bukkit.event.player.PlayerJoinEvent")));
         dispatchExpectingSuccess(fixture, toJson(new GetPlayerChatComponents.Command("request-27", uuid)));
         dispatchExpectingSuccess(fixture, toJson(new GetServerPlatform.Command("request-28")));
         dispatchExpectingSuccess(fixture, toJson(new GetServerErrors.Command("request-29")));
@@ -435,6 +456,7 @@ class AgentRequestDispatcherTest
         verify(fixture.worldActions()).handleLoadChunk(any(LoadChunk.Command.class));
         verify(fixture.worldActions()).handleUnloadChunk(any(UnloadChunk.Command.class));
         verify(fixture.worldActions()).handleIsChunkLoaded(any(IsChunkLoaded.Command.class));
+        verify(fixture.worldActions()).handleGetServerPlugins(any(GetServerPlugins.Command.class));
         verify(fixture.playerStateActions()).handleGetPlayerInventory(any(GetPlayerInventory.Command.class));
         verify(fixture.playerStateActions()).handleDropItem(any(DropItem.Command.class));
         verify(fixture.eventActions()).handleRegisterEventListener(any(RegisterEventListener.Command.class));
@@ -684,8 +706,8 @@ class AgentRequestDispatcherTest
     }
 
     /**
-     * Dispatches a request line and asserts a success response, so a response record whose serialization throws
-     * (which the dispatcher would otherwise swallow into REQUEST_FAILED) is caught rather than hidden.
+     * Dispatches a request line and asserts a success response, so a response record whose serialization throws (which
+     * the dispatcher would otherwise swallow into REQUEST_FAILED) is caught rather than hidden.
      */
     private static void dispatchExpectingSuccess(DispatcherFixture fixture, String requestLine)
     {

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
@@ -192,6 +192,7 @@ class AgentWorldActionsTest
         assertThat(response.loaded()).isTrue();
     }
 
+    @SuppressWarnings("DirectInvocationOnMock")
     private static Plugin stubPlugin(
         String pluginName,
         String pluginVersion,

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentWorldActionsTest.java
@@ -5,6 +5,7 @@ import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import nl.pim16aap2.lightkeeper.protocol.BlockType;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.ExecuteCommand;
+import nl.pim16aap2.lightkeeper.protocol.GetServerPlugins;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.IsChunkLoaded;
 import nl.pim16aap2.lightkeeper.protocol.LoadChunk;
@@ -24,6 +25,8 @@ import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Transformation;
@@ -31,7 +34,9 @@ import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Set;
@@ -39,10 +44,11 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
 
+@ExtendWith(MockitoExtension.class)
 class AgentWorldActionsTest
 {
     @Test
@@ -184,6 +190,93 @@ class AgentWorldActionsTest
 
         // verify
         assertThat(response.loaded()).isTrue();
+    }
+
+    private static Plugin stubPlugin(
+        String pluginName,
+        String pluginVersion,
+        @Nullable String pluginDescription,
+        List<String> authors,
+        boolean pluginEnabled
+    )
+    {
+        final Plugin targetPlugin = mock();
+        when(targetPlugin.getName()).thenReturn(pluginName);
+        when(targetPlugin.getDescription()).thenReturn(mock());
+        when(targetPlugin.getDescription().getVersion()).thenReturn(pluginVersion);
+        when(targetPlugin.getDescription().getDescription()).thenReturn(pluginDescription);
+        when(targetPlugin.getDescription().getAuthors()).thenReturn(authors);
+        when(targetPlugin.isEnabled()).thenReturn(pluginEnabled);
+        return targetPlugin;
+    }
+
+    @Test
+    void handleGetServerPlugins_shouldReturnNamedPluginWhenNameIsProvided()
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+
+        final String pluginName = "requested-plugin";
+        final String pluginVersion = "12";
+        final String pluginDescription = "requested-plugin-description";
+        final List<String> authors = List.of("author0", "author1", "author2");
+        final boolean pluginEnabled = true;
+
+        final Plugin targetPlugin = stubPlugin(
+            pluginName,
+            pluginVersion,
+            pluginDescription,
+            authors,
+            pluginEnabled
+        );
+
+        final GetServerPlugins.Command command = new GetServerPlugins.Command("req-id", pluginName);
+
+        final PluginManager pluginManager = mock();
+        when(pluginManager.getPlugin(pluginName)).thenReturn(targetPlugin);
+
+        // execute
+        final GetServerPlugins.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            response = worldActions.handleGetServerPlugins(command);
+        }
+
+        // verify
+        assertThat(response.plugins())
+            .containsExactly(AgentWorldActions.toServerPluginSnapshot(targetPlugin));
+
+        verify(pluginManager, never()).getPlugins();
+    }
+
+    @Test
+    void handleGetServerPlugins_shouldReturnAllPluginsWhenNameIsNotProvided()
+    {
+        // setup
+        final AgentWorldActions worldActions = createWorldActions(new AtomicLong());
+
+        final Plugin plugin0 = stubPlugin("plugin1", "0.1", "desc0", List.of("authorA", "Author B"), true);
+        final Plugin plugin1 = stubPlugin("plugin2", "2.0", null, List.of(), false);
+
+        final PluginManager pluginManager = mock();
+        when(pluginManager.getPlugins()).thenReturn(new Plugin[]{plugin0, plugin1});
+
+        final GetServerPlugins.Command command = new GetServerPlugins.Command("req-id", null);
+
+        // execute
+        final GetServerPlugins.Response response;
+        try (MockedStatic<Bukkit> bukkitMockedStatic = mockStatic(Bukkit.class))
+        {
+            bukkitMockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            response = worldActions.handleGetServerPlugins(command);
+        }
+
+        // verify
+        assertThat(response.plugins()).containsExactlyInAnyOrder(
+            AgentWorldActions.toServerPluginSnapshot(plugin0),
+            AgentWorldActions.toServerPluginSnapshot(plugin1)
+        );
     }
 
     @Test
@@ -568,8 +661,9 @@ class AgentWorldActionsTest
             new SetBlock.Command("request-unknown-mat", "world", 0, 64, 0, "not_a_material", null);
 
         // execute + verify
-        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class);
-             MockedStatic<Material> materialMockedStatic = mockStatic(Material.class))
+        try (
+            MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class);
+            MockedStatic<Material> materialMockedStatic = mockStatic(Material.class))
         {
             materialMockedStatic.when(() -> Material.matchMaterial(anyString(), eq(true))).thenReturn(null);
             assertThatThrownBy(() -> worldActions.handleSetBlock(command))

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IServerControl.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IServerControl.java
@@ -1,7 +1,7 @@
 package nl.pim16aap2.lightkeeper.framework;
 
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
-import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
+import nl.pim16aap2.lightkeeper.protocol.ServerPluginSnapshot;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -70,7 +70,7 @@ public interface IServerControl
      *     The plugin's name from its {@code plugin.yml}).
      * @return The plugin snapshot if the plugin exists on the server.
      */
-    Optional<ServerPlugin> plugin(String pluginName);
+    Optional<ServerPluginSnapshot> plugin(String pluginName);
 
     /**
      * Crashes the Minecraft server immediately by force-killing the process.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IServerControl.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IServerControl.java
@@ -1,9 +1,11 @@
 package nl.pim16aap2.lightkeeper.framework;
 
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Server-control facet of the framework: command execution, console output, platform, filesystem access, process
@@ -42,8 +44,8 @@ public interface IServerControl
      * Gets the Minecraft server's working directory.
      *
      * <p>Filesystem contract: reading is safe at any time; writing (e.g. seeding database files or patching
-     * plugin configurations) is only safe while the server is stopped — between {@link #stop()} and
-     * {@link #start()} — because the server reads most files once at boot and may overwrite them on shutdown.
+     * plugin configurations) is only safe while the server is stopped — between {@link #stop()} and {@link #start()} —
+     * because the server reads most files once at boot and may overwrite them on shutdown.
      *
      * @return The server directory.
      */
@@ -56,25 +58,33 @@ public interface IServerControl
      * {@link #directory()} applies.
      *
      * @param pluginName
-     *     The plugin's name, as used for its data directory (usually the {@code name} from its
-     *     {@code plugin.yml}).
+     *     The plugin's name, as used for its data directory (usually the {@code name} from its {@code plugin.yml}).
      * @return The plugin data directory.
      */
     Path pluginDataDirectory(String pluginName);
 
     /**
+     * Gets the data of the plugin with the given name.
+     *
+     * @param pluginName
+     *     The plugin's name from its {@code plugin.yml}).
+     * @return The plugin snapshot if the plugin exists on the server.
+     */
+    Optional<ServerPlugin> plugin(String pluginName);
+
+    /**
      * Crashes the Minecraft server immediately by force-killing the process.
      *
      * <p>All fixtures created before the crash are invalidated: player and world handles obtained earlier no
-     * longer refer to live server state. In shared-server mode the server must be started again via
-     * {@link #start()} or {@link #restart()} before the next test method runs, otherwise that method fails fast;
-     * annotate the test with {@code @FreshServer} to receive a new server per method instead.
+     * longer refer to live server state. In shared-server mode the server must be started again via {@link #start()} or
+     * {@link #restart()} before the next test method runs, otherwise that method fails fast; annotate the test with
+     * {@code @FreshServer} to receive a new server per method instead.
      */
     void crash();
 
     /**
-     * Stops the Minecraft server gracefully via the console {@code stop} command, force-killing it only when it
-     * does not exit within the shutdown timeout.
+     * Stops the Minecraft server gracefully via the console {@code stop} command, force-killing it only when it does
+     * not exit within the shutdown timeout.
      *
      * <p>Synthetic players are removed before the server shuts down so they quit cleanly. All fixtures created
      * before the stop are invalidated, exactly as documented on {@link #crash()}. While the server is stopped, the
@@ -89,8 +99,8 @@ public interface IServerControl
      * Starts the Minecraft server after a {@link #stop()} or {@link #crash()} call.
      *
      * <p>Only worlds configured in the runtime manifest are preloaded again. Players and worlds created at runtime
-     * before the server went down are <strong>not</strong> recreated; tests must re-establish their own fixtures
-     * after starting.
+     * before the server went down are <strong>not</strong> recreated; tests must re-establish their own fixtures after
+     * starting.
      *
      * @throws IllegalStateException
      *     If the server is already running.
@@ -106,8 +116,7 @@ public interface IServerControl
     void restart();
 
     /**
-     * Gets the agent's monotonic tick counter, for correlating against {@link CapturedEventSnapshot#tick()}
-     * stamps.
+     * Gets the agent's monotonic tick counter, for correlating against {@link CapturedEventSnapshot#tick()} stamps.
      *
      * <p>This is an agent-relative counter (ticks since the agent enabled), not the server's absolute game tick:
      * it resets on every server start, so values are only comparable within one server session.
@@ -120,9 +129,9 @@ public interface IServerControl
      * Gets a handle over the always-on server-error capture.
      *
      * <p>The agent captures every WARN-or-worse log event inside the server as a structured snapshot — with the
-     * real throwable class, message, and cause chain — from the moment the agent plugin loads (before any
-     * plugin's {@code onEnable}). Failures inside the logging system itself (reported via Log4j's status logger)
-     * and stack traces written to the server process's raw stderr file descriptor are captured as well.
+     * real throwable class, message, and cause chain — from the moment the agent plugin loads (before any plugin's
+     * {@code onEnable}). Failures inside the logging system itself (reported via Log4j's status logger) and stack
+     * traces written to the server process's raw stderr file descriptor are captured as well.
      *
      * <p>In shared-server mode the capture buffer is cleared automatically at the end of every test method, so
      * each test observes only the errors of its own window; the first test's window also covers server boot. Known

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerControlFacade.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerControlFacade.java
@@ -100,7 +100,8 @@ final class ServerControlFacade implements IServerControl
 
         // The plugin name is authored by the test writer (trusted input); this check catches accidental path
         // fragments early rather than acting as a security boundary.
-        if (trimmedPluginName.contains("/") ||
+        if (trimmedPluginName.equals(".") ||
+            trimmedPluginName.contains("/") ||
             trimmedPluginName.contains("\\") ||
             trimmedPluginName.contains(".."))
             throw new IllegalArgumentException(

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerControlFacade.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerControlFacade.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.lightkeeper.framework.IServerControl;
 import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
-import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
+import nl.pim16aap2.lightkeeper.protocol.ServerPluginSnapshot;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 
 import java.nio.file.Path;
@@ -84,7 +84,7 @@ final class ServerControlFacade implements IServerControl
     }
 
     @Override
-    public Optional<ServerPlugin> plugin(String pluginName)
+    public Optional<ServerPluginSnapshot> plugin(String pluginName)
     {
         framework.ensureOpen();
         final String trimmedPluginName = getTrimmedPluginName(pluginName);

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerControlFacade.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/ServerControlFacade.java
@@ -6,18 +6,20 @@ import nl.pim16aap2.lightkeeper.framework.IServerControl;
 import nl.pim16aap2.lightkeeper.framework.Platform;
 import nl.pim16aap2.lightkeeper.framework.ServerErrorsHandle;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
+import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
 import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Default {@link IServerControl} implementation.
  *
  * <p>Wraps the shared framework internals handed to it by {@link DefaultLightkeeperFramework}: it drives the
- * server process, the agent client, and the player registry, and defers the shared open-state gate,
- * server-down flag, and world preload to the owning framework.
+ * server process, the agent client, and the player registry, and defers the shared open-state gate, server-down flag,
+ * and world preload to the owning framework.
  */
 final class ServerControlFacade implements IServerControl
 {
@@ -77,16 +79,34 @@ final class ServerControlFacade implements IServerControl
     public Path pluginDataDirectory(String pluginName)
     {
         framework.ensureOpen();
-        final String trimmedPluginName =
-            Objects.requireNonNull(pluginName, "pluginName may not be null.").trim();
+        final String trimmedPluginName = getTrimmedPluginName(pluginName);
+        return directory().resolve("plugins").resolve(trimmedPluginName);
+    }
+
+    @Override
+    public Optional<ServerPlugin> plugin(String pluginName)
+    {
+        framework.ensureOpen();
+        final String trimmedPluginName = getTrimmedPluginName(pluginName);
+        return agentClient.getServerPlugin(trimmedPluginName);
+    }
+
+    private String getTrimmedPluginName(String pluginName)
+    {
+        Objects.requireNonNull(pluginName, "pluginName may not be null.");
+        final String trimmedPluginName = pluginName.trim();
         if (trimmedPluginName.isEmpty())
             throw new IllegalArgumentException("pluginName may not be blank.");
+
         // The plugin name is authored by the test writer (trusted input); this check catches accidental path
         // fragments early rather than acting as a security boundary.
-        if (trimmedPluginName.contains("/") || trimmedPluginName.contains("\\") || trimmedPluginName.contains(".."))
+        if (trimmedPluginName.contains("/") ||
+            trimmedPluginName.contains("\\") ||
+            trimmedPluginName.contains(".."))
             throw new IllegalArgumentException(
                 "pluginName must be a plain directory name, got '%s'.".formatted(trimmedPluginName));
-        return directory().resolve("plugins").resolve(trimmedPluginName);
+
+        return trimmedPluginName;
     }
 
     @Override
@@ -113,8 +133,8 @@ final class ServerControlFacade implements IServerControl
      * Graceful-stop implementation without the running-state precondition.
      *
      * <p>Tolerates a server that died on its own after the caller's running check: player cleanup swallows
-     * per-player failures, the client close is idempotent, and the process stop handles dead processes. This is
-     * what lets {@link #restart()} avoid a check-then-act race on the running state.
+     * per-player failures, the client close is idempotent, and the process stop handles dead processes. This is what
+     * lets {@link #restart()} avoid a check-then-act race on the running state.
      */
     private void doStop()
     {

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -25,6 +25,7 @@ import nl.pim16aap2.lightkeeper.protocol.GetPlayerInventory;
 import nl.pim16aap2.lightkeeper.protocol.GetPlayerMessages;
 import nl.pim16aap2.lightkeeper.protocol.GetServerErrors;
 import nl.pim16aap2.lightkeeper.protocol.GetServerPlatform;
+import nl.pim16aap2.lightkeeper.protocol.GetServerPlugins;
 import nl.pim16aap2.lightkeeper.protocol.GetServerTick;
 import nl.pim16aap2.lightkeeper.protocol.Handshake;
 import nl.pim16aap2.lightkeeper.protocol.HasPlayerPermission;
@@ -44,6 +45,7 @@ import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
+import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
 import nl.pim16aap2.lightkeeper.protocol.SetBlock;
 import nl.pim16aap2.lightkeeper.protocol.TabCompletePlayer;
 import nl.pim16aap2.lightkeeper.protocol.TeleportPlayer;
@@ -59,6 +61,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -74,8 +77,8 @@ final class UdsAgentClient implements AutoCloseable
     private static final System.Logger LOG = System.getLogger(UdsAgentClient.class.getName());
 
     /**
-     * Default response timeout: the agent's own synchronous-operation timeout plus a safety margin, so the
-     * agent reports a detailed {@code TIMEOUT} error before this client-side watchdog closes the channel.
+     * Default response timeout: the agent's own synchronous-operation timeout plus a safety margin, so the agent
+     * reports a detailed {@code TIMEOUT} error before this client-side watchdog closes the channel.
      *
      * <p>Unix Domain Sockets do not support SO_TIMEOUT, so the transport enforces this with a watchdog.
      */
@@ -498,6 +501,17 @@ final class UdsAgentClient implements AutoCloseable
                 () -> "Unrecognized server platform '" + response.platform() + "'; treating it as UNKNOWN.");
             return Platform.UNKNOWN;
         }
+    }
+
+    Optional<ServerPlugin> getServerPlugin(String pluginName)
+    {
+        final GetServerPlugins.Command command = new GetServerPlugins.Command(nextRequestId(), pluginName);
+        final GetServerPlugins.Response response = send(command);
+        if (response.plugins().isEmpty())
+        {
+            return Optional.empty();
+        }
+        return Optional.of(response.plugins().getFirst());
     }
 
     <R extends IAgentResponse> R send(IAgentCommand<R> command)

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -45,7 +45,7 @@ import nl.pim16aap2.lightkeeper.protocol.QueryEntities;
 import nl.pim16aap2.lightkeeper.protocol.RegisterEventListener;
 import nl.pim16aap2.lightkeeper.protocol.RemovePlayer;
 import nl.pim16aap2.lightkeeper.protocol.RightClickBlock;
-import nl.pim16aap2.lightkeeper.protocol.ServerPlugin;
+import nl.pim16aap2.lightkeeper.protocol.ServerPluginSnapshot;
 import nl.pim16aap2.lightkeeper.protocol.SetBlock;
 import nl.pim16aap2.lightkeeper.protocol.TabCompletePlayer;
 import nl.pim16aap2.lightkeeper.protocol.TeleportPlayer;
@@ -503,7 +503,7 @@ final class UdsAgentClient implements AutoCloseable
         }
     }
 
-    Optional<ServerPlugin> getServerPlugin(String pluginName)
+    Optional<ServerPluginSnapshot> getServerPlugin(String pluginName)
     {
         final GetServerPlugins.Command command = new GetServerPlugins.Command(nextRequestId(), pluginName);
         final GetServerPlugins.Response response = send(command);

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperServerLifecycleIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperServerLifecycleIT.java
@@ -22,6 +22,9 @@ class LightkeeperServerLifecycleIT
         assertThat(serverDirectory).isDirectory();
         assertThat(framework.server().pluginDataDirectory("LightkeeperSpigotTestPlugin"))
             .isEqualTo(serverDirectory.resolve("plugins").resolve("LightkeeperSpigotTestPlugin"));
+        assertThat(framework.server().plugin("LightkeeperSpigotTestPlugin"))
+            .hasValueSatisfying(plugin -> assertThat(plugin.isEnabled()).isTrue());
+
         framework.bots().join("lklife001", framework.worlds().main());
 
         // execute: graceful stop

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetServerPlugins.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetServerPlugins.java
@@ -1,0 +1,66 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Retrieves a list of plugins installed on the server.
+ */
+public final class GetServerPlugins
+{
+    private GetServerPlugins()
+    {
+    }
+
+    /**
+     * Command record for {@code GET_SERVER_PLUGINS}
+     *
+     * @param requestId
+     *     Correlation identifier matching the response's {@code requestId}.
+     * @param name
+     *     The name of the plugin to look for. When provided, only the plugin whose name is an exact match may be
+     *     returned.
+     *
+     *     <p>When {@code null}, all plugins are returned.
+     */
+    public record Command(
+        String requestId,
+        @Nullable String name
+    ) implements IAgentCommand<Response>
+    {
+        /**
+         * Validates command inputs.
+         */
+        public Command
+        {
+            ProtocolPreconditions.requireNonBlank(requestId, "requestId");
+        }
+
+        @Override
+        public Class<Response> responseType()
+        {
+            return Response.class;
+        }
+    }
+
+    /**
+     * Response record for {@code GET_SERVER_PLUGINS}.
+     *
+     * @param plugins
+     *     The list of plugins installed on the server. When the command's {@code name} was provided, this list will
+     *     contain at most one plugin, or be empty if no plugin with that name was found.
+     *
+     *     <p>When the command's {@code name} was {@code null}, this list will contain all plugins installed on the
+     *     server.
+     */
+    public record Response(
+        List<ServerPlugin> plugins
+    ) implements IAgentResponse
+    {
+        public Response
+        {
+            plugins = plugins == null ? List.of() : List.copyOf(plugins);
+        }
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetServerPlugins.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/GetServerPlugins.java
@@ -55,7 +55,7 @@ public final class GetServerPlugins
      *     server.
      */
     public record Response(
-        List<ServerPlugin> plugins
+        List<ServerPluginSnapshot> plugins
     ) implements IAgentResponse
     {
         public Response

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentCommand.java
@@ -7,74 +7,104 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * Sealed command hierarchy for the LightKeeper agent protocol.
  *
  * <p>Every protocol action is represented by exactly one record implementing this interface. Jackson uses the
- * {@code "action"} JSON property to select the correct subtype during deserialization. Discriminators reuse the
- * naming scheme of the former {@code AgentAction} enum for readability. The wire format is versioned through
+ * {@code "action"} JSON property to select the correct subtype during deserialization. Discriminators reuse the naming
+ * scheme of the former {@code AgentAction} enum for readability. The wire format is versioned through
  * {@code RuntimeProtocol.VERSION}; clients using another version are rejected during the handshake.
  *
- * <p>Adding a new action requires: (1) a new namespace class with inner {@code Command} and {@code Response}
- * records, (2) a new {@link JsonSubTypes.Type} entry here, (3) a command {@code permits} entry here, and (4) a
- * response {@code permits} entry in {@link IAgentResponse}. The pattern-matching switch in
- * {@code AgentRequestDispatcher} will then fail to compile until the case is handled — intentional.
+ * <p>Adding a new action requires:
+ * (1) a new namespace class with inner {@code Command} and {@code Response}
+ * records, (2) a new {@link JsonSubTypes.Type} entry here, (3) a command {@code permits} entry here, and (4) a response
+ * {@code permits} entry in {@link IAgentResponse}. The pattern-matching switch in {@code AgentRequestDispatcher} will
+ * then fail to compile until the case is handled — intentional.
  *
  * @param <R>
  *     The typed response record returned by this command.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "action")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = Handshake.Command.class, name = "HANDSHAKE"),
-    @JsonSubTypes.Type(value = MainWorld.Command.class, name = "MAIN_WORLD"),
-    @JsonSubTypes.Type(value = NewWorld.Command.class, name = "NEW_WORLD"),
-    @JsonSubTypes.Type(value = ExecuteCommand.Command.class, name = "EXECUTE_COMMAND"),
-    @JsonSubTypes.Type(value = BlockType.Command.class, name = "BLOCK_TYPE"),
-    @JsonSubTypes.Type(value = SetBlock.Command.class, name = "SET_BLOCK"),
-    @JsonSubTypes.Type(value = CreatePlayer.Command.class, name = "CREATE_PLAYER"),
-    @JsonSubTypes.Type(value = RemovePlayer.Command.class, name = "REMOVE_PLAYER"),
-    @JsonSubTypes.Type(value = ExecutePlayerCommand.Command.class, name = "EXECUTE_PLAYER_COMMAND"),
-    @JsonSubTypes.Type(value = PlacePlayerBlock.Command.class, name = "PLACE_PLAYER_BLOCK"),
-    @JsonSubTypes.Type(value = LeftClickBlock.Command.class, name = "LEFT_CLICK_BLOCK"),
-    @JsonSubTypes.Type(value = RightClickBlock.Command.class, name = "RIGHT_CLICK_BLOCK"),
-    @JsonSubTypes.Type(value = GetOpenMenu.Command.class, name = "GET_OPEN_MENU"),
-    @JsonSubTypes.Type(value = ClickMenuSlot.Command.class, name = "CLICK_MENU_SLOT"),
-    @JsonSubTypes.Type(value = DragMenuSlots.Command.class, name = "DRAG_MENU_SLOTS"),
-    @JsonSubTypes.Type(value = GetPlayerMessages.Command.class, name = "GET_PLAYER_MESSAGES"),
-    @JsonSubTypes.Type(value = WaitTicks.Command.class, name = "WAIT_TICKS"),
-    @JsonSubTypes.Type(value = GetServerTick.Command.class, name = "GET_SERVER_TICK"),
-    @JsonSubTypes.Type(value = TeleportPlayer.Command.class, name = "TELEPORT_PLAYER"),
-    @JsonSubTypes.Type(value = LoadChunk.Command.class, name = "LOAD_CHUNK"),
-    @JsonSubTypes.Type(value = UnloadChunk.Command.class, name = "UNLOAD_CHUNK"),
-    @JsonSubTypes.Type(value = IsChunkLoaded.Command.class, name = "IS_CHUNK_LOADED"),
-    @JsonSubTypes.Type(value = GetPlayerInventory.Command.class, name = "GET_PLAYER_INVENTORY"),
-    @JsonSubTypes.Type(value = DropItem.Command.class, name = "DROP_ITEM"),
-    @JsonSubTypes.Type(value = RegisterEventListener.Command.class, name = "REGISTER_EVENT_LISTENER"),
-    @JsonSubTypes.Type(value = GetCapturedEvents.Command.class, name = "GET_CAPTURED_EVENTS"),
-    @JsonSubTypes.Type(value = ClearCapturedEvents.Command.class, name = "CLEAR_CAPTURED_EVENTS"),
-    @JsonSubTypes.Type(value = UnregisterEventListener.Command.class, name = "UNREGISTER_EVENT_LISTENER"),
-    @JsonSubTypes.Type(value = GetPlayerChatComponents.Command.class, name = "GET_PLAYER_CHAT_COMPONENTS"),
-    @JsonSubTypes.Type(value = GetServerPlatform.Command.class, name = "GET_SERVER_PLATFORM"),
-    @JsonSubTypes.Type(value = GetServerErrors.Command.class, name = "GET_SERVER_ERRORS"),
-    @JsonSubTypes.Type(value = ClearServerErrors.Command.class, name = "CLEAR_SERVER_ERRORS"),
-    @JsonSubTypes.Type(value = MutatePlayerPermission.Command.class, name = "MUTATE_PLAYER_PERMISSION"),
-    @JsonSubTypes.Type(value = HasPlayerPermission.Command.class, name = "HAS_PLAYER_PERMISSION"),
-    @JsonSubTypes.Type(value = CancelNextEvents.Command.class, name = "CANCEL_NEXT_EVENTS"),
-    @JsonSubTypes.Type(value = PlayerChat.Command.class, name = "PLAYER_CHAT"),
-    @JsonSubTypes.Type(value = QueryEntities.Command.class, name = "QUERY_ENTITIES"),
-    @JsonSubTypes.Type(value = TabCompletePlayer.Command.class, name = "TAB_COMPLETE_PLAYER"),
-})
+@JsonSubTypes(
+    {
+        @JsonSubTypes.Type(value = BlockType.Command.class, name = "BLOCK_TYPE"),
+        @JsonSubTypes.Type(value = CancelNextEvents.Command.class, name = "CANCEL_NEXT_EVENTS"),
+        @JsonSubTypes.Type(value = ClearCapturedEvents.Command.class, name = "CLEAR_CAPTURED_EVENTS"),
+        @JsonSubTypes.Type(value = ClearServerErrors.Command.class, name = "CLEAR_SERVER_ERRORS"),
+        @JsonSubTypes.Type(value = ClickMenuSlot.Command.class, name = "CLICK_MENU_SLOT"),
+        @JsonSubTypes.Type(value = CreatePlayer.Command.class, name = "CREATE_PLAYER"),
+        @JsonSubTypes.Type(value = DragMenuSlots.Command.class, name = "DRAG_MENU_SLOTS"),
+        @JsonSubTypes.Type(value = DropItem.Command.class, name = "DROP_ITEM"),
+        @JsonSubTypes.Type(value = ExecuteCommand.Command.class, name = "EXECUTE_COMMAND"),
+        @JsonSubTypes.Type(value = ExecutePlayerCommand.Command.class, name = "EXECUTE_PLAYER_COMMAND"),
+        @JsonSubTypes.Type(value = GetCapturedEvents.Command.class, name = "GET_CAPTURED_EVENTS"),
+        @JsonSubTypes.Type(value = GetOpenMenu.Command.class, name = "GET_OPEN_MENU"),
+        @JsonSubTypes.Type(value = GetPlayerChatComponents.Command.class, name = "GET_PLAYER_CHAT_COMPONENTS"),
+        @JsonSubTypes.Type(value = GetPlayerInventory.Command.class, name = "GET_PLAYER_INVENTORY"),
+        @JsonSubTypes.Type(value = GetPlayerMessages.Command.class, name = "GET_PLAYER_MESSAGES"),
+        @JsonSubTypes.Type(value = GetServerErrors.Command.class, name = "GET_SERVER_ERRORS"),
+        @JsonSubTypes.Type(value = GetServerPlatform.Command.class, name = "GET_SERVER_PLATFORM"),
+        @JsonSubTypes.Type(value = GetServerPlugins.Command.class, name = "GET_SERVER_PLUGINS"),
+        @JsonSubTypes.Type(value = GetServerTick.Command.class, name = "GET_SERVER_TICK"),
+        @JsonSubTypes.Type(value = Handshake.Command.class, name = "HANDSHAKE"),
+        @JsonSubTypes.Type(value = HasPlayerPermission.Command.class, name = "HAS_PLAYER_PERMISSION"),
+        @JsonSubTypes.Type(value = IsChunkLoaded.Command.class, name = "IS_CHUNK_LOADED"),
+        @JsonSubTypes.Type(value = LeftClickBlock.Command.class, name = "LEFT_CLICK_BLOCK"),
+        @JsonSubTypes.Type(value = LoadChunk.Command.class, name = "LOAD_CHUNK"),
+        @JsonSubTypes.Type(value = MainWorld.Command.class, name = "MAIN_WORLD"),
+        @JsonSubTypes.Type(value = MutatePlayerPermission.Command.class, name = "MUTATE_PLAYER_PERMISSION"),
+        @JsonSubTypes.Type(value = NewWorld.Command.class, name = "NEW_WORLD"),
+        @JsonSubTypes.Type(value = PlacePlayerBlock.Command.class, name = "PLACE_PLAYER_BLOCK"),
+        @JsonSubTypes.Type(value = PlayerChat.Command.class, name = "PLAYER_CHAT"),
+        @JsonSubTypes.Type(value = QueryEntities.Command.class, name = "QUERY_ENTITIES"),
+        @JsonSubTypes.Type(value = RegisterEventListener.Command.class, name = "REGISTER_EVENT_LISTENER"),
+        @JsonSubTypes.Type(value = RemovePlayer.Command.class, name = "REMOVE_PLAYER"),
+        @JsonSubTypes.Type(value = RightClickBlock.Command.class, name = "RIGHT_CLICK_BLOCK"),
+        @JsonSubTypes.Type(value = SetBlock.Command.class, name = "SET_BLOCK"),
+        @JsonSubTypes.Type(value = TabCompletePlayer.Command.class, name = "TAB_COMPLETE_PLAYER"),
+        @JsonSubTypes.Type(value = TeleportPlayer.Command.class, name = "TELEPORT_PLAYER"),
+        @JsonSubTypes.Type(value = UnloadChunk.Command.class, name = "UNLOAD_CHUNK"),
+        @JsonSubTypes.Type(value = UnregisterEventListener.Command.class, name = "UNREGISTER_EVENT_LISTENER"),
+        @JsonSubTypes.Type(value = WaitTicks.Command.class, name = "WAIT_TICKS"),
+    }
+)
 public sealed interface IAgentCommand<R extends IAgentResponse>
-    permits Handshake.Command, MainWorld.Command, NewWorld.Command, ExecuteCommand.Command,
-            BlockType.Command, SetBlock.Command, CreatePlayer.Command, RemovePlayer.Command,
-            ExecutePlayerCommand.Command, PlacePlayerBlock.Command, LeftClickBlock.Command,
-            RightClickBlock.Command, GetOpenMenu.Command, ClickMenuSlot.Command,
-            DragMenuSlots.Command, GetPlayerMessages.Command, WaitTicks.Command,
-            GetServerTick.Command, TeleportPlayer.Command, LoadChunk.Command,
-            UnloadChunk.Command, IsChunkLoaded.Command, GetPlayerInventory.Command,
-            DropItem.Command, RegisterEventListener.Command, GetCapturedEvents.Command,
-            ClearCapturedEvents.Command, UnregisterEventListener.Command,
-            GetPlayerChatComponents.Command, GetServerPlatform.Command,
-            GetServerErrors.Command, ClearServerErrors.Command,
-            MutatePlayerPermission.Command, HasPlayerPermission.Command,
-            CancelNextEvents.Command, PlayerChat.Command, QueryEntities.Command,
-            TabCompletePlayer.Command
+    permits
+    BlockType.Command,
+    CancelNextEvents.Command,
+    ClearCapturedEvents.Command,
+    ClearServerErrors.Command,
+    ClickMenuSlot.Command,
+    CreatePlayer.Command,
+    DragMenuSlots.Command,
+    DropItem.Command,
+    ExecuteCommand.Command,
+    ExecutePlayerCommand.Command,
+    GetCapturedEvents.Command,
+    GetOpenMenu.Command,
+    GetPlayerChatComponents.Command,
+    GetPlayerInventory.Command,
+    GetPlayerMessages.Command,
+    GetServerErrors.Command,
+    GetServerPlatform.Command,
+    GetServerPlugins.Command,
+    GetServerTick.Command,
+    Handshake.Command,
+    HasPlayerPermission.Command,
+    IsChunkLoaded.Command,
+    LeftClickBlock.Command,
+    LoadChunk.Command,
+    MainWorld.Command,
+    MutatePlayerPermission.Command,
+    NewWorld.Command,
+    PlacePlayerBlock.Command,
+    PlayerChat.Command,
+    QueryEntities.Command,
+    RegisterEventListener.Command,
+    RemovePlayer.Command,
+    RightClickBlock.Command,
+    SetBlock.Command,
+    TabCompletePlayer.Command,
+    TeleportPlayer.Command,
+    UnloadChunk.Command,
+    UnregisterEventListener.Command,
+    WaitTicks.Command
 {
     /**
      * Correlation identifier matching the response's {@code requestId}.

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/IAgentResponse.java
@@ -30,6 +30,7 @@ public sealed interface IAgentResponse
     GetPlayerMessages.Response,
     GetServerErrors.Response,
     GetServerPlatform.Response,
+    GetServerPlugins.Response,
     GetServerTick.Response,
     Handshake.Response,
     HasPlayerPermission.Response,

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ServerPlugin.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ServerPlugin.java
@@ -1,0 +1,31 @@
+package nl.pim16aap2.lightkeeper.protocol;
+
+import java.util.List;
+
+/**
+ * Represents a snapshot of a plugin on the server.
+ *
+ * @param name
+ *     The name of the plugin as defined in its plugin.yml file.
+ * @param version
+ *     The version of the plugin as defined in its plugin.yml file.
+ * @param description
+ *     A brief description of the plugin as defined in its plugin.yml file.
+ * @param authors
+ *     The authors of the plugin as defined in its plugin.yml file.
+ * @param isEnabled
+ *     Whether the plugin is enabled.
+ */
+public record ServerPlugin(
+    String name,
+    String version,
+    String description,
+    List<String> authors,
+    boolean isEnabled
+)
+{
+    public ServerPlugin
+    {
+        authors = authors == null ? List.of() : List.copyOf(authors);
+    }
+}

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ServerPluginSnapshot.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/ServerPluginSnapshot.java
@@ -16,7 +16,7 @@ import java.util.List;
  * @param isEnabled
  *     Whether the plugin is enabled.
  */
-public record ServerPlugin(
+public record ServerPluginSnapshot(
     String name,
     String version,
     String description,
@@ -24,7 +24,7 @@ public record ServerPlugin(
     boolean isEnabled
 )
 {
-    public ServerPlugin
+    public ServerPluginSnapshot
     {
         authors = authors == null ? List.of() : List.copyOf(authors);
     }

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -17,10 +17,10 @@ public final class RuntimeProtocol
      * Runtime protocol version understood by the framework and in-server agent.
      *
      * <p>Increment this whenever the agent wire format, command set, or response semantics change
-     * in a backward-incompatible way. Both the framework and the agent must agree on this value;
-     * a mismatch causes an {@code HANDSHAKE} failure.
+     * in a backward-incompatible way. Both the framework and the agent must agree on this value; a mismatch causes an
+     * {@code HANDSHAKE} failure.
      */
-    public static final int VERSION = 11;
+    public static final int VERSION = 12;
 
     /**
      * Minecraft server version supported by this LightKeeper build.
@@ -28,8 +28,8 @@ public final class RuntimeProtocol
     public static final String SUPPORTED_MINECRAFT_VERSION = loadSupportedMinecraftVersion();
 
     /**
-     * Default maximum time, in seconds, the agent waits for a scheduled synchronous server operation before
-     * reporting {@code TIMEOUT}. Shared so the client can derive a strictly larger response timeout.
+     * Default maximum time, in seconds, the agent waits for a scheduled synchronous server operation before reporting
+     * {@code TIMEOUT}. Shared so the client can derive a strictly larger response timeout.
      */
     public static final long DEFAULT_SYNC_OPERATION_TIMEOUT_SECONDS = 120L;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving server plugin information, including name, version, description, authors, and enabled status.
  * Plugins can be queried individually or listed collectively.
  * Added optional plugin lookup through server control APIs, returning no result when a plugin is unavailable.

* **Tests**
  * Lifecycle validation now confirms the test plugin is installed and enabled before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->