### PR TITLE
🤖 Make synthetic players lifecycle-safe by default

### DIFF
--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentMenuActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentMenuActions.java
@@ -70,7 +70,7 @@ final class AgentMenuActions
         final UUID uuid = command.uuid();
         return mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "GET_OPEN_MENU");
             final InventoryView view = player.getOpenInventory();
 
             if (!isActionableOpenInventory(view))
@@ -109,7 +109,7 @@ final class AgentMenuActions
 
         mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "CLICK_MENU_SLOT");
             final InventoryView view = player.getOpenInventory();
             if (!isActionableOpenInventory(view))
                 throw new IllegalStateException("Player does not have an actionable open menu.");
@@ -153,7 +153,7 @@ final class AgentMenuActions
 
         mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "DRAG_MENU_SLOTS");
             final InventoryView view = player.getOpenInventory();
             if (!isActionableOpenInventory(view))
                 throw new IllegalStateException("Player does not have an actionable open menu.");

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -30,6 +30,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.EventExecutor;
@@ -160,15 +161,25 @@ final class AgentPlayerActions
             final Location spawnLocation = x == null || y == null || z == null
                 ? world.getSpawnLocation()
                 : new Location(world, x, y, z);
-            final Player spawnedPlayer = botPlayerNmsAdapter.spawnPlayer(uuid, name, world, spawnLocation);
+            final Player spawnedPlayer;
+            try
+            {
+                spawnedPlayer = botPlayerNmsAdapter.spawnPlayer(
+                    uuid,
+                    name,
+                    world,
+                    spawnLocation,
+                    command.invulnerable(),
+                    preparedPlayer -> playerStore.registerSyntheticPlayer(uuid, preparedPlayer));
+            }
+            catch (RuntimeException exception)
+            {
+                playerStore.removeSyntheticPlayer(uuid);
+                throw exception;
+            }
             spawnedPlayer.setInvulnerable(command.invulnerable());
             if (health != null)
                 spawnedPlayer.setHealth(Math.min(spawnedPlayer.getMaxHealth(), health));
-
-            // Register before applying permissions so setPermissions can store the attachment on the player's
-            // state; registering afterwards leaves the attachment created-and-applied but never recorded, so it
-            // can never be revoked on removal.
-            playerStore.registerSyntheticPlayer(uuid, spawnedPlayer);
 
             if (permissionsCsv != null && !permissionsCsv.isBlank())
                 playerStore.setPermissions(plugin, uuid, spawnedPlayer, permissionsCsv);
@@ -219,14 +230,24 @@ final class AgentPlayerActions
 
         final CountDownLatch joinLatch = new CountDownLatch(1);
         final AtomicReference<Player> joinedPlayer = new AtomicReference<>();
+        final AtomicReference<UUID> preRegisteredPlayerId = new AtomicReference<>();
         final Listener listener = new Listener()
         {
         };
         final EventExecutor executor = (ignoredListener, event) ->
         {
-            if (event instanceof PlayerJoinEvent joinEvent && joinEvent.getPlayer().getName().equals(name))
+            if (event instanceof PlayerLoginEvent loginEvent && loginEvent.getPlayer().getName().equals(name)
+                && loginEvent.getResult() == PlayerLoginEvent.Result.ALLOWED)
+            {
+                final Player player = loginEvent.getPlayer();
+                player.setInvulnerable(command.invulnerable());
+                playerStore.registerSyntheticPlayer(player.getUniqueId(), player);
+                preRegisteredPlayerId.set(player.getUniqueId());
+            }
+            else if (event instanceof PlayerJoinEvent joinEvent && joinEvent.getPlayer().getName().equals(name))
             {
                 final Player player = joinEvent.getPlayer();
+                // Reassert the requested final state in case a join handler deliberately changed it.
                 player.setInvulnerable(command.invulnerable());
                 joinedPlayer.set(player);
                 joinLatch.countDown();
@@ -238,11 +259,14 @@ final class AgentPlayerActions
             if (Bukkit.getWorld(command.worldName()) == null)
                 throw new IllegalArgumentException("World '%s' does not exist.".formatted(command.worldName()));
             Bukkit.getPluginManager().registerEvent(
+                PlayerLoginEvent.class, listener, EventPriority.HIGHEST, executor, plugin);
+            Bukkit.getPluginManager().registerEvent(
                 PlayerJoinEvent.class, listener, EventPriority.MONITOR, executor, plugin);
             return Boolean.TRUE;
         });
 
         Exception primaryFailure = null;
+        boolean creationCompleted = false;
         try
         {
             final int port = Bukkit.getServer().getPort();
@@ -263,6 +287,7 @@ final class AgentPlayerActions
 
             final Player player = Objects.requireNonNull(joinedPlayer.get(), "joined player");
             registerJoinedPlayer(player, command);
+            creationCompleted = true;
 
             plugin.getLogger().info(
                 "LK_AGENT: Full-login player '%s' (%s) joined.".formatted(player.getName(), player.getUniqueId()));
@@ -275,6 +300,12 @@ final class AgentPlayerActions
         }
         finally
         {
+            if (!creationCompleted)
+            {
+                final UUID preRegisteredId = preRegisteredPlayerId.get();
+                if (preRegisteredId != null)
+                    playerStore.removeSyntheticPlayer(preRegisteredId);
+            }
             unregisterJoinListener(listener, deadlineNanos, primaryFailure);
         }
     }
@@ -389,7 +420,11 @@ final class AgentPlayerActions
                 : new Location(world, command.x(), command.y(), command.z());
             player.teleport(target);
 
-            playerStore.registerSyntheticPlayer(uuid, player);
+            if (!player.equals(playerStore.getRequiredPlayer(uuid)))
+                throw new IllegalStateException(
+                    "Full-login player '%s' (%s) changed between login and join events."
+                        .formatted(player.getName(), uuid));
+            player.setInvulnerable(command.invulnerable());
             fullLoginPlayerIds.add(uuid);
             if (health != null)
                 player.setHealth(Math.min(player.getMaxHealth(), health));

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActions.java
@@ -112,8 +112,8 @@ final class AgentPlayerActions
      * Handles {@code CREATE_PLAYER} by routing to the full-login pipeline or the legacy spawn path.
      *
      * @param command
-     *     Typed command carrying player name, UUID, world, spawn coordinates, health, permissions, join mode,
-     *     and locale.
+     *     Typed command carrying player name, UUID, world, spawn coordinates, health, permissions,
+     *     invulnerability, join mode, and locale.
      * @return Response containing the created player's UUID and name.
      *
      * @throws Exception
@@ -161,6 +161,7 @@ final class AgentPlayerActions
                 ? world.getSpawnLocation()
                 : new Location(world, x, y, z);
             final Player spawnedPlayer = botPlayerNmsAdapter.spawnPlayer(uuid, name, world, spawnLocation);
+            spawnedPlayer.setInvulnerable(command.invulnerable());
             if (health != null)
                 spawnedPlayer.setHealth(Math.min(spawnedPlayer.getMaxHealth(), health));
 
@@ -225,7 +226,9 @@ final class AgentPlayerActions
         {
             if (event instanceof PlayerJoinEvent joinEvent && joinEvent.getPlayer().getName().equals(name))
             {
-                joinedPlayer.set(joinEvent.getPlayer());
+                final Player player = joinEvent.getPlayer();
+                player.setInvulnerable(command.invulnerable());
+                joinedPlayer.set(player);
                 joinLatch.countDown();
             }
         };
@@ -486,7 +489,7 @@ final class AgentPlayerActions
         final String command = rawCommand.startsWith("/") ? rawCommand.substring(1) : rawCommand;
         final Boolean dispatched = mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "EXECUTE_PLAYER_COMMAND");
             // performCommand only runs commands the player context knows; fall back to the server dispatcher so
             // commands reachable only through Bukkit.dispatchCommand still execute (parity with the flat branch).
             if (player.performCommand(command))
@@ -528,7 +531,7 @@ final class AgentPlayerActions
 
         final List<String> completions = mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "TAB_COMPLETE_PLAYER");
             final CommandMap commandMap = resolveCommandMap();
             final List<String> result = commandMap.tabComplete(player, commandLine);
             return result == null ? List.<String>of() : List.copyOf(result);
@@ -599,7 +602,7 @@ final class AgentPlayerActions
 
         final String finalMaterial = mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "PLACE_PLAYER_BLOCK");
             final World world = player.getWorld();
             world.getBlockAt(x, y, z).setType(material);
             return world.getBlockAt(x, y, z).getType().getKey().toString();
@@ -670,11 +673,14 @@ final class AgentPlayerActions
 
         final Boolean teleported = mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER");
             final World world = Bukkit.getWorld(worldName);
             if (world == null)
                 throw new IllegalArgumentException("World '%s' does not exist.".formatted(worldName));
-            return player.teleport(new Location(world, x, y, z));
+            final boolean result = player.teleport(new Location(world, x, y, z));
+            if (!result)
+                playerStore.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER");
+            return result;
         });
 
         return new TeleportPlayer.Response(teleported);
@@ -700,13 +706,13 @@ final class AgentPlayerActions
 
         mainThreadExecutor.callOnMainThread(() ->
         {
-            // The store methods validate registration themselves; only the set paths need the player instance.
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "MUTATE_PLAYER_PERMISSION");
             switch (mode)
             {
                 case GRANT ->
-                    playerStore.setPermission(plugin, uuid, playerStore.getRequiredPlayer(uuid), permission, true);
+                    playerStore.setPermission(plugin, uuid, player, permission, true);
                 case REVOKE ->
-                    playerStore.setPermission(plugin, uuid, playerStore.getRequiredPlayer(uuid), permission, false);
+                    playerStore.setPermission(plugin, uuid, player, permission, false);
                 case UNSET -> playerStore.unsetPermission(uuid, permission);
             }
             return Boolean.TRUE;
@@ -732,7 +738,7 @@ final class AgentPlayerActions
         final String permission = command.permission();
 
         final Boolean value = mainThreadExecutor.callOnMainThread(
-            () -> playerStore.getRequiredPlayer(uuid).hasPermission(permission)
+            () -> playerStore.getRequiredActivePlayer(uuid, "HAS_PLAYER_PERMISSION").hasPermission(permission)
         );
 
         return new HasPlayerPermission.Response(value);
@@ -759,7 +765,7 @@ final class AgentPlayerActions
 
         mainThreadExecutor.callOnMainThread(() ->
         {
-            playerStore.getRequiredPlayer(uuid).chat(message);
+            playerStore.getRequiredActivePlayer(uuid, "PLAYER_CHAT").chat(message);
             return Boolean.TRUE;
         });
 
@@ -822,7 +828,7 @@ final class AgentPlayerActions
 
         return mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "CLICK_BLOCK");
             final Block block = player.getWorld().getBlockAt(x, y, z);
             final ItemStack item = player.getInventory().getItemInMainHand();
             final PlayerInteractEvent event = new PlayerInteractEvent(

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerStateActions.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerStateActions.java
@@ -83,7 +83,7 @@ final class AgentPlayerStateActions
         final UUID uuid = command.uuid();
         final List<ItemSnapshot> items = mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "GET_PLAYER_INVENTORY");
             return buildInventoryItems(player.getInventory().getContents());
         });
         return new GetPlayerInventory.Response(items);
@@ -108,7 +108,7 @@ final class AgentPlayerStateActions
         final UUID uuid = command.uuid();
         final DropResult result = mainThreadExecutor.callOnMainThread(() ->
         {
-            final Player player = playerStore.getRequiredPlayer(uuid);
+            final Player player = playerStore.getRequiredActivePlayer(uuid, "DROP_ITEM");
             final ItemStack item = player.getInventory().getItemInMainHand();
             if (item == null || AgentMaterials.isAir(item.getType()))
                 return DropResult.EMPTY_HAND;

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerLifecycleListener.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerLifecycleListener.java
@@ -1,0 +1,142 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+/**
+ * Observes Bukkit lifecycle transitions for LightKeeper-managed synthetic players.
+ *
+ * <p>Deaths and disconnects are retained in {@link AgentSyntheticPlayerStore} so a later framework action can
+ * report the lifecycle cause rather than an ambiguous Bukkit rejection. Events for ordinary server players are
+ * ignored.
+ */
+final class AgentSyntheticPlayerLifecycleListener implements Listener
+{
+    private final AgentSyntheticPlayerStore playerStore;
+    private final Logger logger;
+
+    /**
+     * @param playerStore
+     *     Synthetic-player registry whose lifecycle state is updated.
+     * @param logger
+     *     Agent logger used for lifecycle diagnostics.
+     */
+    AgentSyntheticPlayerLifecycleListener(AgentSyntheticPlayerStore playerStore, Logger logger)
+    {
+        this.playerStore = Objects.requireNonNull(playerStore, "playerStore");
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    /**
+     * Records and logs a synthetic-player death.
+     *
+     * @param event
+     *     Bukkit death event.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    void onPlayerDeath(PlayerDeathEvent event)
+    {
+        final Player player = event.getEntity();
+        if (!playerStore.isSyntheticPlayer(player.getUniqueId()))
+            return;
+
+        final String details = "player died; cause=%s location=%s deathMessage=%s".formatted(
+            formatDamageSource(event.getDamageSource()),
+            formatLocation(player.getLocation()),
+            Objects.requireNonNullElse(event.getDeathMessage(), "<none>")
+        );
+        playerStore.markPlayerDead(player.getUniqueId(), details);
+        logger.info(
+            "LK_AGENT: Synthetic player '%s' (%s) died: %s"
+                .formatted(player.getName(), player.getUniqueId(), details));
+    }
+
+    /**
+     * Clears a recorded death once Bukkit has respawned the player.
+     *
+     * @param event
+     *     Bukkit respawn event.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    void onPlayerRespawn(PlayerRespawnEvent event)
+    {
+        final Player player = event.getPlayer();
+        if (!playerStore.isSyntheticPlayer(player.getUniqueId()))
+            return;
+        playerStore.markPlayerRespawned(player.getUniqueId());
+        logger.info(
+            "LK_AGENT: Synthetic player '%s' (%s) respawned at %s."
+                .formatted(player.getName(), player.getUniqueId(), formatLocation(event.getRespawnLocation())));
+    }
+
+    /**
+     * Records the authoritative quit transition after the player has left the server.
+     *
+     * @param event
+     *     Bukkit quit event.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    void onPlayerQuit(PlayerQuitEvent event)
+    {
+        final Player player = event.getPlayer();
+        if (!playerStore.isSyntheticPlayer(player.getUniqueId()))
+            return;
+
+        final String details = "player disconnected; quitMessage=%s"
+            .formatted(Objects.requireNonNullElse(event.getQuitMessage(), "<none>"));
+        playerStore.markPlayerDisconnected(player.getUniqueId(), details);
+        logger.info(
+            "LK_AGENT: Synthetic player '%s' (%s) disconnected: %s"
+                .formatted(player.getName(), player.getUniqueId(), details));
+    }
+
+    /**
+     * Logs attempted kicks without treating them as disconnects because the event may be cancelled.
+     *
+     * @param event
+     *     Bukkit kick event.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    void onPlayerKick(PlayerKickEvent event)
+    {
+        final Player player = event.getPlayer();
+        if (!playerStore.isSyntheticPlayer(player.getUniqueId()))
+            return;
+        logger.info(
+            "LK_AGENT: Synthetic player '%s' (%s) kick event: cancelled=%s reason=%s"
+                .formatted(player.getName(), player.getUniqueId(), event.isCancelled(), event.getReason()));
+    }
+
+    private static String formatLocation(Location location)
+    {
+        final World world = location.getWorld();
+        final String worldName = world == null ? "<no-world>" : world.getName();
+        return String.format(
+            Locale.ROOT,
+            "%s[%.2f, %.2f, %.2f]",
+            worldName,
+            location.getX(),
+            location.getY(),
+            location.getZ()
+        );
+    }
+
+    private static String formatDamageSource(@Nullable DamageSource damageSource)
+    {
+        return damageSource == null ? "<unknown>" : damageSource.getDamageType().getKey().toString();
+    }
+}

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStore.java
@@ -1,6 +1,8 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
+import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
+import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -35,15 +37,120 @@ final class AgentSyntheticPlayerStore
      *     Synthetic player UUID.
      * @return
      *     Registered player instance.
-     * @throws IllegalArgumentException
+     * @throws AgentProtocolException
      *     When the UUID is unknown.
      */
     Player getRequiredPlayer(UUID uuid)
     {
         final SyntheticPlayerState state = players.get(uuid);
         if (state == null)
-            throw new IllegalArgumentException("Synthetic player '%s' is not registered.".formatted(uuid));
+            throw new AgentProtocolException(
+                AgentErrorCode.PLAYER_NOT_REGISTERED,
+                "Synthetic player '%s' is not registered.".formatted(uuid));
         return state.player;
+    }
+
+    /**
+     * Resolves a registered synthetic player that is currently able to perform an in-game action.
+     *
+     * @param uuid
+     *     Synthetic player UUID.
+     * @param action
+     *     Protocol action being attempted, for failure diagnostics.
+     * @return
+     *     Active Bukkit player instance.
+     * @throws AgentProtocolException
+     *     When the UUID is unknown or the player is dead or disconnected.
+     */
+    Player getRequiredActivePlayer(UUID uuid, String action)
+    {
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state == null)
+            throw new AgentProtocolException(
+                AgentErrorCode.PLAYER_NOT_REGISTERED,
+                "Synthetic player '%s' is not registered.".formatted(uuid));
+
+        final PlayerUnavailability recordedUnavailability = state.unavailability;
+        if (recordedUnavailability != null)
+            throw unavailableException(uuid, action, recordedUnavailability);
+
+        final Player player = state.player;
+        if (player.isDead())
+            throw new AgentProtocolException(
+                AgentErrorCode.PLAYER_DEAD,
+                "Synthetic player '%s' cannot perform %s because the player is dead."
+                    .formatted(uuid, action));
+        if (!player.isOnline())
+            throw new AgentProtocolException(
+                AgentErrorCode.PLAYER_DISCONNECTED,
+                "Synthetic player '%s' cannot perform %s because the player is disconnected."
+                    .formatted(uuid, action));
+        return player;
+    }
+
+    /**
+     * Records a synthetic player death so later action failures retain the event's diagnostic context.
+     *
+     * @param uuid
+     *     Synthetic player UUID.
+     * @param details
+     *     Human-readable death details captured from the Bukkit event.
+     */
+    void markPlayerDead(UUID uuid, String details)
+    {
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.unavailability = new PlayerUnavailability(AgentErrorCode.PLAYER_DEAD, details);
+    }
+
+    /**
+     * Clears a recorded death after Bukkit has respawned the synthetic player.
+     *
+     * @param uuid
+     *     Synthetic player UUID.
+     */
+    void markPlayerRespawned(UUID uuid)
+    {
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null && state.unavailability != null
+            && state.unavailability.errorCode() == AgentErrorCode.PLAYER_DEAD)
+            state.unavailability = null;
+    }
+
+    /**
+     * Records that a synthetic player left the server.
+     *
+     * @param uuid
+     *     Synthetic player UUID.
+     * @param details
+     *     Human-readable quit details captured from the Bukkit event.
+     */
+    void markPlayerDisconnected(UUID uuid, String details)
+    {
+        final SyntheticPlayerState state = players.get(uuid);
+        if (state != null)
+            state.unavailability = new PlayerUnavailability(AgentErrorCode.PLAYER_DISCONNECTED, details);
+    }
+
+    /**
+     * Returns whether the UUID belongs to a currently registered synthetic player.
+     *
+     * @param uuid
+     *     Player UUID to inspect.
+     * @return {@code true} when the player is managed by this store.
+     */
+    boolean isSyntheticPlayer(UUID uuid)
+    {
+        return players.containsKey(uuid);
+    }
+
+    private static AgentProtocolException unavailableException(
+        UUID uuid, String action, PlayerUnavailability unavailability)
+    {
+        return new AgentProtocolException(
+            unavailability.errorCode(),
+            "Synthetic player '%s' cannot perform %s: %s"
+                .formatted(uuid, action, unavailability.details()));
     }
 
     /**
@@ -288,10 +395,26 @@ final class AgentSyntheticPlayerStore
          * Accumulated chat-component JSON history.
          */
         private final List<String> componentHistory = new CopyOnWriteArrayList<>();
+        /**
+         * Recorded lifecycle reason that currently prevents player actions, or {@code null} while active.
+         */
+        private volatile @Nullable PlayerUnavailability unavailability;
 
         private SyntheticPlayerState(Player player)
         {
             this.player = player;
         }
+    }
+
+    /**
+     * Immutable lifecycle failure retained between its Bukkit event and a later framework action.
+     *
+     * @param errorCode
+     *     Stable protocol error code for the unavailable state.
+     * @param details
+     *     Human-readable event details.
+     */
+    private record PlayerUnavailability(AgentErrorCode errorCode, String details)
+    {
     }
 }

--- a/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
+++ b/lightkeeper-agent-spigot/src/main/java/nl/pim16aap2/lightkeeper/agent/spigot/SpigotLightkeeperAgentPlugin.java
@@ -129,6 +129,8 @@ public final class SpigotLightkeeperAgentPlugin extends JavaPlugin
 
             final AgentMainThreadExecutor mainThreadExecutor = new AgentMainThreadExecutor(this);
             final AgentSyntheticPlayerStore playerStore = new AgentSyntheticPlayerStore();
+            getServer().getPluginManager().registerEvents(
+                new AgentSyntheticPlayerLifecycleListener(playerStore, getLogger()), this);
             final AgentMenuActions menuActions = new AgentMenuActions(
                 mainThreadExecutor,
                 playerStore

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
@@ -68,7 +68,7 @@ class AgentPlayerActionsTest
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
         when(player.performCommand("gamemode creative")).thenReturn(true);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final ExecutePlayerCommand.Command command =
             new ExecutePlayerCommand.Command("request-cmd", uuid, "/gamemode creative");
 
@@ -93,7 +93,7 @@ class AgentPlayerActionsTest
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
         when(player.performCommand("say hi")).thenReturn(false);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final ExecutePlayerCommand.Command command =
             new ExecutePlayerCommand.Command("request-cmd", uuid, "say hi");
 
@@ -118,7 +118,7 @@ class AgentPlayerActionsTest
         final PlayerActionsFixture fixture = createPlayerActionsFixture();
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final CommandMap commandMap = mock();
         final TabCompleteServer server = mock();
         when(server.getCommandMap()).thenReturn(commandMap);
@@ -148,7 +148,7 @@ class AgentPlayerActionsTest
         final PlayerActionsFixture fixture = createPlayerActionsFixture();
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final CommandMap commandMap = mock();
         final TabCompleteServer server = mock();
         when(server.getCommandMap()).thenReturn(commandMap);
@@ -177,7 +177,7 @@ class AgentPlayerActionsTest
         final PlayerActionsFixture fixture = createPlayerActionsFixture();
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final CommandMap commandMap = mock();
         final TabCompleteServer server = mock();
         when(server.getCommandMap()).thenReturn(commandMap);
@@ -210,7 +210,8 @@ class AgentPlayerActionsTest
         {
             bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
             assertThatThrownBy(() -> playerActions.handleTabCompletePlayer(command))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                    assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_NOT_REGISTERED))
                 .hasMessageContaining("not registered");
         }
     }
@@ -225,7 +226,7 @@ class AgentPlayerActionsTest
         final Player player = mockPlayer(uuid);
         final PluginManager pluginManager = mock();
         final ArgumentCaptor<PlayerInteractEvent> eventCaptor = ArgumentCaptor.forClass(PlayerInteractEvent.class);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final LeftClickBlock.Command command =
             new LeftClickBlock.Command("request-click", uuid, 1, 64, 2, "NORTH");
 
@@ -268,7 +269,7 @@ class AgentPlayerActionsTest
         when(player.getWorld()).thenReturn(world);
         when(inventory.getItemInMainHand()).thenReturn(item);
         when(world.dropItemNaturally(any(), any())).thenReturn(entity);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final DropItem.Command command = new DropItem.Command("req-drop", uuid);
 
         // execute
@@ -308,7 +309,7 @@ class AgentPlayerActionsTest
         when(player.getWorld()).thenReturn(world);
         when(inventory.getItemInMainHand()).thenReturn(item);
         when(world.dropItemNaturally(any(), any())).thenReturn(entity);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final DropItem.Command command = new DropItem.Command("req-drop-cancel", uuid);
 
         // execute
@@ -415,7 +416,7 @@ class AgentPlayerActionsTest
             airItem,
             stone
         });
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final GetPlayerInventory.Command command = new GetPlayerInventory.Command("request-inventory", uuid);
 
         // execute
@@ -445,7 +446,7 @@ class AgentPlayerActionsTest
         final Player player = mock();
         final PermissionAttachment attachment = mock();
         when(player.addAttachment(any())).thenReturn(attachment);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final MutatePlayerPermission.Command command = new MutatePlayerPermission.Command(
             "request-grant", uuid, "test.perm", MutatePlayerPermission.Mode.GRANT);
 
@@ -472,7 +473,7 @@ class AgentPlayerActionsTest
         final Player player = mock();
         final PermissionAttachment attachment = mock();
         when(player.addAttachment(any())).thenReturn(attachment);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final MutatePlayerPermission.Command command = new MutatePlayerPermission.Command(
             "request-revoke", uuid, "test.perm", MutatePlayerPermission.Mode.REVOKE);
 
@@ -499,7 +500,7 @@ class AgentPlayerActionsTest
         final Player player = mock();
         final PermissionAttachment attachment = mock();
         when(player.addAttachment(any())).thenReturn(attachment);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final MutatePlayerPermission.Command grantCommand = new MutatePlayerPermission.Command(
             "request-grant", uuid, "test.perm", MutatePlayerPermission.Mode.GRANT);
         final MutatePlayerPermission.Command unsetCommand = new MutatePlayerPermission.Command(
@@ -526,7 +527,7 @@ class AgentPlayerActionsTest
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
         when(player.hasPermission("test.perm")).thenReturn(true);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final HasPlayerPermission.Command command =
             new HasPlayerPermission.Command("request-has-true", uuid, "test.perm");
 
@@ -551,7 +552,7 @@ class AgentPlayerActionsTest
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
         when(player.hasPermission("test.perm")).thenReturn(false);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final HasPlayerPermission.Command command =
             new HasPlayerPermission.Command("request-has-false", uuid, "test.perm");
 
@@ -649,7 +650,7 @@ class AgentPlayerActionsTest
         final ItemStack emptyHand = mock();
         when(emptyHand.getType()).thenReturn(Material.AIR);
         when(player.getInventory().getItemInMainHand()).thenReturn(emptyHand);
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final DropItem.Command command = new DropItem.Command("request-drop", uuid);
 
         // execute
@@ -665,7 +666,30 @@ class AgentPlayerActionsTest
     }
 
     @Test
-    void handleCreatePlayer_shouldSpawnPlayerWithCoordinatesAndOptionalPermissions()
+    void handleTeleportPlayer_shouldReportDeadPlayerBeforeTeleport()
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.isDead()).thenReturn(true);
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        final TeleportPlayer.Command command =
+            new TeleportPlayer.Command("request-teleport", uuid, "world", 1.0D, 64.0D, 2.0D);
+
+        // execute + verify
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
+        {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            assertThatThrownBy(() -> fixture.playerActions().handleTeleportPlayer(command))
+                .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                    assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD));
+        }
+        verify(player, never()).teleport(any(org.bukkit.Location.class));
+    }
+
+    @Test
+    void handleCreatePlayer_shouldSpawnVulnerablePlayerWithCoordinatesAndOptionalPermissions()
         throws Exception
     {
         // setup
@@ -679,7 +703,7 @@ class AgentPlayerActionsTest
         when(player.addAttachment(any())).thenReturn(attachment);
         final CreatePlayer.Command command = new CreatePlayer.Command(
             "request-create", "testbot", uuid, "world", 10.0, 64.0, 20.0, null, "test.perm",
-            JoinMode.LEGACY_SPAWN, null
+            false, JoinMode.LEGACY_SPAWN, null
         );
 
         // execute
@@ -699,6 +723,7 @@ class AgentPlayerActionsTest
         // is dropped and removePermissionAttachment finds nothing to detach.
         fixture.playerStore().removePermissionAttachment(uuid, player);
         verify(player).removeAttachment(attachment);
+        verify(player).setInvulnerable(false);
     }
 
     @Test
@@ -710,7 +735,8 @@ class AgentPlayerActionsTest
         when(fixture.nmsAdapter().loginDriver()).thenReturn(loginDriver);
         when(loginDriver.login(any())).thenReturn(new IBotLoginOutcome.Denied(BotJoinPhase.LOGIN, "Banned"));
         final CreatePlayer.Command command = new CreatePlayer.Command(
-            "request-full", "fullbot", null, "world", null, null, null, null, null, JoinMode.FULL_LOGIN, "en_us");
+            "request-full", "fullbot", null, "world", null, null, null, null, null, true,
+            JoinMode.FULL_LOGIN, "en_us");
 
         try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
         {
@@ -737,7 +763,8 @@ class AgentPlayerActionsTest
         when(fixture.nmsAdapter().loginDriver()).thenReturn(loginDriver);
         when(loginDriver.login(any())).thenReturn(new IBotLoginOutcome.TimedOut(BotJoinPhase.LOGIN));
         final CreatePlayer.Command command = new CreatePlayer.Command(
-            "request-full-to", "fullbot", null, "world", null, null, null, null, null, JoinMode.FULL_LOGIN, null);
+            "request-full-to", "fullbot", null, "world", null, null, null, null, null, true,
+            JoinMode.FULL_LOGIN, null);
 
         try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
         {
@@ -766,7 +793,8 @@ class AgentPlayerActionsTest
         when(fixture.nmsAdapter().loginDriver()).thenReturn(loginDriver);
         when(loginDriver.login(any())).thenReturn(new IBotLoginOutcome.Joined("fullbot"));
         final CreatePlayer.Command command = new CreatePlayer.Command(
-            "request-full-nj", "fullbot", null, "world", null, null, null, null, null, JoinMode.FULL_LOGIN, null);
+            "request-full-nj", "fullbot", null, "world", null, null, null, null, null, true,
+            JoinMode.FULL_LOGIN, null);
 
         try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
         {
@@ -799,7 +827,8 @@ class AgentPlayerActionsTest
         when(player.getUniqueId()).thenReturn(uuid);
         when(player.getName()).thenReturn("fullbot");
         final CreatePlayer.Command createCommand = new CreatePlayer.Command(
-            "request-full-rm", "fullbot", null, "world", null, null, null, null, null, JoinMode.FULL_LOGIN, null);
+            "request-full-rm", "fullbot", null, "world", null, null, null, null, null, true,
+            JoinMode.FULL_LOGIN, null);
 
         try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
         {
@@ -813,6 +842,7 @@ class AgentPlayerActionsTest
             // verify — the bot leaves through the real disconnect flow (kick), never the legacy player-list
             // removal that would leave its TCP connection open (Paper crashes on the second removal when the
             // server times that connection out).
+            verify(player).setInvulnerable(true);
             verify(player).kickPlayer(anyString());
             verify(fixture.nmsAdapter(), never()).removePlayer(any());
         }
@@ -834,8 +864,8 @@ class AgentPlayerActionsTest
         when(player.getName()).thenReturn("fullbot");
         when(player.isOnline()).thenReturn(true);
         final CreatePlayer.Command createCommand = new CreatePlayer.Command(
-            "request-full-veto", "fullbot", null, "world", null, null, null, null, null, JoinMode.FULL_LOGIN,
-            null);
+            "request-full-veto", "fullbot", null, "world", null, null, null, null, null, true,
+            JoinMode.FULL_LOGIN, null);
 
         try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
         {
@@ -917,7 +947,7 @@ class AgentPlayerActionsTest
         final PlayerActionsFixture fixture = createPlayerActionsFixture();
         final UUID uuid = UUID.randomUUID();
         final Player player = mock();
-        fixture.playerStore().registerSyntheticPlayer(uuid, player);
+        registerActivePlayer(fixture, uuid, player);
         final PlayerChat.Command command = new PlayerChat.Command("request-chat", uuid, "hello world");
 
         // execute
@@ -946,7 +976,8 @@ class AgentPlayerActionsTest
         {
             bukkitMockedStatic.when(Bukkit::isPrimaryThread).thenReturn(true);
             assertThatThrownBy(() -> playerActions.handlePlayerChat(command))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                    assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_NOT_REGISTERED))
                 .hasMessageContaining("not registered");
         }
     }
@@ -1002,6 +1033,12 @@ class AgentPlayerActionsTest
         when(world.getBlockAt(1, 64, 2)).thenReturn(block);
         when(inventory.getItemInMainHand()).thenReturn(item);
         return player;
+    }
+
+    private static void registerActivePlayer(PlayerActionsFixture fixture, UUID uuid, Player player)
+    {
+        when(player.isOnline()).thenReturn(true);
+        fixture.playerStore().registerSyntheticPlayer(uuid, player);
     }
 
     private record PlayerActionsFixture(

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentPlayerActionsTest.java
@@ -37,6 +37,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.permissions.PermissionAttachment;
@@ -48,10 +49,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.net.InetAddress;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -677,14 +684,18 @@ class AgentPlayerActionsTest
         final TeleportPlayer.Command command =
             new TeleportPlayer.Command("request-teleport", uuid, "world", 1.0D, 64.0D, 2.0D);
 
-        // execute + verify
+        // execute
+        final Throwable thrown;
         try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
         {
             bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
-            assertThatThrownBy(() -> fixture.playerActions().handleTeleportPlayer(command))
-                .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
-                    assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD));
+            thrown = catchThrowable(() -> fixture.playerActions().handleTeleportPlayer(command));
         }
+
+        // verify
+        assertThat(thrown)
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD));
         verify(player, never()).teleport(any(org.bukkit.Location.class));
     }
 
@@ -698,7 +709,14 @@ class AgentPlayerActionsTest
         final World world = mock();
         final Player player = mockPlayer(uuid);
         when(player.getName()).thenReturn("testbot");
-        when(fixture.nmsAdapter().spawnPlayer(eq(uuid), eq("testbot"), eq(world), any())).thenReturn(player);
+        when(fixture.nmsAdapter().spawnPlayer(eq(uuid), eq("testbot"), eq(world), any(), eq(false), any()))
+            .thenAnswer(invocation ->
+            {
+                @SuppressWarnings("unchecked")
+                final Consumer<Player> beforeJoin = invocation.getArgument(5);
+                beforeJoin.accept(player);
+                return player;
+            });
         final PermissionAttachment attachment = mock();
         when(player.addAttachment(any())).thenReturn(attachment);
         final CreatePlayer.Command command = new CreatePlayer.Command(
@@ -723,7 +741,7 @@ class AgentPlayerActionsTest
         // is dropped and removePermissionAttachment finds nothing to detach.
         fixture.playerStore().removePermissionAttachment(uuid, player);
         verify(player).removeAttachment(attachment);
-        verify(player).setInvulnerable(false);
+        verify(fixture.nmsAdapter()).spawnPlayer(eq(uuid), eq("testbot"), eq(world), any(), eq(false), any());
     }
 
     @Test
@@ -752,6 +770,64 @@ class AgentPlayerActionsTest
                     .isEqualTo(AgentErrorCode.PLAYER_JOIN_DENIED))
                 .hasMessageContaining("Banned");
         }
+    }
+
+    @Test
+    void handleCreatePlayer_shouldApplyInvulnerabilityBeforeFullLoginJoinHandlers()
+        throws Exception
+    {
+        // setup
+        final PlayerActionsFixture fixture = createPlayerActionsFixture();
+        final IBotLoginDriver loginDriver = mock();
+        when(fixture.nmsAdapter().loginDriver()).thenReturn(loginDriver);
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(player.getName()).thenReturn("fullbot");
+        final AtomicBoolean invulnerable = new AtomicBoolean();
+        doAnswer(invocation ->
+        {
+            invulnerable.set(invocation.getArgument(0));
+            return null;
+        }).when(player).setInvulnerable(anyBoolean());
+
+        final Map<Class<?>, Listener> listeners = new HashMap<>();
+        final Map<Class<?>, EventExecutor> eventExecutors = new HashMap<>();
+        final PluginManager pluginManager = mock();
+        doAnswer(invocation ->
+        {
+            final Class<?> eventType = invocation.getArgument(0);
+            listeners.put(eventType, invocation.getArgument(1));
+            eventExecutors.put(eventType, invocation.getArgument(3));
+            return null;
+        }).when(pluginManager).registerEvent(any(), any(), any(), any(), any());
+
+        final AtomicBoolean invulnerableAtJoin = new AtomicBoolean();
+        when(loginDriver.login(any())).thenAnswer(invocation ->
+        {
+            Objects.requireNonNull(eventExecutors.get(PlayerLoginEvent.class)).execute(
+                Objects.requireNonNull(listeners.get(PlayerLoginEvent.class)),
+                new PlayerLoginEvent(player, "localhost", InetAddress.getLoopbackAddress()));
+            invulnerableAtJoin.set(invulnerable.get());
+            Objects.requireNonNull(eventExecutors.get(PlayerJoinEvent.class)).execute(
+                Objects.requireNonNull(listeners.get(PlayerJoinEvent.class)), new PlayerJoinEvent(player, "joined"));
+            return new IBotLoginOutcome.Joined("fullbot");
+        });
+        final CreatePlayer.Command command = new CreatePlayer.Command(
+            "request-full-safe", "fullbot", null, "world", null, null, null, null, null, true,
+            JoinMode.FULL_LOGIN, null);
+
+        // execute
+        final CreatePlayer.Response response;
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class))
+        {
+            stubFullLoginBukkitStatics(bukkit, pluginManager);
+            response = fixture.playerActions().handleCreatePlayer(command);
+        }
+
+        // verify
+        assertThat(response.uuid()).isEqualTo(uuid);
+        assertThat(invulnerableAtJoin).isTrue();
     }
 
     @Test
@@ -842,7 +918,6 @@ class AgentPlayerActionsTest
             // verify — the bot leaves through the real disconnect flow (kick), never the legacy player-list
             // removal that would leave its TCP connection open (Paper crashes on the second removal when the
             // server times that connection out).
-            verify(player).setInvulnerable(true);
             verify(player).kickPlayer(anyString());
             verify(fixture.nmsAdapter(), never()).removePlayer(any());
         }
@@ -890,12 +965,20 @@ class AgentPlayerActionsTest
     }
 
     /**
-     * Creates a plugin-manager mock that immediately fires a {@code PlayerJoinEvent} for the given player
-     * whenever an event executor is registered, completing a FULL_LOGIN join's join-latch synchronously.
+     * Creates a plugin-manager mock that immediately fires the login and join events for the given player when
+     * their executors are registered, completing a FULL_LOGIN join's join-latch synchronously.
      */
     private static PluginManager joinEventFiringPluginManager(Player player)
     {
         final PluginManager pluginManager = mock();
+        doAnswer(invocation ->
+        {
+            final Listener listener = invocation.getArgument(1);
+            final EventExecutor eventExecutor = invocation.getArgument(3);
+            eventExecutor.execute(
+                listener, new PlayerLoginEvent(player, "localhost", InetAddress.getLoopbackAddress()));
+            return null;
+        }).when(pluginManager).registerEvent(eq(PlayerLoginEvent.class), any(), any(), any(), any());
         doAnswer(invocation ->
         {
             final Listener listener = invocation.getArgument(1);

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentRequestDispatcherTest.java
@@ -381,7 +381,19 @@ class AgentRequestDispatcherTest
         dispatchExpectingSuccess(fixture, toJson(new ExecuteCommand.Command("request-2", CommandSource.CONSOLE, "time set day")));
         dispatchExpectingSuccess(fixture, toJson(new BlockType.Command("request-3", "world", 0, 64, 0)));
         dispatchExpectingSuccess(fixture, toJson(new SetBlock.Command("request-4", "world", 0, 64, 0, "stone", null)));
-        dispatchExpectingSuccess(fixture, toJson(new CreatePlayer.Command("request-5", "bot", uuid, "world", null, null, null, null, null, JoinMode.LEGACY_SPAWN, null)));
+        dispatchExpectingSuccess(fixture,
+            toJson(new CreatePlayer.Command("request-5",
+                "bot",
+                uuid,
+                "world",
+                null,
+                null,
+                null,
+                null,
+                null,
+                true,
+                JoinMode.LEGACY_SPAWN,
+                null)));
         dispatchExpectingSuccess(fixture, toJson(new RemovePlayer.Command("request-6", uuid)));
         dispatchExpectingSuccess(fixture, toJson(new ExecutePlayerCommand.Command("request-7", uuid, "gamemode creative")));
         dispatchExpectingSuccess(fixture, toJson(new PlacePlayerBlock.Command("request-8", uuid, "stone", 0, 64, 0)));
@@ -488,7 +500,7 @@ class AgentRequestDispatcherTest
         final AgentRequestDispatcher dispatcher = createDispatcher("token", 1, "");
         final String requestLine = "{\"requestId\":\"req-123\",\"action\":\"CREATE_PLAYER\","
             + "\"name\":\"\",\"uuid\":\"550e8400-e29b-41d4-a716-446655440000\","
-            + "\"worldName\":\"world\"}";
+            + "\"worldName\":\"world\",\"invulnerable\":true,\"joinMode\":\"LEGACY_SPAWN\"}";
 
         // execute
         final AgentRequestDispatcher.RequestDispatchResult result =

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerLifecycleListenerTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerLifecycleListenerTest.java
@@ -1,0 +1,85 @@
+package nl.pim16aap2.lightkeeper.agent.spigot;
+
+import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
+import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AgentSyntheticPlayerLifecycleListenerTest
+{
+    @Test
+    void onPlayerDeath_shouldLogAndRetainSyntheticPlayerDeathDetails()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final Logger logger = mock();
+        final AgentSyntheticPlayerLifecycleListener listener =
+            new AgentSyntheticPlayerLifecycleListener(store, logger);
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        final World world = mock();
+        final PlayerDeathEvent event = mock();
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(player.getName()).thenReturn("fallingbot");
+        when(player.getLocation()).thenReturn(new Location(world, 1.0D, 64.0D, 2.0D));
+        when(player.isOnline()).thenReturn(true);
+        when(world.getName()).thenReturn("world");
+        when(event.getEntity()).thenReturn(player);
+        when(event.getDeathMessage()).thenReturn("fallingbot fell from a high place");
+        store.registerSyntheticPlayer(uuid, player);
+
+        // execute
+        listener.onPlayerDeath(event);
+
+        // verify
+        verify(logger).info(contains("LK_AGENT: Synthetic player 'fallingbot'"));
+        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER"))
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD))
+            .hasMessageContaining("cause=<unknown>")
+            .hasMessageContaining("world[1.00, 64.00, 2.00]")
+            .hasMessageContaining("fell from a high place");
+    }
+
+    @Test
+    void onPlayerQuit_shouldLogAndRetainDisconnectedState()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final Logger logger = mock();
+        final AgentSyntheticPlayerLifecycleListener listener =
+            new AgentSyntheticPlayerLifecycleListener(store, logger);
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        final PlayerQuitEvent event = mock();
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(player.getName()).thenReturn("leavingbot");
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getQuitMessage()).thenReturn("leavingbot left the game");
+        store.registerSyntheticPlayer(uuid, player);
+
+        // execute
+        listener.onPlayerQuit(event);
+
+        // verify
+        verify(logger).info(contains("LK_AGENT: Synthetic player 'leavingbot'"));
+        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "PLAYER_CHAT"))
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DISCONNECTED))
+            .hasMessageContaining("left the game");
+    }
+}

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerLifecycleListenerTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerLifecycleListenerTest.java
@@ -7,6 +7,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -81,5 +82,36 @@ class AgentSyntheticPlayerLifecycleListenerTest
             .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
                 assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DISCONNECTED))
             .hasMessageContaining("left the game");
+    }
+
+    @Test
+    void onPlayerRespawn_shouldClearRecordedDeath()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final Logger logger = mock();
+        final AgentSyntheticPlayerLifecycleListener listener =
+            new AgentSyntheticPlayerLifecycleListener(store, logger);
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        final World world = mock();
+        final Location respawnLocation = new Location(world, 4.0D, 70.0D, 8.0D);
+        final PlayerRespawnEvent event = mock();
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(player.getName()).thenReturn("respawnbot");
+        when(player.isOnline()).thenReturn(true);
+        when(world.getName()).thenReturn("world");
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getRespawnLocation()).thenReturn(respawnLocation);
+        store.registerSyntheticPlayer(uuid, player);
+        store.markPlayerDead(uuid, "player died");
+
+        // execute
+        listener.onPlayerRespawn(event);
+
+        // verify
+        assertThat(store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER")).isSameAs(player);
+        verify(logger).info(contains("Synthetic player 'respawnbot'"));
+        verify(logger).info(contains("respawned at world[4.00, 70.00, 8.00]"));
     }
 }

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
@@ -26,8 +26,11 @@ class AgentSyntheticPlayerStoreTest
         when(player.isDead()).thenReturn(true);
         store.registerSyntheticPlayer(uuid, player);
 
-        // execute + verify
-        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER"))
+        // execute
+        final Throwable thrown = catchThrowable(() -> store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER"));
+
+        // verify
+        assertThat(thrown)
             .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
                 assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD))
             .hasMessageContaining("TELEPORT_PLAYER")
@@ -44,8 +47,11 @@ class AgentSyntheticPlayerStoreTest
         when(player.isOnline()).thenReturn(false);
         store.registerSyntheticPlayer(uuid, player);
 
-        // execute + verify
-        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "PLAYER_CHAT"))
+        // execute
+        final Throwable thrown = catchThrowable(() -> store.getRequiredActivePlayer(uuid, "PLAYER_CHAT"));
+
+        // verify
+        assertThat(thrown)
             .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
                 assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DISCONNECTED))
             .hasMessageContaining("PLAYER_CHAT")
@@ -81,15 +87,23 @@ class AgentSyntheticPlayerStoreTest
         store.registerSyntheticPlayer(uuid, player);
         store.markPlayerDead(uuid, "cause=minecraft:fall location=world[1.0,64.0,2.0]");
 
-        // execute + verify
-        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER"))
+        // execute - inspect the recorded death
+        final Throwable deathFailure = catchThrowable(
+            () -> store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER"));
+
+        // verify - the diagnostic survives Bukkit's transient entity state
+        assertThat(deathFailure)
             .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
                 assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD))
             .hasMessageContaining("minecraft:fall")
             .hasMessageContaining("world[1.0,64.0,2.0]");
 
+        // execute - complete the lifecycle transition
         store.markPlayerRespawned(uuid);
-        assertThat(store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER")).isSameAs(player);
+        final Player respawnedPlayer = store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER");
+
+        // verify - actions are available again after respawn
+        assertThat(respawnedPlayer).isSameAs(player);
     }
 
     @Test

--- a/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
+++ b/lightkeeper-agent-spigot/src/test/java/nl/pim16aap2/lightkeeper/agent/spigot/AgentSyntheticPlayerStoreTest.java
@@ -1,6 +1,8 @@
 package nl.pim16aap2.lightkeeper.agent.spigot;
 
 import nl.pim16aap2.lightkeeper.nms.api.IBotPlayerNmsAdapter;
+import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
+import nl.pim16aap2.lightkeeper.protocol.AgentProtocolException;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -15,6 +17,82 @@ import static org.mockito.Mockito.*;
 class AgentSyntheticPlayerStoreTest
 {
     @Test
+    void getRequiredActivePlayer_shouldReportDeadPlayer()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.isDead()).thenReturn(true);
+        store.registerSyntheticPlayer(uuid, player);
+
+        // execute + verify
+        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER"))
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD))
+            .hasMessageContaining("TELEPORT_PLAYER")
+            .hasMessageContaining(uuid.toString());
+    }
+
+    @Test
+    void getRequiredActivePlayer_shouldReportDisconnectedPlayer()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.isOnline()).thenReturn(false);
+        store.registerSyntheticPlayer(uuid, player);
+
+        // execute + verify
+        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "PLAYER_CHAT"))
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DISCONNECTED))
+            .hasMessageContaining("PLAYER_CHAT")
+            .hasMessageContaining(uuid.toString());
+    }
+
+    @Test
+    void getRequiredActivePlayer_shouldAcceptOnlinePlayerWhenBukkitEntityIsInvalid()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.isOnline()).thenReturn(true);
+        store.registerSyntheticPlayer(uuid, player);
+
+        // execute
+        final Player result = store.getRequiredActivePlayer(uuid, "EXECUTE_PLAYER_COMMAND");
+
+        // verify
+        assertThat(result).isSameAs(player);
+        verify(player, never()).isValid();
+    }
+
+    @Test
+    void markPlayerDead_shouldPreserveDeathDetailsUntilRespawn()
+    {
+        // setup
+        final AgentSyntheticPlayerStore store = new AgentSyntheticPlayerStore();
+        final UUID uuid = UUID.randomUUID();
+        final Player player = mock();
+        when(player.isOnline()).thenReturn(true);
+        store.registerSyntheticPlayer(uuid, player);
+        store.markPlayerDead(uuid, "cause=minecraft:fall location=world[1.0,64.0,2.0]");
+
+        // execute + verify
+        assertThatThrownBy(() -> store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER"))
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_DEAD))
+            .hasMessageContaining("minecraft:fall")
+            .hasMessageContaining("world[1.0,64.0,2.0]");
+
+        store.markPlayerRespawned(uuid);
+        assertThat(store.getRequiredActivePlayer(uuid, "TELEPORT_PLAYER")).isSameAs(player);
+    }
+
+    @Test
     void getRequiredPlayer_shouldThrowExceptionWhenPlayerIsNotRegistered()
     {
         // setup
@@ -23,7 +101,8 @@ class AgentSyntheticPlayerStoreTest
 
         // execute + verify
         assertThatThrownBy(() -> store.getRequiredPlayer(uuid))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_NOT_REGISTERED))
             .hasMessageContaining(uuid.toString());
     }
 
@@ -322,7 +401,8 @@ class AgentSyntheticPlayerStoreTest
         assertThat(store.syntheticPlayerIds()).isEmpty();
         assertThat(store.getPlayerMessages(uuid)).isEmpty();
         assertThatThrownBy(() -> store.getRequiredPlayer(uuid))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOfSatisfying(AgentProtocolException.class, exception ->
+                assertThat(exception.errorCode()).isEqualTo(AgentErrorCode.PLAYER_NOT_REGISTERED));
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IBots.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IBots.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 public interface IBots
 {
     /**
-     * Joins a synthetic player into a world at spawn.
+     * Joins an invulnerable synthetic player into a world at spawn.
      *
      * @param name
      *     Player name.
@@ -21,7 +21,7 @@ public interface IBots
     PlayerHandle join(String name, WorldHandle world);
 
     /**
-     * Joins a synthetic player into a world at spawn.
+     * Joins an invulnerable synthetic player into a world at spawn.
      *
      * @param name
      *     Player name.

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IPlayerBuilder.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/IPlayerBuilder.java
@@ -64,6 +64,16 @@ public interface IPlayerBuilder
     IPlayerBuilder withHealth(double health);
 
     /**
+     * Allows ordinary server damage to affect the synthetic player.
+     *
+     * <p>Synthetic players are invulnerable by default so unrelated survival mechanics cannot make tests
+     * nondeterministic. Use this opt-in for tests that explicitly exercise damage or death behavior.
+     *
+     * @return This builder.
+     */
+    IPlayerBuilder vulnerable();
+
+    /**
      * Grants permissions to the synthetic player.
      *
      * @param permissions

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerUnavailableException.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/PlayerUnavailableException.java
@@ -1,0 +1,54 @@
+package nl.pim16aap2.lightkeeper.framework;
+
+import java.util.Objects;
+
+/**
+ * Thrown when a synthetic player cannot perform an action because its server-side lifecycle state is no longer
+ * active.
+ *
+ * <p>The {@link Reason} is stable for programmatic assertions; the exception message retains the agent's
+ * contextual diagnostics, such as the attempted action and recorded death details.
+ */
+public class PlayerUnavailableException extends IllegalStateException
+{
+    private static final long serialVersionUID = 1L;
+
+    private final Reason reason;
+
+    /**
+     * Creates a player-availability exception.
+     *
+     * @param reason
+     *     Machine-readable reason the player is unavailable.
+     * @param message
+     *     Human-readable lifecycle and action diagnostics from the agent.
+     */
+    public PlayerUnavailableException(Reason reason, String message)
+    {
+        super(message);
+        this.reason = Objects.requireNonNull(reason, "reason may not be null.");
+    }
+
+    /**
+     * Returns why the synthetic player was unavailable.
+     *
+     * @return Machine-readable availability reason.
+     */
+    public Reason reason()
+    {
+        return reason;
+    }
+
+    /**
+     * Machine-readable synthetic-player availability failures.
+     */
+    public enum Reason
+    {
+        /** The player handle does not identify a registered synthetic player. */
+        NOT_REGISTERED,
+        /** The player is dead and has not respawned. */
+        DEAD,
+        /** The player left the server or otherwise went offline. */
+        DISCONNECTED
+    }
+}

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/BotsFacade.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/BotsFacade.java
@@ -21,6 +21,10 @@ import java.util.UUID;
  */
 final class BotsFacade implements IBots
 {
+    /**
+     * Canonical damage-safety default for every synthetic-player creation entry point.
+     */
+    static final boolean DEFAULT_INVULNERABLE = true;
     private static final System.Logger LOG = System.getLogger(BotsFacade.class.getName());
 
     private final DefaultLightkeeperFramework framework;
@@ -61,6 +65,7 @@ final class BotsFacade implements IBots
             null,
             null,
             null,
+            DEFAULT_INVULNERABLE,
             JoinMode.LEGACY_SPAWN,
             null
         );
@@ -95,6 +100,7 @@ final class BotsFacade implements IBots
         @Nullable Double z,
         @Nullable Double health,
         Set<String> permissions,
+        boolean invulnerable,
         JoinMode joinMode,
         @Nullable String locale)
     {
@@ -107,6 +113,7 @@ final class BotsFacade implements IBots
             z,
             health,
             permissions,
+            invulnerable,
             joinMode,
             locale
         );

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultLightkeeperFramework.java
@@ -801,9 +801,11 @@ public final class DefaultLightkeeperFramework implements ILightkeeperFramework,
         @Nullable Double z,
         @Nullable Double health,
         java.util.Set<String> permissions,
+        boolean invulnerable,
         nl.pim16aap2.lightkeeper.protocol.JoinMode joinMode,
         @Nullable String locale)
     {
-        return botsFacade.createFromBuilder(name, uuid, worldHandle, x, y, z, health, permissions, joinMode, locale);
+        return botsFacade.createFromBuilder(
+            name, uuid, worldHandle, x, y, z, health, permissions, invulnerable, joinMode, locale);
     }
 }

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultPlayerBuilder.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/DefaultPlayerBuilder.java
@@ -23,6 +23,7 @@ final class DefaultPlayerBuilder implements IPlayerBuilder
     private @Nullable Double y;
     private @Nullable Double z;
     private @Nullable Double health;
+    private boolean invulnerable = BotsFacade.DEFAULT_INVULNERABLE;
     private final Set<String> permissions = new HashSet<>();
     private JoinMode joinMode = JoinMode.LEGACY_SPAWN;
     private @Nullable String locale;
@@ -87,6 +88,13 @@ final class DefaultPlayerBuilder implements IPlayerBuilder
     }
 
     @Override
+    public IPlayerBuilder vulnerable()
+    {
+        this.invulnerable = false;
+        return this;
+    }
+
+    @Override
     public IPlayerBuilder withPermissions(String... permissions)
     {
         if (permissions == null || permissions.length == 0)
@@ -134,6 +142,7 @@ final class DefaultPlayerBuilder implements IPlayerBuilder
             z,
             health,
             permissions,
+            invulnerable,
             joinMode,
             locale
         );

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClient.java
@@ -200,6 +200,7 @@ final class UdsAgentClient implements AutoCloseable
         @Nullable Double z,
         @Nullable Double health,
         @Nullable Set<String> permissions,
+        boolean invulnerable,
         JoinMode joinMode,
         @Nullable String locale)
     {
@@ -221,6 +222,7 @@ final class UdsAgentClient implements AutoCloseable
             z,
             health,
             permissionsCsv,
+            invulnerable,
             joinMode,
             locale
         );

--- a/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentTransport.java
+++ b/lightkeeper-framework-junit/src/main/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentTransport.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.lightkeeper.framework.internal;
 
 import nl.pim16aap2.lightkeeper.framework.BotJoinDeniedException;
 import nl.pim16aap2.lightkeeper.framework.BotJoinTimeoutException;
+import nl.pim16aap2.lightkeeper.framework.PlayerUnavailableException;
 import nl.pim16aap2.lightkeeper.protocol.AgentErrorCode;
 import nl.pim16aap2.lightkeeper.protocol.AgentProtocolMapper;
 import nl.pim16aap2.lightkeeper.protocol.IAgentCommand;
@@ -167,6 +168,12 @@ final class UdsAgentTransport implements AutoCloseable
             throw new BotJoinDeniedException(errorMessage);
         if (errorCode == AgentErrorCode.PLAYER_JOIN_TIMEOUT)
             throw new BotJoinTimeoutException(errorMessage);
+        if (errorCode == AgentErrorCode.PLAYER_DEAD)
+            throw new PlayerUnavailableException(PlayerUnavailableException.Reason.DEAD, errorMessage);
+        if (errorCode == AgentErrorCode.PLAYER_DISCONNECTED)
+            throw new PlayerUnavailableException(PlayerUnavailableException.Reason.DISCONNECTED, errorMessage);
+        if (errorCode == AgentErrorCode.PLAYER_NOT_REGISTERED)
+            throw new PlayerUnavailableException(PlayerUnavailableException.Reason.NOT_REGISTERED, errorMessage);
 
         final String displayedErrorCode = errorCode != null
             ? errorCode.wireCode()

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/BotsFacadeTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/BotsFacadeTest.java
@@ -9,6 +9,7 @@ import nl.pim16aap2.lightkeeper.runtime.RuntimeManifest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +31,7 @@ class BotsFacadeTest
         final PlayerScopeRegistry playerScopeRegistry = mock(PlayerScopeRegistry.class);
         final UUID uuid = UUID.randomUUID();
         when(agentClient.createPlayer(
-            "lkbot001", uuid, "world", null, null, null, null, null, JoinMode.LEGACY_SPAWN, null))
+            "lkbot001", uuid, "world", null, null, null, null, null, true, JoinMode.LEGACY_SPAWN, null))
             .thenReturn(new AgentPlayerData(uuid, "lkbot001"));
         final DefaultLightkeeperFramework framework = framework(agentClient, playerScopeRegistry);
         final WorldHandle world = FrameworkHandleFactory.worldHandle(framework, "world");
@@ -53,7 +54,7 @@ class BotsFacadeTest
         final UUID generatedUuid = UUID.randomUUID();
         when(agentClient.createPlayer(
             eq("lkbot002"), any(UUID.class), eq("world"), isNull(), isNull(), isNull(), isNull(), isNull(),
-            eq(JoinMode.LEGACY_SPAWN), isNull()))
+            eq(true), eq(JoinMode.LEGACY_SPAWN), isNull()))
             .thenReturn(new AgentPlayerData(generatedUuid, "lkbot002"));
         final DefaultLightkeeperFramework framework = framework(agentClient, playerScopeRegistry);
         final WorldHandle world = FrameworkHandleFactory.worldHandle(framework, "world");
@@ -106,6 +107,57 @@ class BotsFacadeTest
 
         // verify
         assertThat(builder).isNotNull();
+    }
+
+    @Test
+    void build_shouldCreateInvulnerablePlayerByDefault()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final PlayerScopeRegistry playerScopeRegistry = mock(PlayerScopeRegistry.class);
+        final UUID createdUuid = UUID.randomUUID();
+        when(agentClient.createPlayer(
+            eq("safe_bot"), any(UUID.class), eq("world"), isNull(), isNull(), isNull(), isNull(), eq(Set.of()),
+            eq(true), eq(JoinMode.LEGACY_SPAWN), isNull()))
+            .thenReturn(new AgentPlayerData(createdUuid, "safe_bot"));
+        final DefaultLightkeeperFramework framework = framework(agentClient, playerScopeRegistry);
+        final WorldHandle world = FrameworkHandleFactory.worldHandle(framework, "world");
+
+        // execute
+        final PlayerHandle player = framework.bots().builder()
+            .withName("safe_bot")
+            .atSpawn(world)
+            .build();
+
+        // verify
+        assertThat(player.uniqueId()).isEqualTo(createdUuid);
+        verify(playerScopeRegistry).register(createdUuid);
+    }
+
+    @Test
+    void build_shouldCreateVulnerablePlayerWhenRequested()
+    {
+        // setup
+        final UdsAgentClient agentClient = mock(UdsAgentClient.class);
+        final PlayerScopeRegistry playerScopeRegistry = mock(PlayerScopeRegistry.class);
+        final UUID createdUuid = UUID.randomUUID();
+        when(agentClient.createPlayer(
+            eq("damage_bot"), any(UUID.class), eq("world"), isNull(), isNull(), isNull(), isNull(), eq(Set.of()),
+            eq(false), eq(JoinMode.LEGACY_SPAWN), isNull()))
+            .thenReturn(new AgentPlayerData(createdUuid, "damage_bot"));
+        final DefaultLightkeeperFramework framework = framework(agentClient, playerScopeRegistry);
+        final WorldHandle world = FrameworkHandleFactory.worldHandle(framework, "world");
+
+        // execute
+        final PlayerHandle player = framework.bots().builder()
+            .withName("damage_bot")
+            .atSpawn(world)
+            .vulnerable()
+            .build();
+
+        // verify
+        assertThat(player.uniqueId()).isEqualTo(createdUuid);
+        verify(playerScopeRegistry).register(createdUuid);
     }
 
     @Test

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.lightkeeper.framework.internal;
 import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.ChatComponentSnapshot;
 import nl.pim16aap2.lightkeeper.framework.Platform;
+import nl.pim16aap2.lightkeeper.framework.PlayerUnavailableException;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
 import nl.pim16aap2.lightkeeper.protocol.GetCapturedEvents;
@@ -79,6 +80,50 @@ class UdsAgentClientTest
             assertThatThrownBy(() -> client.send(new WaitTicks.Command("1", 1)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("code=PROTOCOL_MISMATCH");
+            client.close();
+        }
+    }
+
+    @Test
+    void send_shouldTranslatePlayerDeadFailureToTypedException(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-player-dead.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":false,"
+            + "\"errorCode\":\"PLAYER_DEAD\","
+            + "\"errorMessage\":\"Player died from minecraft:fall.\"}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson))
+        {
+            final UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3));
+
+            // execute + verify
+            assertThatThrownBy(() -> client.send(new WaitTicks.Command("1", 1)))
+                .isInstanceOfSatisfying(PlayerUnavailableException.class, exception ->
+                    assertThat(exception.reason()).isEqualTo(PlayerUnavailableException.Reason.DEAD))
+                .hasMessageContaining("minecraft:fall");
+            client.close();
+        }
+    }
+
+    @Test
+    void send_shouldTranslatePlayerDisconnectedFailureToTypedException(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-player-disconnected.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":false,"
+            + "\"errorCode\":\"PLAYER_DISCONNECTED\","
+            + "\"errorMessage\":\"Player left the server.\"}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson))
+        {
+            final UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3));
+
+            // execute + verify
+            assertThatThrownBy(() -> client.send(new WaitTicks.Command("1", 1)))
+                .isInstanceOfSatisfying(PlayerUnavailableException.class, exception ->
+                    assertThat(exception.reason()).isEqualTo(PlayerUnavailableException.Reason.DISCONNECTED))
+                .hasMessageContaining("left the server");
             client.close();
         }
     }

--- a/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
+++ b/lightkeeper-framework-junit/src/test/java/nl/pim16aap2/lightkeeper/framework/internal/UdsAgentClientTest.java
@@ -129,6 +129,31 @@ class UdsAgentClientTest
     }
 
     @Test
+    void send_shouldTranslatePlayerNotRegisteredFailureToTypedException(@TempDir Path tempDirectory)
+        throws Exception
+    {
+        // setup
+        final Path socketPath = tempDirectory.resolve("agent-player-not-registered.sock");
+        final String responseJson = "{\"requestId\":\"1\",\"success\":false,"
+            + "\"errorCode\":\"PLAYER_NOT_REGISTERED\","
+            + "\"errorMessage\":\"Player is not registered.\"}";
+        try (AgentSocketServer server = AgentSocketServer.start(socketPath, responseJson))
+        {
+            final UdsAgentClient client = new UdsAgentClient(socketPath, Duration.ofSeconds(3));
+
+            // execute
+            final Throwable thrown = catchThrowable(() -> client.send(new WaitTicks.Command("1", 1)));
+
+            // verify
+            assertThat(thrown)
+                .isInstanceOfSatisfying(PlayerUnavailableException.class, exception ->
+                    assertThat(exception.reason()).isEqualTo(PlayerUnavailableException.Reason.NOT_REGISTERED))
+                .hasMessageContaining("not registered");
+            client.close();
+        }
+    }
+
+    @Test
     void send_shouldPreserveUnknownWireErrorCode(@TempDir Path tempDirectory)
         throws Exception
     {

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
 import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.eventually;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -246,5 +247,44 @@ class LightkeeperBotIT
             .hasMessageContaining("cannot perform TELEPORT_PLAYER")
             .hasMessageContaining("player died")
             .hasMessageContaining("cause=minecraft:");
+    }
+
+    @Test
+    void invulnerabilitySetting_shouldControlPostJoinDamage(ILightkeeperFramework framework)
+    {
+        // setup
+        final var world = framework.worlds().main();
+        final var protectedPlayer = framework.bots().builder()
+            .withName("lkjoinsafe")
+            .atSpawn(world)
+            .build();
+        final var vulnerablePlayer = framework.bots().builder()
+            .withName("lkjoinvulner")
+            .atSpawn(world)
+            .vulnerable()
+            .build();
+
+        // execute
+        framework.waitUntil(
+            () -> framework.server().output().stream()
+                .anyMatch(line -> line.contains("LK_POST_JOIN_INVULNERABILITY name=lkjoinsafe invulnerable=true"))
+                && framework.server().output().stream()
+                .anyMatch(line -> line.contains("LK_POST_JOIN_INVULNERABILITY name=lkjoinvulner invulnerable=false"))
+                && framework.server().output().stream()
+                .anyMatch(line -> line.contains("Synthetic player 'lkjoinvulner'") && line.contains("died")),
+            Duration.ofSeconds(15)
+        );
+        protectedPlayer.teleport(world, 1.0D, 100.0D, 1.0D);
+        final Throwable vulnerableFailure = catchThrowable(
+            () -> vulnerablePlayer.teleport(world, 2.0D, 100.0D, 2.0D));
+
+        // verify
+        assertThat(framework.server().output())
+            .anyMatch(line -> line.contains("LK_POST_JOIN_INVULNERABILITY name=lkjoinsafe invulnerable=true"))
+            .anyMatch(line -> line.contains("LK_POST_JOIN_INVULNERABILITY name=lkjoinvulner invulnerable=false"));
+        assertThat(vulnerableFailure)
+            .isInstanceOfSatisfying(PlayerUnavailableException.class, exception ->
+                assertThat(exception.reason()).isEqualTo(PlayerUnavailableException.Reason.DEAD))
+            .hasMessageContaining("player died");
     }
 }

--- a/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
+++ b/lightkeeper-integration-tests/src/test/java/nl/pim16aap2/lightkeeper/maven/test/LightkeeperBotIT.java
@@ -5,6 +5,7 @@ import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.InteractionResult;
 import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
+import nl.pim16aap2.lightkeeper.framework.PlayerUnavailableException;
 import nl.pim16aap2.lightkeeper.protocol.CommandSource;
 import nl.pim16aap2.lightkeeper.protocol.IProtocolValue;
 import nl.pim16aap2.lightkeeper.protocol.DropResult;
@@ -19,6 +20,7 @@ import java.util.UUID;
 
 import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat;
 import static nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.eventually;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -213,5 +215,36 @@ class LightkeeperBotIT
                 .isInstanceOfSatisfying(IProtocolValue.PRef.class, playerRef ->
                     assertThat(playerRef.id()).isEqualTo(player.uniqueId().toString()));
         }
+    }
+
+    @Test
+    void deadPlayer_shouldReportRecordedDeathBeforeFollowingInteraction(ILightkeeperFramework framework)
+    {
+        // setup
+        final var world = framework.worlds().main();
+        final var player = framework.bots().builder()
+            .withName("lkdeathcheck")
+            .atSpawn(world)
+            .vulnerable()
+            .build();
+
+        // execute
+        player.andWaitTicks(100);
+        final var killResult = framework.server().executeCommand(
+            CommandSource.CONSOLE, "kill " + player.name());
+        framework.waitUntil(
+            () -> framework.server().output().stream()
+                .anyMatch(line -> line.contains("Synthetic player 'lkdeathcheck'") && line.contains("died")),
+            Duration.ofSeconds(15)
+        );
+
+        // verify
+        assertThat(killResult.success()).isTrue();
+        assertThatThrownBy(() -> player.teleport(world, 1.0D, 100.0D, 1.0D))
+            .isInstanceOfSatisfying(PlayerUnavailableException.class, exception ->
+                assertThat(exception.reason()).isEqualTo(PlayerUnavailableException.Reason.DEAD))
+            .hasMessageContaining("cannot perform TELEPORT_PLAYER")
+            .hasMessageContaining("player died")
+            .hasMessageContaining("cause=minecraft:");
     }
 }

--- a/lightkeeper-nms-parent/lightkeeper-nms-api/src/main/java/nl/pim16aap2/lightkeeper/nms/api/IBotPlayerNmsAdapter.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-api/src/main/java/nl/pim16aap2/lightkeeper/nms/api/IBotPlayerNmsAdapter.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 /**
  * Version-specific NMS bridge for synthetic player lifecycle.
@@ -23,9 +24,20 @@ public interface IBotPlayerNmsAdapter
      *     The target world.
      * @param spawnLocation
      *     Spawn location.
+     * @param invulnerable
+     *     Whether the player must be invulnerable before join handlers observe it.
+     * @param beforeJoin
+     *     Initializer invoked exactly once after the Bukkit player is configured and before join handlers can
+     *     observe it.
      * @return Registered Bukkit player handle.
      */
-    Player spawnPlayer(UUID uuid, String name, World world, Location spawnLocation);
+    Player spawnPlayer(
+        UUID uuid,
+        String name,
+        World world,
+        Location spawnLocation,
+        boolean invulnerable,
+        Consumer<Player> beforeJoin);
 
     /**
      * Returns the full-login driver for this adapter.

--- a/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/main/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7.java
@@ -27,6 +27,7 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
 
 /**
  * Paper 1.21.11 (v1_21_R7) synthetic-player adapter.
@@ -349,15 +350,27 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
      *     Target world.
      * @param spawnLocation
      *     Initial player location.
+     * @param invulnerable
+     *     Whether the player must be invulnerable before join handlers observe it.
+     * @param beforeJoin
+     *     Initializer invoked exactly once after the Bukkit player is configured and before join handlers can
+     *     observe it.
      * @return The spawned Bukkit player instance.
      */
     @Override
-    public Player spawnPlayer(UUID uuid, String name, World world, Location spawnLocation)
+    public Player spawnPlayer(
+        UUID uuid,
+        String name,
+        World world,
+        Location spawnLocation,
+        boolean invulnerable,
+        Consumer<Player> beforeJoin)
     {
         Objects.requireNonNull(uuid, "uuid may not be null.");
         Objects.requireNonNull(name, "name may not be null.");
         Objects.requireNonNull(world, "world may not be null.");
         Objects.requireNonNull(spawnLocation, "spawnLocation may not be null.");
+        Objects.requireNonNull(beforeJoin, "beforeJoin may not be null.");
 
         try
         {
@@ -379,9 +392,11 @@ public final class BotPlayerNmsAdapterV1_21_R7 implements IBotPlayerNmsAdapter
             connectionAddressField.set(connection, new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             final Object listenerCookie = commonListenerCreateInitialMethod.invoke(null, gameProfile, false);
 
+            final Player bukkitPlayer = (Player) serverPlayerGetBukkitEntityMethod.invoke(serverPlayer);
+            bukkitPlayer.setInvulnerable(invulnerable);
+            beforeJoin.accept(bukkitPlayer);
             playerListPlaceNewPlayerMethod.invoke(playerList, connection, serverPlayer, listenerCookie);
 
-            final Player bukkitPlayer = (Player) serverPlayerGetBukkitEntityMethod.invoke(serverPlayer);
             bukkitPlayer.teleport(spawnLocation);
             playerChannels.put(uuid, embeddedChannel);
             playerMessageQueues.put(uuid, new ConcurrentLinkedQueue<>());

--- a/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/test/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7Test.java
+++ b/lightkeeper-nms-parent/lightkeeper-nms-v1_21_R7/src/test/java/nl/pim16aap2/lightkeeper/nms/v121r7/BotPlayerNmsAdapterV1_21_R7Test.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.lightkeeper.nms.v121r7;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.bukkit.entity.Player;
+import org.mockito.InOrder;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -15,9 +16,12 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -516,7 +520,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
     }
 
     @Test
-    void spawnPlayer_shouldCreateAndRegisterPlayerWhenHandlesAreConfigured()
+    void spawnPlayer_shouldApplyInvulnerabilityBeforeRegisteringPlayer()
         throws Exception
     {
         // setup
@@ -524,10 +528,12 @@ class BotPlayerNmsAdapterV1_21_R7Test
         final org.bukkit.World world = mock(org.bukkit.World.class);
         final org.bukkit.Location location = mock(org.bukkit.Location.class);
         final org.bukkit.entity.Player bukkitPlayer = mock(org.bukkit.entity.Player.class);
+        @SuppressWarnings("unchecked")
+        final Consumer<org.bukkit.entity.Player> beforeJoin = mock(Consumer.class);
         when(bukkitPlayer.teleport(location)).thenReturn(true);
 
         final FakeMinecraftServer server = new FakeMinecraftServer();
-        final FakePlayerList playerList = new FakePlayerList();
+        final FakePlayerList playerList = mock();
         final BotPlayerNmsAdapterV1_21_R7 adapter = allocateAdapter();
         setField(adapter, "minecraftServer", server);
         setField(adapter, "playerList", playerList);
@@ -567,11 +573,15 @@ class BotPlayerNmsAdapterV1_21_R7Test
         FakeServerPlayer.returningBukkitPlayer = bukkitPlayer;
 
         // execute
-        final org.bukkit.entity.Player created = adapter.spawnPlayer(playerId, "bot", world, location);
+        final org.bukkit.entity.Player created =
+            adapter.spawnPlayer(playerId, "bot", world, location, true, beforeJoin);
 
         // verify
         assertThat(created).isSameAs(bukkitPlayer);
-        assertThat(playerList.placedPlayer).isNotNull();
+        final InOrder creationOrder = inOrder(bukkitPlayer, beforeJoin, playerList);
+        creationOrder.verify(bukkitPlayer).setInvulnerable(true);
+        creationOrder.verify(beforeJoin).accept(bukkitPlayer);
+        creationOrder.verify(playerList).placeNewPlayer(any(), any(), any());
         verify(bukkitPlayer).teleport(location);
     }
 
@@ -892,7 +902,6 @@ class BotPlayerNmsAdapterV1_21_R7Test
     public static final class FakePlayerList
     {
         private @Nullable FakeServerPlayer removedPlayer;
-        private @Nullable FakeServerPlayer placedPlayer;
 
         public void remove(FakeServerPlayer serverPlayer)
         {
@@ -901,7 +910,7 @@ class BotPlayerNmsAdapterV1_21_R7Test
 
         public void placeNewPlayer(FakeConnection connection, FakeServerPlayer serverPlayer, Object cookie)
         {
-            this.placedPlayer = serverPlayer;
+            // no-op
         }
     }
 

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/AgentErrorCode.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/AgentErrorCode.java
@@ -24,6 +24,9 @@ public enum AgentErrorCode
     INTERRUPTED,
     PLAYER_JOIN_DENIED,
     PLAYER_JOIN_TIMEOUT,
+    PLAYER_NOT_REGISTERED,
+    PLAYER_DEAD,
+    PLAYER_DISCONNECTED,
     UNKNOWN;
 
     private static final Map<String, AgentErrorCode> BY_WIRE_CODE = Arrays.stream(values())

--- a/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/CreatePlayer.java
+++ b/lightkeeper-protocol/src/main/java/nl/pim16aap2/lightkeeper/protocol/CreatePlayer.java
@@ -35,6 +35,8 @@ public final class CreatePlayer
      *     Starting health value, or {@code null} to use the server default.
      * @param permissionsCsv
      *     Comma-separated list of permission nodes to grant, or {@code null} for none.
+     * @param invulnerable
+     *     Whether the synthetic player is protected from ordinary damage.
      * @param joinMode
      *     How the player joins the server: the full login pipeline or the internal legacy spawn.
      * @param locale
@@ -52,6 +54,7 @@ public final class CreatePlayer
         @Nullable Double z,
         @Nullable Double health,
         @Nullable String permissionsCsv,
+        boolean invulnerable,
         JoinMode joinMode,
         @Nullable String locale
     ) implements IAgentCommand<Response>

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandSerializationTest.java
@@ -87,7 +87,7 @@ class AgentCommandSerializationTest
             "req-3", "Alice", uuid, "world",
             null, null, null,
             null, null,
-            JoinMode.LEGACY_SPAWN, null
+            true, JoinMode.LEGACY_SPAWN, null
         );
 
         // execute
@@ -107,6 +107,7 @@ class AgentCommandSerializationTest
         assertThat(result.z()).isNull();
         assertThat(result.health()).isNull();
         assertThat(result.permissionsCsv()).isNull();
+        assertThat(result.invulnerable()).isTrue();
         assertThat(result.joinMode()).isEqualTo(JoinMode.LEGACY_SPAWN);
         assertThat(result.locale()).isNull();
     }
@@ -125,7 +126,7 @@ class AgentCommandSerializationTest
             "req-4", "Bob", uuid, "nether",
             10.0, 64.0, -5.0,
             20.0, "minecraft.command.tp,some.other.node",
-            JoinMode.LEGACY_SPAWN, null
+            false, JoinMode.LEGACY_SPAWN, null
         );
 
         // execute
@@ -145,6 +146,7 @@ class AgentCommandSerializationTest
         assertThat(result.z()).isEqualTo(-5.0);
         assertThat(result.health()).isEqualTo(20.0);
         assertThat(result.permissionsCsv()).isEqualTo("minecraft.command.tp,some.other.node");
+        assertThat(result.invulnerable()).isFalse();
         assertThat(result.joinMode()).isEqualTo(JoinMode.LEGACY_SPAWN);
         assertThat(result.locale()).isNull();
     }
@@ -162,7 +164,7 @@ class AgentCommandSerializationTest
             "req-4b", "Carol", null, "world",
             null, null, null,
             null, null,
-            JoinMode.FULL_LOGIN, "en_us"
+            true, JoinMode.FULL_LOGIN, "en_us"
         );
 
         // execute
@@ -177,6 +179,7 @@ class AgentCommandSerializationTest
         assertThat(result.name()).isEqualTo("Carol");
         assertThat(result.uuid()).isNull();
         assertThat(result.worldName()).isEqualTo("world");
+        assertThat(result.invulnerable()).isTrue();
         assertThat(result.joinMode()).isEqualTo(JoinMode.FULL_LOGIN);
         assertThat(result.locale()).isEqualTo("en_us");
     }

--- a/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
+++ b/lightkeeper-protocol/src/test/java/nl/pim16aap2/lightkeeper/protocol/AgentCommandValidationTest.java
@@ -339,7 +339,7 @@ class AgentCommandValidationTest
         // execute + verify
         assertThatThrownBy(() -> new CreatePlayer.Command(
             "request-1", "Alice", UUID.randomUUID(), "world",
-            null, null, null, null, null, JoinMode.FULL_LOGIN, null))
+            null, null, null, null, null, true, JoinMode.FULL_LOGIN, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("uuid")
             .hasMessageContaining("FULL_LOGIN");
@@ -352,7 +352,7 @@ class AgentCommandValidationTest
         // execute + verify
         assertThatThrownBy(() -> new CreatePlayer.Command(
             "request-1", "Alice", null, "world",
-            null, null, null, null, null, JoinMode.LEGACY_SPAWN, null))
+            null, null, null, null, null, true, JoinMode.LEGACY_SPAWN, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("uuid");
     }
@@ -363,7 +363,7 @@ class AgentCommandValidationTest
         // setup + execute
         final CreatePlayer.Command command = new CreatePlayer.Command(
             "request-1", "Alice", null, "world",
-            null, null, null, null, null, JoinMode.FULL_LOGIN, "en_us");
+            null, null, null, null, null, true, JoinMode.FULL_LOGIN, "en_us");
 
         // verify
         assertThat(command.uuid()).isNull();
@@ -378,7 +378,7 @@ class AgentCommandValidationTest
         // execute + verify
         assertThatThrownBy(() -> new CreatePlayer.Command(
             "request-1", "Alice", UUID.randomUUID(), "world",
-            null, null, null, null, null, null, null))
+            null, null, null, null, null, true, null, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("joinMode");
     }
@@ -389,7 +389,7 @@ class AgentCommandValidationTest
         // execute + verify
         assertThatThrownBy(() -> new CreatePlayer.Command(
             "request-1", "Alice", null, "world",
-            null, null, null, null, null, JoinMode.FULL_LOGIN, "   "))
+            null, null, null, null, null, true, JoinMode.FULL_LOGIN, "   "))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("locale");
     }

--- a/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
+++ b/lightkeeper-runtime-core/src/main/java/nl/pim16aap2/lightkeeper/runtime/RuntimeProtocol.java
@@ -20,7 +20,7 @@ public final class RuntimeProtocol
      * in a backward-incompatible way. Both the framework and the agent must agree on this value;
      * a mismatch causes an {@code HANDSHAKE} failure.
      */
-    public static final int VERSION = 11;
+    public static final int VERSION = 12;
 
     /**
      * Minecraft server version supported by this LightKeeper build.

--- a/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LightkeeperSpigotTestPlugin.java
+++ b/lightkeeper-spigot-test-plugin/src/main/java/nl/pim16aap2/lightkeeper/spigot/testplugin/LightkeeperSpigotTestPlugin.java
@@ -13,6 +13,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -40,6 +41,14 @@ public final class LightkeeperSpigotTestPlugin extends JavaPlugin implements Lis
      * Command name used to emit a clickable {@code run_command} chat component for chat-click integration tests.
      */
     private static final String CLICK_COMMAND_NAME = "lktestclick";
+    /**
+     * Player-name prefix that enables post-join invulnerability reporting for lifecycle integration tests.
+     */
+    private static final String JOIN_INVULNERABILITY_PLAYER_PREFIX = "lkjoin";
+    /**
+     * Prefix for the post-join invulnerability state recorded by the lifecycle integration test.
+     */
+    private static final String JOIN_INVULNERABILITY_MESSAGE_PREFIX = "LK_POST_JOIN_INVULNERABILITY";
     /**
      * Prefix used for deterministic block interaction messages.
      */
@@ -158,6 +167,27 @@ public final class LightkeeperSpigotTestPlugin extends JavaPlugin implements Lis
                     itemKey(event.getItem())
                 )
         );
+    }
+
+    /**
+     * Schedules damage after Minecraft's spawn-protection window and records the invulnerability state then.
+     *
+     * @param event
+     *     Player join event fired after the player is exposed to plugin handlers.
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerJoin(PlayerJoinEvent event)
+    {
+        final Player player = event.getPlayer();
+        if (!player.getName().startsWith(JOIN_INVULNERABILITY_PLAYER_PREFIX))
+            return;
+        Bukkit.getScheduler().runTaskLater(this, () ->
+        {
+            getLogger().info(
+                "%s name=%s invulnerable=%s"
+                    .formatted(JOIN_INVULNERABILITY_MESSAGE_PREFIX, player.getName(), player.isInvulnerable()));
+            player.damage(1_000.0D);
+        }, 100L);
     }
 
     private static NamespacedKey itemKey(ItemStack itemStack)


### PR DESCRIPTION
## Why

- Synthetic players could die between test actions, while subsequent actions only checked registration and reported an ambiguous downstream failure.
- Test bots should remain deterministic unless a test explicitly opts into damage.

## How

- Make synthetic players invulnerable by default and add `IPlayerBuilder.vulnerable()` as the explicit opt-out.
- Track and log death, respawn, quit, and kick lifecycle events, and translate unavailable-player failures into `PlayerUnavailableException` with structured reasons.
- Check that players are alive and connected before actions, while avoiding Bukkit's non-portable `Entity.isValid()` state for legacy synthetic players.
- Propagate invulnerability through the runtime protocol and bump its version to 12.

## Impact

- Failures now identify whether a player died, disconnected, or was never registered, with the relevant action and lifecycle details.
- Existing builders produce invulnerable players; tests that exercise damage or death must call `.vulnerable()`.

## Tests

- `mvn clean verify install -Perrorprone -Dmaven.javadoc.skip=true checkstyle:checkstyle pmd:check jacoco:report`
- Paper integration matrix: 54 tests passed.
- Spigot integration matrix: 54 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Synthetic players are now invulnerable by default, with an option to make them vulnerable.
  * Added clear handling for unregistered, dead, and disconnected players.
  * Player lifecycle events now report death and disconnection details.
* **Bug Fixes**
  * Actions are blocked when a synthetic player is no longer active.
  * Invulnerability is consistently applied during player creation and login.
* **Documentation**
  * Updated join behavior documentation to reflect default invulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->